### PR TITLE
feat: Google Calendar + TimeTree calendar adapters

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import { authRoutes } from './routes/auth.js';
+import { calendarRoutes } from './routes/calendars.js';
 import type { AppEnv } from './types.js';
 
 export const app = new Hono<AppEnv>();
@@ -18,3 +19,4 @@ app.use(
 app.get('/health', (c) => c.json({ status: 'ok' }));
 
 app.route('/api/auth', authRoutes);
+app.route('/api/calendars', calendarRoutes);

--- a/apps/api/src/lib/adapter-factory.ts
+++ b/apps/api/src/lib/adapter-factory.ts
@@ -1,0 +1,31 @@
+import { GoogleCalendarAdapter, TimeTreeAdapter } from '@calendar-hub/calendar-sdk';
+import type { CalendarAdapter } from '@calendar-hub/calendar-sdk';
+import { getRefreshToken } from './token-store.js';
+import { refreshAccessToken } from './google-oauth.js';
+
+/**
+ * 連携アカウントIDからCalendarAdapterを生成
+ */
+export async function createAdapter(userId: string, accountId: string): Promise<CalendarAdapter> {
+  const provider = accountId.startsWith('google_') ? 'google' : 'timetree';
+
+  if (provider === 'google') {
+    const refreshToken = await getRefreshToken(userId, accountId);
+    if (!refreshToken) throw new Error(`No refresh token for account: ${accountId}`);
+
+    const tokens = await refreshAccessToken(refreshToken);
+    if (!tokens.access_token) throw new Error('Failed to get access token');
+
+    return new GoogleCalendarAdapter(tokens.access_token);
+  }
+
+  if (provider === 'timetree') {
+    // TimeTreeはsession_idで認証（refresh tokenにsession_idを保存している）
+    const sessionId = await getRefreshToken(userId, accountId);
+    if (!sessionId) throw new Error(`No session for account: ${accountId}`);
+
+    return new TimeTreeAdapter(sessionId);
+  }
+
+  throw new Error(`Unknown provider: ${provider}`);
+}

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -117,6 +117,34 @@ authRoutes.get('/accounts', requireAuth, async (c) => {
   return c.json({ accounts });
 });
 
+// TimeTreeアカウント連携: email/passwordでログイン
+authRoutes.post('/connect/timetree', requireAuth, async (c) => {
+  const user = c.get('user');
+  const { email, password } = await c.req.json();
+
+  if (!email || !password) {
+    return c.json({ error: 'email and password are required' }, 400);
+  }
+
+  try {
+    const { TimeTreeAdapter } = await import('@calendar-hub/calendar-sdk');
+    const session = await TimeTreeAdapter.login(email, password);
+
+    await saveConnectedAccount(
+      user.uid,
+      'timetree',
+      email,
+      session.sessionId, // session_idをrefresh tokenとして保存
+      ['calendar.read', 'calendar.write'],
+    );
+
+    return c.json({ success: true, email });
+  } catch (err) {
+    console.error('TimeTree login error:', err);
+    return c.json({ error: 'TimeTree login failed' }, 401);
+  }
+});
+
 // アカウント連携解除
 authRoutes.delete('/accounts/:accountId', requireAuth, async (c) => {
   const user = c.get('user');

--- a/apps/api/src/routes/calendars.ts
+++ b/apps/api/src/routes/calendars.ts
@@ -1,0 +1,151 @@
+import { Hono } from 'hono';
+import type { AppEnv } from '../types.js';
+import { requireAuth } from '../middleware/auth.js';
+import { createAdapter } from '../lib/adapter-factory.js';
+import { listConnectedAccounts } from '../lib/token-store.js';
+
+export const calendarRoutes = new Hono<AppEnv>();
+
+// 全連携アカウントのカレンダー一覧
+calendarRoutes.get('/', requireAuth, async (c) => {
+  const user = c.get('user');
+  const accounts = await listConnectedAccounts(user.uid);
+  const activeAccounts = accounts.filter((a) => a.isActive);
+
+  const results = await Promise.allSettled(
+    activeAccounts.map(async (account) => {
+      const adapter = await createAdapter(user.uid, account.id);
+      const calendars = await adapter.listCalendars();
+      return calendars.map((cal) => ({ ...cal, accountId: account.id }));
+    }),
+  );
+
+  const calendars = results.filter((r) => r.status === 'fulfilled').flatMap((r) => r.value);
+
+  const errors = results
+    .filter((r) => r.status === 'rejected')
+    .map((r, i) => ({
+      accountId: activeAccounts[i].id,
+      error: String(r.reason),
+    }));
+
+  return c.json({ calendars, errors });
+});
+
+// 特定アカウントのイベント一覧
+calendarRoutes.get('/:accountId/events', requireAuth, async (c) => {
+  const user = c.get('user');
+  const accountId = c.req.param('accountId');
+  const calendarId = c.req.query('calendarId');
+  const timeMin = c.req.query('timeMin');
+  const timeMax = c.req.query('timeMax');
+
+  if (!calendarId || !timeMin || !timeMax) {
+    return c.json({ error: 'calendarId, timeMin, timeMax are required' }, 400);
+  }
+
+  const adapter = await createAdapter(user.uid, accountId);
+  const events = await adapter.listEvents(calendarId, new Date(timeMin), new Date(timeMax));
+
+  return c.json({ events });
+});
+
+// 全アカウント横断のイベント一覧
+calendarRoutes.get('/events/merged', requireAuth, async (c) => {
+  const user = c.get('user');
+  const timeMin = c.req.query('timeMin');
+  const timeMax = c.req.query('timeMax');
+
+  if (!timeMin || !timeMax) {
+    return c.json({ error: 'timeMin, timeMax are required' }, 400);
+  }
+
+  const accounts = await listConnectedAccounts(user.uid);
+  const activeAccounts = accounts.filter((a) => a.isActive);
+
+  const results = await Promise.allSettled(
+    activeAccounts.map(async (account) => {
+      const adapter = await createAdapter(user.uid, account.id);
+      const calendars = await adapter.listCalendars();
+      const allEvents = await Promise.all(
+        calendars.map((cal) => adapter.listEvents(cal.id, new Date(timeMin), new Date(timeMax))),
+      );
+      return allEvents.flat();
+    }),
+  );
+
+  const events = results
+    .filter((r) => r.status === 'fulfilled')
+    .flatMap((r) => r.value)
+    .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+  return c.json({ events });
+});
+
+// イベント作成
+calendarRoutes.post('/:accountId/events', requireAuth, async (c) => {
+  const user = c.get('user');
+  const accountId = c.req.param('accountId');
+  const body = await c.req.json();
+
+  const { calendarId, title, description, start, end, isAllDay, location, timeZone } = body;
+  if (!calendarId || !title || !start || !end) {
+    return c.json({ error: 'calendarId, title, start, end are required' }, 400);
+  }
+
+  const adapter = await createAdapter(user.uid, accountId);
+  const event = await adapter.createEvent(calendarId, {
+    title,
+    description,
+    start: new Date(start),
+    end: new Date(end),
+    isAllDay,
+    location,
+    timeZone,
+  });
+
+  return c.json({ event }, 201);
+});
+
+// イベント更新
+calendarRoutes.patch('/:accountId/events/:eventId', requireAuth, async (c) => {
+  const user = c.get('user');
+  const accountId = c.req.param('accountId');
+  const eventId = c.req.param('eventId');
+  const body = await c.req.json();
+
+  const { calendarId, ...updateFields } = body;
+  if (!calendarId) {
+    return c.json({ error: 'calendarId is required' }, 400);
+  }
+
+  const update: Record<string, unknown> = {};
+  if (updateFields.title !== undefined) update.title = updateFields.title;
+  if (updateFields.description !== undefined) update.description = updateFields.description;
+  if (updateFields.start !== undefined) update.start = new Date(updateFields.start);
+  if (updateFields.end !== undefined) update.end = new Date(updateFields.end);
+  if (updateFields.isAllDay !== undefined) update.isAllDay = updateFields.isAllDay;
+  if (updateFields.location !== undefined) update.location = updateFields.location;
+
+  const adapter = await createAdapter(user.uid, accountId);
+  const event = await adapter.updateEvent(calendarId, eventId, update);
+
+  return c.json({ event });
+});
+
+// イベント削除
+calendarRoutes.delete('/:accountId/events/:eventId', requireAuth, async (c) => {
+  const user = c.get('user');
+  const accountId = c.req.param('accountId');
+  const eventId = c.req.param('eventId');
+  const calendarId = c.req.query('calendarId');
+
+  if (!calendarId) {
+    return c.json({ error: 'calendarId is required' }, 400);
+  }
+
+  const adapter = await createAdapter(user.uid, accountId);
+  await adapter.deleteEvent(calendarId, eventId);
+
+  return c.json({ success: true });
+});

--- a/docs/adr/002-calendar-integration.md
+++ b/docs/adr/002-calendar-integration.md
@@ -40,12 +40,21 @@ interface CalendarAdapter {
 - **複数アカウント**: 各アカウントのrefresh tokenをFirestoreに暗号化保存。リクエスト時にaccess tokenを取得
 - **同期**: `syncToken` を使った差分同期（Push NotificationはPhase 2で検討）
 
-### TimeTree API
+### TimeTree API（2024年3月更新）
 
-- **認証**: OAuth App（OAuth 2.0）
-- **SDK**: `@timetreeapp/web-api` npm package
-- **制限**: 600リクエスト/10分（IPベース + トークンベース）
-- **データ形式**: JSON API準拠
+> **注意**: TimeTree公式APIは2023年12月22日に廃止。以下は代替の内部API方式。
+
+- **認証**: email/password → session cookie (`_session_id`)
+- **内部API**: `https://timetreeapp.com/api/v1/` (非公式、Webアプリが使用するREST API)
+- **主要エンドポイント**:
+  - `PUT /auth/email/signin` - ログイン
+  - `GET /calendars?since=0` - カレンダー一覧
+  - `GET /calendar/{id}/events/sync` - イベント取得（ページネーション対応）
+  - `POST /calendar/{id}/events` - イベント作成
+  - `PUT /calendar/{id}/events/{eventId}` - イベント更新
+  - `DELETE /calendar/{id}/events/{eventId}` - イベント削除
+- **リスク**: 非公式APIのためTimeTreeのWebアプリ更新で動作しなくなる可能性
+- **参考**: [TimeTree-Exporter](https://github.com/eoleedi/TimeTree-Exporter) の解析結果に基づく
 
 ### キャッシュ戦略
 

--- a/packages/calendar-sdk/package.json
+++ b/packages/calendar-sdk/package.json
@@ -11,9 +11,11 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@calendar-hub/shared": "workspace:*"
+    "@calendar-hub/shared": "workspace:*",
+    "googleapis": "^171.4.0"
   },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "typescript": "^5.5.0"
   }
 }

--- a/packages/calendar-sdk/src/adapters/google.ts
+++ b/packages/calendar-sdk/src/adapters/google.ts
@@ -1,0 +1,112 @@
+import { google, type calendar_v3 } from 'googleapis';
+import type { CalendarEvent } from '@calendar-hub/shared';
+import type { Calendar, CalendarAdapter, CreateEventInput, UpdateEventInput } from '../types.js';
+
+export class GoogleCalendarAdapter implements CalendarAdapter {
+  readonly provider = 'google' as const;
+  private calendar: calendar_v3.Calendar;
+
+  constructor(accessToken: string) {
+    const auth = new google.auth.OAuth2();
+    auth.setCredentials({ access_token: accessToken });
+    this.calendar = google.calendar({ version: 'v3', auth });
+  }
+
+  async listCalendars(): Promise<Calendar[]> {
+    const res = await this.calendar.calendarList.list();
+    return (res.data.items ?? []).map((item) => ({
+      id: item.id!,
+      name: item.summary ?? '',
+      description: item.description ?? undefined,
+      color: item.backgroundColor ?? undefined,
+      provider: 'google',
+      accountId: '',
+      primary: item.primary ?? false,
+    }));
+  }
+
+  async listEvents(calendarId: string, timeMin: Date, timeMax: Date): Promise<CalendarEvent[]> {
+    const res = await this.calendar.events.list({
+      calendarId,
+      timeMin: timeMin.toISOString(),
+      timeMax: timeMax.toISOString(),
+      singleEvents: true,
+      orderBy: 'startTime',
+      maxResults: 2500,
+    });
+
+    return (res.data.items ?? []).map((item) => this.toCalendarEvent(item, calendarId));
+  }
+
+  async createEvent(calendarId: string, event: CreateEventInput): Promise<CalendarEvent> {
+    const res = await this.calendar.events.insert({
+      calendarId,
+      requestBody: this.toGoogleEvent(event),
+    });
+    return this.toCalendarEvent(res.data, calendarId);
+  }
+
+  async updateEvent(
+    calendarId: string,
+    eventId: string,
+    event: UpdateEventInput,
+  ): Promise<CalendarEvent> {
+    const res = await this.calendar.events.patch({
+      calendarId,
+      eventId,
+      requestBody: this.toGoogleEvent(event),
+    });
+    return this.toCalendarEvent(res.data, calendarId);
+  }
+
+  async deleteEvent(calendarId: string, eventId: string): Promise<void> {
+    await this.calendar.events.delete({ calendarId, eventId });
+  }
+
+  private toCalendarEvent(item: calendar_v3.Schema$Event, calendarId: string): CalendarEvent {
+    const isAllDay = !item.start?.dateTime;
+    const startStr = isAllDay ? (item.start?.date ?? '') : (item.start?.dateTime ?? '');
+    const endStr = isAllDay ? (item.end?.date ?? '') : (item.end?.dateTime ?? '');
+    const start = isAllDay ? new Date(startStr + 'T00:00:00') : new Date(startStr);
+    const end = isAllDay ? new Date(endStr + 'T00:00:00') : new Date(endStr);
+
+    return {
+      id: `google_${item.id}`,
+      source: 'google',
+      originalId: item.id!,
+      calendarId,
+      title: item.summary ?? '(無題)',
+      description: item.description ?? undefined,
+      start,
+      end,
+      isAllDay,
+      status: item.status === 'cancelled' ? 'cancelled' : 'confirmed',
+      location: item.location ?? undefined,
+    };
+  }
+
+  private toGoogleEvent(event: CreateEventInput | UpdateEventInput): calendar_v3.Schema$Event {
+    const body: calendar_v3.Schema$Event = {};
+    if (event.title !== undefined) body.summary = event.title;
+    if (event.description !== undefined) body.description = event.description;
+    if (event.location !== undefined) body.location = event.location;
+
+    const tz = (event as CreateEventInput).timeZone ?? 'Asia/Tokyo';
+
+    if (event.start && event.end) {
+      if ((event as CreateEventInput).isAllDay) {
+        body.start = { date: toDateString(event.start) };
+        body.end = { date: toDateString(event.end) };
+      } else {
+        body.start = { dateTime: event.start.toISOString(), timeZone: tz };
+        body.end = { dateTime: event.end.toISOString(), timeZone: tz };
+      }
+    }
+
+    return body;
+  }
+}
+
+function toDateString(d: Date): string {
+  return d.toISOString().split('T')[0];
+}

--- a/packages/calendar-sdk/src/adapters/timetree.ts
+++ b/packages/calendar-sdk/src/adapters/timetree.ts
@@ -1,0 +1,220 @@
+import type { CalendarEvent } from '@calendar-hub/shared';
+import type { Calendar, CalendarAdapter, CreateEventInput, UpdateEventInput } from '../types.js';
+
+const BASE_URL = 'https://timetreeapp.com';
+
+interface TimeTreeSession {
+  sessionId: string;
+}
+
+interface TimeTreeRawEvent {
+  id: string;
+  title: string;
+  start_at: string;
+  end_at: string;
+  all_day: boolean;
+  start_timezone: string;
+  end_timezone: string;
+  note: string;
+  location: string;
+  location_lat: string;
+  location_lon: string;
+  category: string;
+  calendar_id: string;
+  updated_at: string;
+  created_at: string;
+}
+
+interface TimeTreeRawCalendar {
+  id: string;
+  name: string;
+  color: string;
+  description: string;
+  image_url: string;
+}
+
+/**
+ * TimeTree WebアプリのintAPIを使ったCalendarAdapter
+ *
+ * 注意: 非公式APIを使用。TimeTreeのWebアプリ更新により動作しなくなる可能性あり。
+ * 認証: email/passwordでログイン → session cookie取得
+ */
+export class TimeTreeAdapter implements CalendarAdapter {
+  readonly provider = 'timetree' as const;
+  private sessionId: string;
+  private headers: Record<string, string>;
+
+  constructor(sessionId: string) {
+    this.sessionId = sessionId;
+    this.headers = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Cookie: `_session_id=${sessionId}`,
+      'User-Agent': 'CalendarHub/1.0',
+    };
+  }
+
+  /**
+   * email/passwordでTimeTreeにログインし、session_idを取得
+   */
+  static async login(email: string, password: string): Promise<TimeTreeSession> {
+    const uuid = crypto.randomUUID();
+    const res = await fetch(`${BASE_URL}/api/v1/auth/email/signin`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'User-Agent': 'CalendarHub/1.0',
+      },
+      body: JSON.stringify({ email, password, uuid }),
+      redirect: 'manual',
+    });
+
+    if (!res.ok && res.status !== 302) {
+      throw new Error(`TimeTree login failed: ${res.status}`);
+    }
+
+    const cookies = res.headers.getSetCookie?.() ?? [];
+    const sessionCookie = cookies.find((c) => c.startsWith('_session_id='));
+    if (!sessionCookie) {
+      throw new Error('TimeTree login failed: no session cookie');
+    }
+
+    const sessionId = sessionCookie.split('=')[1].split(';')[0];
+    return { sessionId };
+  }
+
+  async listCalendars(): Promise<Calendar[]> {
+    const res = await fetch(`${BASE_URL}/api/v1/calendars?since=0`, {
+      headers: this.headers,
+    });
+
+    if (!res.ok) throw new Error(`TimeTree listCalendars failed: ${res.status}`);
+
+    const data = (await res.json()) as { calendars: TimeTreeRawCalendar[] };
+    return data.calendars.map((cal) => ({
+      id: cal.id,
+      name: cal.name,
+      description: cal.description || undefined,
+      color: cal.color || undefined,
+      provider: 'timetree',
+      accountId: '',
+    }));
+  }
+
+  async listEvents(calendarId: string, timeMin: Date, timeMax: Date): Promise<CalendarEvent[]> {
+    const allEvents: TimeTreeRawEvent[] = [];
+    let url = `${BASE_URL}/api/v1/calendar/${calendarId}/events/sync`;
+    let hasMore = true;
+
+    while (hasMore) {
+      const res = await fetch(url, { headers: this.headers });
+      if (!res.ok) throw new Error(`TimeTree listEvents failed: ${res.status}`);
+
+      const data = (await res.json()) as {
+        events: TimeTreeRawEvent[];
+        chunk?: boolean;
+        since?: string;
+      };
+
+      allEvents.push(...data.events);
+
+      if (data.chunk && data.since) {
+        url = `${BASE_URL}/api/v1/calendar/${calendarId}/events/sync?since=${data.since}`;
+      } else {
+        hasMore = false;
+      }
+    }
+
+    return allEvents
+      .filter((ev) => {
+        const start = new Date(ev.start_at);
+        const end = new Date(ev.end_at);
+        return start < timeMax && end > timeMin;
+      })
+      .map((ev) => this.toCalendarEvent(ev, calendarId));
+  }
+
+  async createEvent(calendarId: string, event: CreateEventInput): Promise<CalendarEvent> {
+    const res = await fetch(`${BASE_URL}/api/v1/calendar/${calendarId}/events`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({
+        event: {
+          title: event.title,
+          note: event.description ?? '',
+          all_day: event.isAllDay ?? false,
+          start_at: event.start.toISOString(),
+          end_at: event.end.toISOString(),
+          start_timezone: event.timeZone ?? 'Asia/Tokyo',
+          end_timezone: event.timeZone ?? 'Asia/Tokyo',
+          location: event.location ?? '',
+          category: 'schedule',
+        },
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`TimeTree createEvent failed: ${res.status} ${body}`);
+    }
+
+    const data = (await res.json()) as { event: TimeTreeRawEvent };
+    return this.toCalendarEvent(data.event, calendarId);
+  }
+
+  async updateEvent(
+    calendarId: string,
+    eventId: string,
+    event: UpdateEventInput,
+  ): Promise<CalendarEvent> {
+    const body: Record<string, unknown> = {};
+    if (event.title !== undefined) body.title = event.title;
+    if (event.description !== undefined) body.note = event.description;
+    if (event.start !== undefined) body.start_at = event.start.toISOString();
+    if (event.end !== undefined) body.end_at = event.end.toISOString();
+    if (event.isAllDay !== undefined) body.all_day = event.isAllDay;
+    if (event.location !== undefined) body.location = event.location;
+
+    const res = await fetch(`${BASE_URL}/api/v1/calendar/${calendarId}/events/${eventId}`, {
+      method: 'PUT',
+      headers: this.headers,
+      body: JSON.stringify({ event: body }),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`TimeTree updateEvent failed: ${res.status} ${text}`);
+    }
+
+    const data = (await res.json()) as { event: TimeTreeRawEvent };
+    return this.toCalendarEvent(data.event, calendarId);
+  }
+
+  async deleteEvent(calendarId: string, eventId: string): Promise<void> {
+    const res = await fetch(`${BASE_URL}/api/v1/calendar/${calendarId}/events/${eventId}`, {
+      method: 'DELETE',
+      headers: this.headers,
+    });
+
+    if (!res.ok) {
+      throw new Error(`TimeTree deleteEvent failed: ${res.status}`);
+    }
+  }
+
+  private toCalendarEvent(raw: TimeTreeRawEvent, calendarId: string): CalendarEvent {
+    return {
+      id: `timetree_${raw.id}`,
+      source: 'timetree',
+      originalId: raw.id,
+      calendarId,
+      title: raw.title || '(無題)',
+      description: raw.note || undefined,
+      start: new Date(raw.start_at),
+      end: new Date(raw.end_at),
+      isAllDay: raw.all_day,
+      status: 'confirmed',
+      location: raw.location || undefined,
+    };
+  }
+}

--- a/packages/calendar-sdk/src/index.ts
+++ b/packages/calendar-sdk/src/index.ts
@@ -1,4 +1,12 @@
 // Calendar Hub - Calendar SDK
-// Google Calendar API & TimeTree API integration
+// Google Calendar API & TimeTree internal API integration
 
 export { type CalendarEvent, type CalendarProvider } from '@calendar-hub/shared';
+export {
+  type Calendar,
+  type CalendarAdapter,
+  type CreateEventInput,
+  type UpdateEventInput,
+} from './types.js';
+export { GoogleCalendarAdapter } from './adapters/google.js';
+export { TimeTreeAdapter } from './adapters/timetree.js';

--- a/packages/calendar-sdk/src/types.ts
+++ b/packages/calendar-sdk/src/types.ts
@@ -1,0 +1,56 @@
+import type { CalendarProvider } from '@calendar-hub/shared';
+
+export interface Calendar {
+  id: string;
+  name: string;
+  description?: string;
+  color?: string;
+  provider: CalendarProvider;
+  accountId: string;
+  primary?: boolean;
+}
+
+export interface CreateEventInput {
+  title: string;
+  description?: string;
+  start: Date;
+  end: Date;
+  isAllDay?: boolean;
+  location?: string;
+  timeZone?: string;
+}
+
+export interface UpdateEventInput {
+  title?: string;
+  description?: string;
+  start?: Date;
+  end?: Date;
+  isAllDay?: boolean;
+  location?: string;
+  timeZone?: string;
+}
+
+export interface CalendarAdapter {
+  readonly provider: CalendarProvider;
+
+  listCalendars(): Promise<Calendar[]>;
+
+  listEvents(
+    calendarId: string,
+    timeMin: Date,
+    timeMax: Date,
+  ): Promise<import('@calendar-hub/shared').CalendarEvent[]>;
+
+  createEvent(
+    calendarId: string,
+    event: CreateEventInput,
+  ): Promise<import('@calendar-hub/shared').CalendarEvent>;
+
+  updateEvent(
+    calendarId: string,
+    eventId: string,
+    event: UpdateEventInput,
+  ): Promise<import('@calendar-hub/shared').CalendarEvent>;
+
+  deleteEvent(calendarId: string, eventId: string): Promise<void>;
+}

--- a/packages/calendar-sdk/tsconfig.json
+++ b/packages/calendar-sdk/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,7 +110,13 @@ importers:
       '@calendar-hub/shared':
         specifier: workspace:*
         version: link:../shared
+      googleapis:
+        specifier: ^171.4.0
+        version: 171.4.0
     devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
       typescript:
         specifier: ^5.5.0
         version: 5.9.3


### PR DESCRIPTION
## Summary
- CalendarAdapterインターフェースによるプロバイダー抽象化
- GoogleCalendarAdapter: googleapis SDKでCRUD操作
- TimeTreeAdapter: 内部WebアプリAPI（公式API 2023/12廃止のため）でCRUD操作
- Calendar APIルート: カレンダー一覧、統合イベント取得、CRUD
- アダプターファクトリ: 連携アカウントからAdapter動的生成
- TimeTree認証エンドポイント (email/password)
- ADR-002更新: TimeTree API廃止と内部API方式への変更を記録

## Test plan
- [ ] `pnpm turbo build` で全パッケージビルド成功を確認
- [ ] Google Calendar API: 連携アカウントのカレンダー一覧取得
- [ ] Google Calendar API: イベントCRUD操作
- [ ] TimeTree: email/passwordログイン→session取得
- [ ] TimeTree: カレンダー一覧・イベント取得
- [ ] 統合イベント取得 (`/api/calendars/events/merged`)

Closes #3
Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added TimeTree and Google Calendar integrations with full event management (create, read, update, delete).
  - Can now view and manage events across multiple connected calendar accounts.
  - Support for merged calendar view displaying events from all connected services.

* **Documentation**
  - Updated calendar integration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->