### PR TITLE
feat: unified calendar UI + free time calculation

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,9 +11,11 @@
   },
   "dependencies": {
     "@calendar-hub/shared": "workspace:*",
+    "date-fns": "^4.1.0",
     "firebase": "^12.11.0",
     "next": "^15.0.0",
     "react": "^19.0.0",
+    "react-big-calendar": "^1.19.4",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {

--- a/apps/web/src/app/calendar/calendar-content.tsx
+++ b/apps/web/src/app/calendar/calendar-content.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { startOfMonth, endOfMonth, startOfWeek, endOfWeek } from 'date-fns';
+import type { View } from 'react-big-calendar';
+import { useAuth } from '../../components/AuthProvider';
+import { useCalendarEvents } from '../../hooks/useCalendarEvents';
+import { CalendarView } from '../../components/CalendarView';
+import { FreeSlotsPanel } from '../../components/FreeSlotsPanel';
+import type { CalendarEvent } from '@calendar-hub/shared';
+
+export function CalendarContent() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [view, setView] = useState<View>('week');
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push('/login');
+    }
+  }, [user, loading, router]);
+
+  // ビューに応じた表示範囲を計算
+  const { rangeStart, rangeEnd } = useMemo(() => {
+    switch (view) {
+      case 'month': {
+        const monthStart = startOfMonth(currentDate);
+        const monthEnd = endOfMonth(currentDate);
+        return {
+          rangeStart: startOfWeek(monthStart, { weekStartsOn: 1 }),
+          rangeEnd: endOfWeek(monthEnd, { weekStartsOn: 1 }),
+        };
+      }
+      case 'week':
+        return {
+          rangeStart: startOfWeek(currentDate, { weekStartsOn: 1 }),
+          rangeEnd: endOfWeek(currentDate, { weekStartsOn: 1 }),
+        };
+      case 'day':
+        return {
+          rangeStart: new Date(
+            currentDate.getFullYear(),
+            currentDate.getMonth(),
+            currentDate.getDate(),
+          ),
+          rangeEnd: new Date(
+            currentDate.getFullYear(),
+            currentDate.getMonth(),
+            currentDate.getDate() + 1,
+          ),
+        };
+      default:
+        return { rangeStart: startOfWeek(currentDate), rangeEnd: endOfWeek(currentDate) };
+    }
+  }, [currentDate, view]);
+
+  const { events, loading: eventsLoading, error } = useCalendarEvents(rangeStart, rangeEnd);
+
+  const handleNavigate = useCallback((date: Date) => {
+    setCurrentDate(date);
+  }, []);
+
+  const handleViewChange = useCallback((newView: View) => {
+    setView(newView);
+  }, []);
+
+  const handleSelectEvent = useCallback((event: CalendarEvent) => {
+    setSelectedEvent(event);
+  }, []);
+
+  if (loading) return <main style={{ padding: '2rem' }}>Loading...</main>;
+  if (!user) return null;
+
+  return (
+    <main style={{ padding: '1rem', maxWidth: '1400px', margin: '0 auto' }}>
+      <header
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: '1rem',
+        }}
+      >
+        <h1 style={{ fontSize: '20px', margin: 0 }}>Calendar Hub</h1>
+        <nav style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
+          <a href="/settings" style={{ color: '#666', fontSize: '14px' }}>
+            設定
+          </a>
+          <span style={{ color: '#999', fontSize: '13px' }}>{user.email}</span>
+        </nav>
+      </header>
+
+      {error && (
+        <div
+          style={{
+            padding: '8px 12px',
+            background: '#fee',
+            borderRadius: '4px',
+            marginBottom: '1rem',
+            fontSize: '13px',
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 280px', gap: '1rem' }}>
+        <div>
+          {eventsLoading && (
+            <div style={{ textAlign: 'center', padding: '8px', color: '#666', fontSize: '13px' }}>
+              予定を読み込み中...
+            </div>
+          )}
+          <CalendarView
+            events={events}
+            currentDate={currentDate}
+            view={view}
+            onNavigate={handleNavigate}
+            onViewChange={handleViewChange}
+            onSelectEvent={handleSelectEvent}
+          />
+        </div>
+
+        <aside>
+          <FreeSlotsPanel events={events} rangeStart={rangeStart} rangeEnd={rangeEnd} />
+
+          {selectedEvent && (
+            <div
+              style={{
+                marginTop: '1rem',
+                padding: '12px',
+                border: '1px solid #e0e0e0',
+                borderRadius: '8px',
+              }}
+            >
+              <h3 style={{ fontSize: '14px', marginBottom: '8px' }}>{selectedEvent.title}</h3>
+              <p style={{ fontSize: '12px', color: '#666' }}>
+                {selectedEvent.source === 'google' ? 'Google Calendar' : 'TimeTree'}
+              </p>
+              {selectedEvent.description && (
+                <p style={{ fontSize: '12px', color: '#333', marginTop: '4px' }}>
+                  {selectedEvent.description}
+                </p>
+              )}
+              {selectedEvent.location && (
+                <p style={{ fontSize: '12px', color: '#666', marginTop: '4px' }}>
+                  {selectedEvent.location}
+                </p>
+              )}
+              <button
+                onClick={() => setSelectedEvent(null)}
+                style={{
+                  marginTop: '8px',
+                  fontSize: '12px',
+                  cursor: 'pointer',
+                  border: '1px solid #ddd',
+                  borderRadius: '4px',
+                  padding: '4px 8px',
+                  background: '#fff',
+                }}
+              >
+                閉じる
+              </button>
+            </div>
+          )}
+        </aside>
+      </div>
+
+      <div
+        style={{ display: 'flex', gap: '12px', marginTop: '8px', fontSize: '12px', color: '#666' }}
+      >
+        <span>
+          <span
+            style={{
+              display: 'inline-block',
+              width: '10px',
+              height: '10px',
+              borderRadius: '2px',
+              background: '#4285f4',
+              marginRight: '4px',
+            }}
+          />
+          Google
+        </span>
+        <span>
+          <span
+            style={{
+              display: 'inline-block',
+              width: '10px',
+              height: '10px',
+              borderRadius: '2px',
+              background: '#4caf50',
+              marginRight: '4px',
+            }}
+          />
+          TimeTree
+        </span>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/calendar/page.tsx
+++ b/apps/web/src/app/calendar/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+
+const CalendarContent = dynamic(() => import('./calendar-content').then((m) => m.CalendarContent), {
+  ssr: false,
+});
+
+export default function CalendarPage() {
+  return (
+    <Suspense fallback={<main style={{ padding: '2rem' }}>Loading...</main>}>
+      <CalendarContent />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -11,6 +11,8 @@ export default function Home() {
   useEffect(() => {
     if (!loading && !user) {
       router.push('/login');
+    } else if (!loading && user) {
+      router.push('/calendar');
     }
   }, [user, loading, router]);
 

--- a/apps/web/src/components/CalendarView.tsx
+++ b/apps/web/src/components/CalendarView.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useMemo, useCallback } from 'react';
+import { Calendar, dateFnsLocalizer, type View } from 'react-big-calendar';
+import { format, parse, startOfWeek, getDay } from 'date-fns';
+import { ja } from 'date-fns/locale';
+import type { CalendarEvent } from '@calendar-hub/shared';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+
+const locales = { ja };
+
+const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek: () => startOfWeek(new Date(), { weekStartsOn: 1 }),
+  getDay,
+  locales,
+});
+
+interface CalendarViewProps {
+  events: CalendarEvent[];
+  currentDate: Date;
+  view: View;
+  onNavigate: (date: Date) => void;
+  onViewChange: (view: View) => void;
+  onSelectEvent?: (event: CalendarEvent) => void;
+}
+
+interface BigCalEvent {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  allDay: boolean;
+  resource: CalendarEvent;
+}
+
+const SOURCE_COLORS: Record<string, string> = {
+  google: '#4285f4',
+  timetree: '#4caf50',
+};
+
+export function CalendarView({
+  events,
+  currentDate,
+  view,
+  onNavigate,
+  onViewChange,
+  onSelectEvent,
+}: CalendarViewProps) {
+  const bigCalEvents: BigCalEvent[] = useMemo(
+    () =>
+      events.map((e) => ({
+        id: e.id,
+        title: e.title,
+        start: e.start instanceof Date ? e.start : new Date(e.start),
+        end: e.end instanceof Date ? e.end : new Date(e.end),
+        allDay: e.isAllDay,
+        resource: e,
+      })),
+    [events],
+  );
+
+  const eventStyleGetter = useCallback((event: BigCalEvent) => {
+    const color = SOURCE_COLORS[event.resource.source] ?? '#666';
+    return {
+      style: {
+        backgroundColor: color,
+        borderRadius: '4px',
+        border: 'none',
+        color: '#fff',
+        fontSize: '12px',
+      },
+    };
+  }, []);
+
+  const handleSelectEvent = useCallback(
+    (event: BigCalEvent) => {
+      onSelectEvent?.(event.resource);
+    },
+    [onSelectEvent],
+  );
+
+  return (
+    <div style={{ height: 'calc(100vh - 200px)', minHeight: '500px' }}>
+      <Calendar<BigCalEvent>
+        localizer={localizer}
+        events={bigCalEvents}
+        date={currentDate}
+        view={view}
+        onNavigate={onNavigate}
+        onView={onViewChange}
+        onSelectEvent={handleSelectEvent}
+        eventPropGetter={eventStyleGetter}
+        views={['month', 'week', 'day']}
+        messages={{
+          today: '今日',
+          previous: '前',
+          next: '次',
+          month: '月',
+          week: '週',
+          day: '日',
+          noEventsInRange: '予定はありません',
+        }}
+        culture="ja"
+        step={30}
+        timeslots={2}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/FreeSlotsPanel.tsx
+++ b/apps/web/src/components/FreeSlotsPanel.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { CalendarEvent } from '@calendar-hub/shared';
+import { calculateFreeSlots, type FreeSlot } from '@calendar-hub/shared/dist/free-time.js';
+import { format } from 'date-fns';
+import { ja } from 'date-fns/locale';
+
+interface FreeSlotsPanelProps {
+  events: CalendarEvent[];
+  rangeStart: Date;
+  rangeEnd: Date;
+}
+
+export function FreeSlotsPanel({ events, rangeStart, rangeEnd }: FreeSlotsPanelProps) {
+  const freeSlots = useMemo(
+    () => calculateFreeSlots(events, rangeStart, rangeEnd),
+    [events, rangeStart, rangeEnd],
+  );
+
+  // 日付ごとにグループ化
+  const groupedSlots = useMemo(() => {
+    const groups = new Map<string, FreeSlot[]>();
+    for (const slot of freeSlots) {
+      const key = format(slot.start, 'yyyy-MM-dd');
+      const existing = groups.get(key) ?? [];
+      existing.push(slot);
+      groups.set(key, existing);
+    }
+    return groups;
+  }, [freeSlots]);
+
+  const totalFreeMinutes = useMemo(
+    () => freeSlots.reduce((sum, s) => sum + s.durationMinutes, 0),
+    [freeSlots],
+  );
+
+  return (
+    <div style={panelStyle}>
+      <h3 style={{ marginBottom: '8px', fontSize: '14px' }}>
+        空き時間
+        <span style={{ fontWeight: 'normal', color: '#666', marginLeft: '8px' }}>
+          合計 {Math.floor(totalFreeMinutes / 60)}h {totalFreeMinutes % 60}m
+        </span>
+      </h3>
+
+      {freeSlots.length === 0 ? (
+        <p style={{ color: '#999', fontSize: '13px' }}>空き時間がありません</p>
+      ) : (
+        <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
+          {Array.from(groupedSlots.entries()).map(([dateKey, slots]) => (
+            <div key={dateKey} style={{ marginBottom: '12px' }}>
+              <div
+                style={{ fontSize: '12px', fontWeight: 'bold', color: '#666', marginBottom: '4px' }}
+              >
+                {format(new Date(dateKey), 'M/d (E)', { locale: ja })}
+              </div>
+              {slots.map((slot, i) => (
+                <div
+                  key={i}
+                  style={{
+                    padding: '6px 8px',
+                    marginBottom: '4px',
+                    background: '#f0f7ff',
+                    borderRadius: '4px',
+                    fontSize: '13px',
+                    borderLeft: '3px solid #4285f4',
+                  }}
+                >
+                  {format(slot.start, 'HH:mm')} - {format(slot.end, 'HH:mm')}
+                  <span style={{ color: '#666', marginLeft: '8px' }}>
+                    ({slot.durationMinutes}分)
+                  </span>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const panelStyle: React.CSSProperties = {
+  padding: '12px',
+  border: '1px solid #e0e0e0',
+  borderRadius: '8px',
+  background: '#fafafa',
+};

--- a/apps/web/src/hooks/useCalendarEvents.ts
+++ b/apps/web/src/hooks/useCalendarEvents.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import type { CalendarEvent } from '@calendar-hub/shared';
+import { apiGet } from '../lib/api';
+
+interface UseCalendarEventsResult {
+  events: CalendarEvent[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useCalendarEvents(
+  timeMin: Date | null,
+  timeMax: Date | null,
+): UseCalendarEventsResult {
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchEvents = useCallback(async () => {
+    if (!timeMin || !timeMax) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await apiGet<{ events: CalendarEvent[] }>(
+        `/api/calendars/events/merged?timeMin=${timeMin.toISOString()}&timeMax=${timeMax.toISOString()}`,
+      );
+      // Date文字列をDateオブジェクトに変換
+      const parsed = data.events.map((e) => ({
+        ...e,
+        start: new Date(e.start),
+        end: new Date(e.end),
+      }));
+      setEvents(parsed);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch events');
+    } finally {
+      setLoading(false);
+    }
+  }, [timeMin, timeMax]);
+
+  useEffect(() => {
+    fetchEvents();
+  }, [fetchEvents]);
+
+  return { events, loading, error, refetch: fetchEvents };
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -30,6 +30,16 @@ export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
   return res.json();
 }
 
+export async function apiPatch<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'PATCH',
+    headers: await getAuthHeaders(),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
 export async function apiDelete<T>(path: string): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
     method: 'DELETE',

--- a/packages/shared/src/free-time.ts
+++ b/packages/shared/src/free-time.ts
@@ -1,0 +1,85 @@
+import type { CalendarEvent } from './index.js';
+
+export interface FreeSlot {
+  start: Date;
+  end: Date;
+  durationMinutes: number;
+}
+
+export interface FreeTimeOptions {
+  dayStartHour?: number; // デフォルト 8
+  dayEndHour?: number; // デフォルト 22
+  minSlotMinutes?: number; // 最小スロット長（デフォルト 30分）
+}
+
+/**
+ * 指定期間内のイベントから空き時間スロットを算出する。
+ * events は start 昇順でソート済みを想定。
+ */
+export function calculateFreeSlots(
+  events: CalendarEvent[],
+  rangeStart: Date,
+  rangeEnd: Date,
+  options: FreeTimeOptions = {},
+): FreeSlot[] {
+  const { dayStartHour = 8, dayEndHour = 22, minSlotMinutes = 30 } = options;
+
+  const slots: FreeSlot[] = [];
+  const sortedEvents = [...events]
+    .filter((e) => !e.isAllDay)
+    .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+  // 日ごとに計算
+  const current = new Date(rangeStart);
+  current.setHours(0, 0, 0, 0);
+
+  while (current < rangeEnd) {
+    const dayStart = new Date(current);
+    dayStart.setHours(dayStartHour, 0, 0, 0);
+    const dayEnd = new Date(current);
+    dayEnd.setHours(dayEndHour, 0, 0, 0);
+
+    // この日のイベントを抽出
+    const dayEvents = sortedEvents.filter((e) => {
+      return e.start < dayEnd && e.end > dayStart;
+    });
+
+    // イベント間の空きを計算
+    let cursor = dayStart;
+    for (const event of dayEvents) {
+      const eventStart = event.start < dayStart ? dayStart : event.start;
+      const eventEnd = event.end > dayEnd ? dayEnd : event.end;
+
+      if (cursor < eventStart) {
+        const durationMinutes = (eventStart.getTime() - cursor.getTime()) / 60000;
+        if (durationMinutes >= minSlotMinutes) {
+          slots.push({
+            start: new Date(cursor),
+            end: new Date(eventStart),
+            durationMinutes,
+          });
+        }
+      }
+      if (eventEnd > cursor) {
+        cursor = new Date(eventEnd);
+      }
+    }
+
+    // 最後のイベント後 ～ dayEnd の空き
+    if (cursor < dayEnd) {
+      const durationMinutes = (dayEnd.getTime() - cursor.getTime()) / 60000;
+      if (durationMinutes >= minSlotMinutes) {
+        slots.push({
+          start: new Date(cursor),
+          end: new Date(dayEnd),
+          durationMinutes,
+        });
+      }
+    }
+
+    // 翌日へ
+    current.setDate(current.getDate() + 1);
+  }
+
+  return slots;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 // Calendar Hub - Shared types and utilities
 
 export { encrypt, decrypt, type EncryptedData } from './crypto.js';
+export { calculateFreeSlots, type FreeSlot, type FreeTimeOptions } from './free-time.js';
 
 export type CalendarProvider = 'google' | 'timetree';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@calendar-hub/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       firebase:
         specifier: ^12.11.0
         version: 12.11.0
@@ -81,6 +84,9 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.2.4
+      react-big-calendar:
+        specifier: ^1.19.4
+        version: 1.19.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
@@ -131,6 +137,10 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@emnapi/runtime@1.9.1':
     resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
@@ -797,6 +807,9 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -826,6 +839,11 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@restart/hooks@0.4.16':
+    resolution: {integrity: sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -898,6 +916,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/warning@3.0.4':
+    resolution: {integrity: sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg==}
 
   '@typescript-eslint/eslint-plugin@8.57.1':
     resolution: {integrity: sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==}
@@ -1081,6 +1102,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clsx@1.2.1:
+    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1113,6 +1138,15 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  date-arithmetic@4.1.0:
+    resolution: {integrity: sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1129,9 +1163,16 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1370,6 +1411,9 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  globalize@0.1.1:
+    resolution: {integrity: sha512-5e01v8eLGfuQSOvx2MsDMOWS0GFtCx1wPzQSmcHw4hkxFzrQDBO3Xwg/m8Hr/7qXMrHeOIE29qWVzyv06u1TZA==}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -1479,6 +1523,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1516,6 +1563,9 @@ packages:
 
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -1574,6 +1624,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.17.23:
+    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -1604,12 +1657,19 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -1618,9 +1678,16 @@ packages:
   lru-memoizer@2.3.0:
     resolution: {integrity: sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==}
 
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  memoize-one@6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -1656,6 +1723,12 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  moment-timezone@0.5.48:
+    resolution: {integrity: sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==}
+
+  moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1714,6 +1787,10 @@ packages:
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
@@ -1795,6 +1872,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   proto3-json-serializer@2.0.2:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
@@ -1811,10 +1891,28 @@ packages:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
+  react-big-calendar@1.19.4:
+    resolution: {integrity: sha512-FrvbDx2LF6JAWFD96LU1jjloppC5OgIvMYUYIPzAw5Aq+ArYFPxAjLqXc4DyxfsQDN0TJTMuS/BIbcSB7Pg0YA==}
+    peerDependencies:
+      react: ^16.14.0 || ^17 || ^18 || ^19
+      react-dom: ^16.14.0 || ^17 || ^18 || ^19
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-lifecycles-compat@3.0.4:
+    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
+
+  react-overlays@5.2.1:
+    resolution: {integrity: sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==}
+    peerDependencies:
+      react: '>=16.3.0'
+      react-dom: '>=16.3.0'
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -2007,6 +2105,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uncontrollable@7.2.1:
+    resolution: {integrity: sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==}
+    peerDependencies:
+      react: '>=15.0.0'
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
@@ -2030,6 +2133,9 @@ packages:
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
+
+  warning@4.0.3:
+    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -2097,6 +2203,8 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@babel/runtime@7.29.2': {}
 
   '@emnapi/runtime@1.9.1':
     dependencies:
@@ -2763,6 +2871,8 @@ snapshots:
   '@opentelemetry/api@1.9.0':
     optional: true
 
+  '@popperjs/core@2.11.8': {}
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -2785,6 +2895,11 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@restart/hooks@0.4.16(react@19.2.4)':
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.4
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2850,6 +2965,8 @@ snapshots:
 
   '@types/tough-cookie@4.0.5':
     optional: true
+
+  '@types/warning@3.0.4': {}
 
   '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -3057,6 +3174,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clsx@1.2.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3084,6 +3203,12 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  date-arithmetic@4.1.0: {}
+
+  date-fns@4.1.0: {}
+
+  dayjs@1.11.20: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -3093,8 +3218,15 @@ snapshots:
   delayed-stream@1.0.0:
     optional: true
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2:
     optional: true
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      csstype: 3.2.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3458,6 +3590,8 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  globalize@0.1.1: {}
+
   globals@14.0.0: {}
 
   google-auth-library@10.6.2:
@@ -3600,6 +3734,10 @@ snapshots:
   inherits@2.0.4:
     optional: true
 
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -3624,6 +3762,8 @@ snapshots:
   isexe@2.0.0: {}
 
   jose@4.15.9: {}
+
+  js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -3714,6 +3854,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.17.23: {}
+
   lodash.camelcase@4.3.0: {}
 
   lodash.clonedeep@4.5.0: {}
@@ -3734,6 +3876,8 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
+  lodash@4.17.23: {}
+
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.3.0
@@ -3744,6 +3888,10 @@ snapshots:
 
   long@5.3.2: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -3753,7 +3901,11 @@ snapshots:
       lodash.clonedeep: 4.5.0
       lru-cache: 6.0.0
 
+  luxon@3.7.2: {}
+
   math-intrinsics@1.1.0: {}
+
+  memoize-one@6.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -3784,6 +3936,12 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
+
+  moment-timezone@0.5.48:
+    dependencies:
+      moment: 2.30.1
+
+  moment@2.30.1: {}
 
   ms@2.1.3: {}
 
@@ -3833,6 +3991,8 @@ snapshots:
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
+
+  object-assign@4.1.1: {}
 
   object-hash@3.0.0:
     optional: true
@@ -3900,6 +4060,12 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   proto3-json-serializer@2.0.2:
     dependencies:
       protobufjs: 7.5.4
@@ -3926,10 +4092,48 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  react-big-calendar@1.19.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      clsx: 1.2.1
+      date-arithmetic: 4.1.0
+      dayjs: 1.11.20
+      dom-helpers: 5.2.1
+      globalize: 0.1.1
+      invariant: 2.2.4
+      lodash: 4.17.23
+      lodash-es: 4.17.23
+      luxon: 3.7.2
+      memoize-one: 6.0.0
+      moment: 2.30.1
+      moment-timezone: 0.5.48
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-overlays: 5.2.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      uncontrollable: 7.2.1(react@19.2.4)
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-is@16.13.1: {}
+
+  react-lifecycles-compat@3.0.4: {}
+
+  react-overlays@5.2.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@popperjs/core': 2.11.8
+      '@restart/hooks': 0.4.16(react@19.2.4)
+      '@types/warning': 3.0.4
+      dom-helpers: 5.2.1
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      uncontrollable: 7.2.1(react@19.2.4)
+      warning: 4.0.3
 
   react@19.2.4: {}
 
@@ -4158,6 +4362,14 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  uncontrollable@7.2.1(react@19.2.4):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/react': 19.2.14
+      invariant: 2.2.4
+      react: 19.2.4
+      react-lifecycles-compat: 3.0.4
+
   undici-types@7.18.2: {}
 
   uri-js@4.4.1:
@@ -4176,6 +4388,10 @@ snapshots:
 
   uuid@9.0.1:
     optional: true
+
+  warning@4.0.3:
+    dependencies:
+      loose-envify: 1.4.0
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
## Summary
- react-big-calendar による月/週/日ビュー統合カレンダー表示
- ソース別色分け (Google: 青, TimeTree: 緑)
- 空き時間算出アルゴリズム (8:00-22:00、30分以上のスロットを検出)
- FreeSlotsPanel: 日別の空き時間一覧と合計時間表示
- イベント詳細サイドバー
- ホーム → /calendar 自動リダイレクト

## Test plan
- [ ] `pnpm turbo build` で全パッケージビルド成功
- [ ] `/calendar` ページで月/週/日ビュー切替
- [ ] 統合イベント表示 (Google + TimeTree)
- [ ] 空き時間パネルの表示確認
- [ ] イベントクリックで詳細表示

Closes #5
Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added calendar page with month, week, and day view options
  * Display calendar events with details including title, source, description, and location
  * Free time slot analysis and sidebar display showing available time slots
  * Calendar navigation with date controls
  * Secure authentication for calendar access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->