### PR TITLE
feat: implement email notification system

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,10 +17,12 @@
     "@hono/node-server": "^1.19.11",
     "firebase-admin": "^13.7.0",
     "googleapis": "^171.4.0",
-    "hono": "^4.12.8"
+    "hono": "^4.12.8",
+    "nodemailer": "^8.0.3"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "@types/nodemailer": "^7.0.11",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0"
   }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,6 +5,7 @@ import { authRoutes } from './routes/auth.js';
 import { calendarRoutes } from './routes/calendars.js';
 import { profileRoutes } from './routes/profile.js';
 import { aiRoutes } from './routes/ai.js';
+import { notificationRoutes } from './routes/notifications.js';
 import type { AppEnv } from './types.js';
 
 export const app = new Hono<AppEnv>();
@@ -24,3 +25,4 @@ app.route('/api/auth', authRoutes);
 app.route('/api/calendars', calendarRoutes);
 app.route('/api/profile', profileRoutes);
 app.route('/api/ai', aiRoutes);
+app.route('/api/notifications', notificationRoutes);

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -1,0 +1,107 @@
+import nodemailer from 'nodemailer';
+
+interface SendEmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}
+
+interface GmailAuth {
+  email: string;
+  accessToken: string;
+}
+
+/**
+ * Gmail OAuth2経由でメール送信
+ * access_tokenはrefreshAccessToken()で事前に取得しておく
+ */
+export async function sendEmail(auth: GmailAuth, options: SendEmailOptions): Promise<void> {
+  const transporter = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      type: 'OAuth2',
+      user: auth.email,
+      accessToken: auth.accessToken,
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    },
+  });
+
+  await transporter.sendMail({
+    from: `Calendar Hub <${auth.email}>`,
+    to: options.to,
+    subject: options.subject,
+    html: options.html,
+    text: options.text,
+  });
+}
+
+/**
+ * AI提案通知メールのHTML生成
+ */
+export function buildSuggestionEmailHtml(
+  suggestions: Array<{
+    title: string;
+    start: string;
+    end: string;
+    reasoning: string;
+  }>,
+  insights: string,
+): string {
+  const suggestionsHtml = suggestions
+    .map(
+      (s) => `
+    <div style="border:1px solid #e0e0e0;border-radius:8px;padding:16px;margin-bottom:12px;">
+      <h3 style="margin:0 0 8px;">${escapeHtml(s.title)}</h3>
+      <p style="margin:4px 0;color:#666;">
+        ${escapeHtml(s.start)} 〜 ${escapeHtml(s.end)}
+      </p>
+      <p style="margin:4px 0;font-size:14px;">${escapeHtml(s.reasoning)}</p>
+    </div>`,
+    )
+    .join('');
+
+  const insightsHtml = insights ? `<h2>Insights</h2><p>${escapeHtml(insights)}</p>` : '';
+
+  return `
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:20px;">
+  <h1 style="color:#333;">Calendar Hub - AI提案</h1>
+  <p>新しいスケジュール提案があります：</p>
+  ${suggestionsHtml}
+  ${insightsHtml}
+  <hr style="border:none;border-top:1px solid #eee;margin:24px 0;">
+  <p style="font-size:12px;color:#999;">
+    この通知はCalendar Hubから自動送信されています。
+    設定画面から通知をオフにできます。
+  </p>
+</body>
+</html>`;
+}
+
+/**
+ * テスト通知メールのHTML生成
+ */
+export function buildTestEmailHtml(): string {
+  return `
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:20px;">
+  <h1 style="color:#333;">Calendar Hub - テスト通知</h1>
+  <p>メール通知が正常に設定されています。</p>
+  <p style="font-size:14px;color:#666;">送信日時: ${new Date().toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}</p>
+</body>
+</html>`;
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/apps/api/src/lib/google-oauth.ts
+++ b/apps/api/src/lib/google-oauth.ts
@@ -12,6 +12,7 @@ const SCOPES = [
   'https://www.googleapis.com/auth/calendar.readonly',
   'https://www.googleapis.com/auth/calendar.events',
   'https://www.googleapis.com/auth/userinfo.email',
+  'https://www.googleapis.com/auth/gmail.send',
 ];
 
 export function generateAuthUrl(state: string): string {

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -5,9 +5,17 @@ import { requireAuth } from '../middleware/auth.js';
 import { getDb } from '../lib/firebase-admin.js';
 import { createAdapter } from '../lib/adapter-factory.js';
 import { listConnectedAccounts } from '../lib/token-store.js';
-import type { CalendarEvent, UserProfile, AiSuggestionStatus } from '@calendar-hub/shared';
+import type {
+  CalendarEvent,
+  UserProfile,
+  AiSuggestionStatus,
+  NotificationSettings,
+} from '@calendar-hub/shared';
 import { calculateFreeSlots } from '@calendar-hub/shared/free-time';
 import { generateSuggestions } from '@calendar-hub/ai-sdk';
+import { getRefreshToken } from '../lib/token-store.js';
+import { refreshAccessToken, getGoogleUserInfo } from '../lib/google-oauth.js';
+import { sendEmail, buildSuggestionEmailHtml } from '../lib/email.js';
 
 export const aiRoutes = new Hono<AppEnv>();
 
@@ -79,6 +87,15 @@ aiRoutes.post('/suggest', requireAuth, async (c) => {
 
   await batch.commit();
 
+  // メール通知（非同期、レスポンスをブロックしない）
+  sendSuggestionNotification(
+    user.uid,
+    db,
+    result.suggestions,
+    result.insights,
+    activeAccounts,
+  ).catch((err) => console.error('Notification send failed:', err));
+
   return c.json({
     suggestions: result.suggestions.map((s, i) => ({
       id: suggestionIds[i],
@@ -131,3 +148,48 @@ aiRoutes.patch('/suggestions/:suggestionId', requireAuth, async (c) => {
 
   return c.json({ success: true, status });
 });
+
+/**
+ * AI提案のメール通知を送信（通知設定が有効な場合のみ）
+ */
+async function sendSuggestionNotification(
+  userId: string,
+  db: FirebaseFirestore.Firestore,
+  suggestions: Array<{
+    title: string;
+    start: string;
+    end: string;
+    reasoning: string;
+  }>,
+  insights: string,
+  activeAccounts: Array<{ id: string; provider: string; isActive: boolean }>,
+): Promise<void> {
+  // 通知設定チェック
+  const userDoc = await db.collection('users').doc(userId).get();
+  const notifSettings = userDoc.data()?.notificationSettings as NotificationSettings | undefined;
+
+  if (!notifSettings?.enabled || !notifSettings.aiSuggestionNotify) return;
+  if (!notifSettings.channels.includes('email')) return;
+
+  // Googleアカウントでメール送信
+  const googleAccount = activeAccounts.find((a) => a.provider === 'google');
+  if (!googleAccount) return;
+
+  const refreshToken = await getRefreshToken(userId, googleAccount.id);
+  if (!refreshToken) return;
+
+  const tokens = await refreshAccessToken(refreshToken);
+  if (!tokens.access_token) return;
+
+  const userInfo = await getGoogleUserInfo(tokens.access_token);
+  const html = buildSuggestionEmailHtml(suggestions, insights);
+
+  await sendEmail(
+    { email: userInfo.email, accessToken: tokens.access_token },
+    {
+      to: userInfo.email,
+      subject: `Calendar Hub - ${suggestions.length}件の新しいスケジュール提案`,
+      html,
+    },
+  );
+}

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -1,0 +1,92 @@
+import { Hono } from 'hono';
+import type { AppEnv } from '../types.js';
+import { requireAuth } from '../middleware/auth.js';
+import { getDb } from '../lib/firebase-admin.js';
+import { sendEmail, buildTestEmailHtml } from '../lib/email.js';
+import { listConnectedAccounts, getRefreshToken } from '../lib/token-store.js';
+import { refreshAccessToken, getGoogleUserInfo } from '../lib/google-oauth.js';
+import type { NotificationSettings } from '@calendar-hub/shared';
+
+export const notificationRoutes = new Hono<AppEnv>();
+
+// 通知設定取得
+notificationRoutes.get('/settings', requireAuth, async (c) => {
+  const user = c.get('user');
+  const db = getDb();
+
+  const doc = await db.collection('users').doc(user.uid).get();
+  const data = doc.data();
+  const settings: NotificationSettings = data?.notificationSettings ?? {
+    enabled: false,
+    channels: [],
+    dailySummary: false,
+    aiSuggestionNotify: false,
+  };
+
+  return c.json({ settings });
+});
+
+// 通知設定更新
+notificationRoutes.put('/settings', requireAuth, async (c) => {
+  const user = c.get('user');
+  const body = await c.req.json();
+  const settings = body.settings as Partial<NotificationSettings>;
+
+  if (settings.enabled === undefined && settings.channels === undefined) {
+    return c.json({ error: 'At least one setting field is required' }, 400);
+  }
+
+  const db = getDb();
+  await db
+    .collection('users')
+    .doc(user.uid)
+    .set({ notificationSettings: settings }, { merge: true });
+
+  return c.json({ success: true, settings });
+});
+
+// テスト通知送信
+notificationRoutes.post('/test', requireAuth, async (c) => {
+  const user = c.get('user');
+
+  // 通知設定確認
+  const db = getDb();
+  const userDoc = await db.collection('users').doc(user.uid).get();
+  const settings = userDoc.data()?.notificationSettings as NotificationSettings | undefined;
+
+  if (!settings?.enabled) {
+    return c.json({ error: 'Notifications are not enabled' }, 400);
+  }
+
+  // Googleアカウントからメール送信用トークンを取得
+  const accounts = await listConnectedAccounts(user.uid);
+  const googleAccount = accounts.find((a) => a.provider === 'google' && a.isActive);
+
+  if (!googleAccount) {
+    return c.json({ error: 'No active Google account connected' }, 400);
+  }
+
+  try {
+    const refreshToken = await getRefreshToken(user.uid, googleAccount.id);
+    if (!refreshToken) throw new Error('No refresh token');
+
+    const tokens = await refreshAccessToken(refreshToken);
+    if (!tokens.access_token) throw new Error('Failed to get access token');
+
+    const userInfo = await getGoogleUserInfo(tokens.access_token);
+
+    await sendEmail(
+      { email: userInfo.email, accessToken: tokens.access_token },
+      {
+        to: userInfo.email,
+        subject: 'Calendar Hub - テスト通知',
+        html: buildTestEmailHtml(),
+      },
+    );
+
+    return c.json({ success: true, sentTo: userInfo.email });
+  } catch (err) {
+    console.error('Test notification error:', err);
+    return c.json({ error: 'Failed to send test notification' }, 500);
+  }
+});

--- a/apps/web/src/app/settings/settings-content.tsx
+++ b/apps/web/src/app/settings/settings-content.tsx
@@ -5,14 +5,16 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { signOut } from 'firebase/auth';
 import { auth } from '../../lib/firebase';
 import { useAuth } from '../../components/AuthProvider';
-import { apiGet, apiDelete } from '../../lib/api';
-import type { ConnectedAccountPublic } from '@calendar-hub/shared';
+import { apiGet, apiPost, apiPut, apiDelete } from '../../lib/api';
+import type { ConnectedAccountPublic, NotificationSettings } from '@calendar-hub/shared';
 
 export function SettingsContent() {
   const { user, loading } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
   const [accounts, setAccounts] = useState<ConnectedAccountPublic[]>([]);
+  const [notifSettings, setNotifSettings] = useState<NotificationSettings | null>(null);
+  const [testSending, setTestSending] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
   useEffect(() => {
@@ -36,6 +38,7 @@ export function SettingsContent() {
   useEffect(() => {
     if (user) {
       loadAccounts();
+      loadNotificationSettings();
     }
   }, [user]);
 
@@ -45,6 +48,44 @@ export function SettingsContent() {
       setAccounts(data.accounts);
     } catch (err) {
       console.error('Failed to load accounts:', err);
+    }
+  };
+
+  const loadNotificationSettings = async () => {
+    try {
+      const data = await apiGet<{ settings: NotificationSettings }>('/api/notifications/settings');
+      setNotifSettings(data.settings);
+    } catch (err) {
+      console.error('Failed to load notification settings:', err);
+    }
+  };
+
+  const handleToggleNotifications = async (enabled: boolean) => {
+    try {
+      const updated: Partial<NotificationSettings> = {
+        enabled,
+        channels: enabled ? ['email'] : [],
+        aiSuggestionNotify: enabled,
+      };
+      await apiPut('/api/notifications/settings', { settings: updated });
+      setNotifSettings((prev) => (prev ? { ...prev, ...updated } : null));
+      setMessage(enabled ? 'メール通知を有効にしました' : 'メール通知を無効にしました');
+    } catch (err) {
+      console.error('Failed to update notification settings:', err);
+      setMessage('エラー: 通知設定の更新に失敗しました');
+    }
+  };
+
+  const handleTestNotification = async () => {
+    setTestSending(true);
+    try {
+      const data = await apiPost<{ success: boolean; sentTo: string }>('/api/notifications/test');
+      setMessage(`テストメールを ${data.sentTo} に送信しました`);
+    } catch (err) {
+      console.error('Failed to send test notification:', err);
+      setMessage('エラー: テスト通知の送信に失敗しました');
+    } finally {
+      setTestSending(false);
     }
   };
 
@@ -139,6 +180,42 @@ export function SettingsContent() {
             + Googleアカウントを追加
           </button>
         </div>
+      </section>
+
+      <section style={{ marginTop: '2rem' }}>
+        <h2 style={{ marginBottom: '1rem' }}>通知設定</h2>
+
+        {notifSettings && (
+          <div
+            style={{
+              padding: '16px',
+              border: '1px solid #ddd',
+              borderRadius: '8px',
+            }}
+          >
+            <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={notifSettings.enabled}
+                onChange={(e) => handleToggleNotifications(e.target.checked)}
+              />
+              メール通知を有効にする
+            </label>
+            <p style={{ fontSize: '13px', color: '#666', margin: '8px 0' }}>
+              AI提案の結果をメールで受け取ります
+            </p>
+
+            {notifSettings.enabled && (
+              <button
+                onClick={handleTestNotification}
+                disabled={testSending}
+                style={{ ...buttonStyleSmall, marginTop: '8px' }}
+              >
+                {testSending ? '送信中...' : 'テスト通知を送信'}
+              </button>
+            )}
+          </div>
+        )}
       </section>
 
       <div style={{ marginTop: '2rem' }}>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -40,6 +40,16 @@ export async function apiPatch<T>(path: string, body: unknown): Promise<T> {
   return res.json();
 }
 
+export async function apiPut<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'PUT',
+    headers: await getAuthHeaders(),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
 export async function apiDelete<T>(path: string): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
     method: 'DELETE',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,10 +59,16 @@ importers:
       hono:
         specifier: ^4.12.8
         version: 4.12.8
+      nodemailer:
+        specifier: ^8.0.3
+        version: 8.0.3
     devDependencies:
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
+      '@types/nodemailer':
+        specifier: ^7.0.11
+        version: 7.0.11
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -1036,6 +1042,9 @@ packages:
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  '@types/nodemailer@7.0.11':
+    resolution: {integrity: sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -2043,6 +2052,10 @@ packages:
   node-forge@1.3.3:
     resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
     engines: {node: '>= 6.13.0'}
+
+  nodemailer@8.0.3:
+    resolution: {integrity: sha512-JQNBqvK+bj3NMhUFR3wmCl3SYcOeMotDiwDBvIoCuQdF0PvlIY0BH+FJ2CG7u4cXKPChplE78oowlH/Otsc4ZQ==}
+    engines: {node: '>=6.0.0'}
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -3437,6 +3450,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/nodemailer@7.0.11':
+    dependencies:
+      '@types/node': 25.5.0
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -4586,6 +4603,8 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-forge@1.3.3: {}
+
+  nodemailer@8.0.3: {}
 
   npm-run-path@5.3.0:
     dependencies:


### PR DESCRIPTION
## Summary
- nodemailer + Gmail OAuth2 によるメール通知送信ロジック
- 通知設定 CRUD API (`GET/PUT /api/notifications/settings`, `POST /api/notifications/test`)
- 設定画面に通知設定パネル追加（メール通知ON/OFF、テスト送信）
- AI提案生成時の自動メール通知（非同期、レスポンスブロックなし）
- Gmail送信用に `gmail.send` スコープをOAuth連携に追加

## Test plan
- [x] `pnpm turbo build` 全パッケージビルド成功
- [x] `vitest run` 28件全PASS
- [ ] ローカルでメール送信動作確認（Gmail OAuth再連携が必要）

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)