### PR TITLE
fix: skip Firebase init when API key missing

### DIFF
--- a/apps/web/src/lib/firebase.ts
+++ b/apps/web/src/lib/firebase.ts
@@ -1,5 +1,5 @@
-import { initializeApp, getApps } from 'firebase/app';
-import { getAuth, GoogleAuthProvider } from 'firebase/auth';
+import { initializeApp, getApps, type FirebaseApp } from 'firebase/app';
+import { getAuth, GoogleAuthProvider, type Auth } from 'firebase/auth';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -9,7 +9,12 @@ const firebaseConfig = {
   messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
 };
 
-const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
+function getFirebaseApp(): FirebaseApp | null {
+  if (!firebaseConfig.apiKey) return null;
+  return getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
+}
 
-export const auth = getAuth(app);
+const app = getFirebaseApp();
+
+export const auth: Auth = app ? getAuth(app) : ({} as Auth);
 export const googleProvider = new GoogleAuthProvider();


### PR DESCRIPTION
## Summary
- CI環境でFirebase API Keyが未設定の場合、`initializeApp()`をスキップするよう防御的初期化に変更
- Next.jsの静的ページ生成（prerender）時の`auth/invalid-api-key`エラーを解消
- 直近5回連続CI失敗の修正

## Test plan
- [x] ローカルビルド成功（静的ページ 8/8 生成）
- [x] テスト 74件全PASS
- [x] Lint エラー・警告なし
- [ ] CI（GitHub Actions）でビルド成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Firebase initialization to gracefully handle scenarios where credentials are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->