### PR TITLE
refactor: extract PageShell and useRequireAuth

### DIFF
--- a/apps/web/src/app/ai/ai-content.tsx
+++ b/apps/web/src/app/ai/ai-content.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
 import { startOfWeek, endOfWeek, format } from 'date-fns';
 import { ja } from 'date-fns/locale';
-import { useAuth } from '../../components/AuthProvider';
+import { useRequireAuth } from '../../hooks/useRequireAuth';
 import { apiGet, apiPost, apiPatch } from '../../lib/api';
-import { AppNav } from '../../components/AppNav';
+import { PageShell, PageLoading } from '../../components/PageShell';
 
 interface Suggestion {
   id: string;
@@ -33,16 +32,11 @@ const PRIORITY_COLORS: Record<string, string> = {
 };
 
 export function AiContent() {
-  const { user, loading } = useAuth();
-  const router = useRouter();
+  const { user, loading } = useRequireAuth();
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [insights, setInsights] = useState('');
   const [generating, setGenerating] = useState(false);
   const [loadingList, setLoadingList] = useState(false);
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login');
-  }, [user, loading, router]);
 
   useEffect(() => {
     if (user) loadSuggestions();
@@ -91,112 +85,99 @@ export function AiContent() {
     }
   };
 
-  if (loading)
-    return <div style={{ padding: '2rem', color: 'var(--color-text-muted)' }}>Loading...</div>;
+  if (loading) return <PageLoading />;
   if (!user) return null;
 
   return (
-    <div style={s.page}>
-      <AppNav />
-      <main style={s.main}>
-        <div style={s.header}>
-          <div>
-            <h1 style={s.title}>AI提案</h1>
-            <p style={s.desc}>あなたのスケジュールをAIが分析し、最適な予定を提案します</p>
-          </div>
-          <button onClick={handleGenerate} disabled={generating} style={s.generateBtn}>
-            {generating ? <span style={s.spinner}>◎ 分析中...</span> : '今週のスケジュールを分析'}
-          </button>
+    <PageShell maxWidth="medium">
+      <div style={s.header}>
+        <div>
+          <h1 style={s.title}>AI提案</h1>
+          <p style={s.desc}>あなたのスケジュールをAIが分析し、最適な予定を提案します</p>
         </div>
+        <button onClick={handleGenerate} disabled={generating} style={s.generateBtn}>
+          {generating ? <span style={s.spinner}>◎ 分析中...</span> : '今週のスケジュールを分析'}
+        </button>
+      </div>
 
-        {insights && (
-          <div style={s.insightsCard}>
-            <span style={s.insightsIcon}>◇</span>
-            <p style={s.insightsText}>{insights}</p>
-          </div>
-        )}
+      {insights && (
+        <div style={s.insightsCard}>
+          <span style={s.insightsIcon}>◇</span>
+          <p style={s.insightsText}>{insights}</p>
+        </div>
+      )}
 
-        {loadingList ? (
-          <p style={s.emptyText}>提案を読み込み中...</p>
-        ) : suggestions.length === 0 ? (
-          <div style={s.emptyState}>
-            <span style={s.emptyIcon}>◇</span>
-            <p style={s.emptyText}>まだ提案はありません</p>
-            <p style={s.emptyHint}>上のボタンでAI分析を開始してください</p>
-          </div>
-        ) : (
-          <div style={s.list}>
-            {suggestions.map((sg) => {
-              const cfg = TYPE_CONFIG[sg.type] ?? TYPE_CONFIG.schedule;
-              const isPending = sg.status === 'pending';
-              return (
-                <div key={sg.id} style={{ ...s.card, opacity: isPending ? 1 : 0.5 }}>
-                  <div
-                    style={{ ...s.cardBorder, background: PRIORITY_COLORS[sg.priority] ?? '#666' }}
-                  />
-                  <div style={s.cardBody}>
-                    <div style={s.cardTop}>
-                      <div style={s.badges}>
-                        <span style={s.typeBadge}>
-                          {cfg.icon} {cfg.label}
-                        </span>
-                        <span style={{ ...s.priBadge, color: PRIORITY_COLORS[sg.priority] }}>
-                          {sg.priority}
-                        </span>
-                      </div>
-                      {isPending ? (
-                        <div style={s.actions}>
-                          <button
-                            onClick={() => handleAction(sg.id, 'accepted')}
-                            style={s.acceptBtn}
-                          >
-                            承認
-                          </button>
-                          <button
-                            onClick={() => handleAction(sg.id, 'rejected')}
-                            style={s.rejectBtn}
-                          >
-                            却下
-                          </button>
-                        </div>
-                      ) : (
-                        <span
-                          style={{
-                            ...s.statusLabel,
-                            color: sg.status === 'accepted' ? '#5a9a6a' : '#e07850',
-                          }}
-                        >
-                          {sg.status === 'accepted' ? '承認済み' : '却下済み'}
-                        </span>
-                      )}
+      {loadingList ? (
+        <p style={s.emptyText}>提案を読み込み中...</p>
+      ) : suggestions.length === 0 ? (
+        <div style={s.emptyState}>
+          <span style={s.emptyIcon}>◇</span>
+          <p style={s.emptyText}>まだ提案はありません</p>
+          <p style={s.emptyHint}>上のボタンでAI分析を開始してください</p>
+        </div>
+      ) : (
+        <div style={s.list}>
+          {suggestions.map((sg) => {
+            const cfg = TYPE_CONFIG[sg.type] ?? TYPE_CONFIG.schedule;
+            const isPending = sg.status === 'pending';
+            return (
+              <div key={sg.id} style={{ ...s.card, opacity: isPending ? 1 : 0.5 }}>
+                <div
+                  style={{ ...s.cardBorder, background: PRIORITY_COLORS[sg.priority] ?? '#666' }}
+                />
+                <div style={s.cardBody}>
+                  <div style={s.cardTop}>
+                    <div style={s.badges}>
+                      <span style={s.typeBadge}>
+                        {cfg.icon} {cfg.label}
+                      </span>
+                      <span style={{ ...s.priBadge, color: PRIORITY_COLORS[sg.priority] }}>
+                        {sg.priority}
+                      </span>
                     </div>
-                    <h3 style={s.cardTitle}>{sg.title}</h3>
-                    <p style={s.cardDesc}>{sg.description}</p>
-                    {sg.start && sg.end && (
-                      <p style={s.cardTime}>
-                        {format(new Date(sg.start), 'M/d (E) HH:mm', { locale: ja })} -{' '}
-                        {format(new Date(sg.end), 'HH:mm')}
-                      </p>
+                    {isPending ? (
+                      <div style={s.actions}>
+                        <button onClick={() => handleAction(sg.id, 'accepted')} style={s.acceptBtn}>
+                          承認
+                        </button>
+                        <button onClick={() => handleAction(sg.id, 'rejected')} style={s.rejectBtn}>
+                          却下
+                        </button>
+                      </div>
+                    ) : (
+                      <span
+                        style={{
+                          ...s.statusLabel,
+                          color: sg.status === 'accepted' ? '#5a9a6a' : '#e07850',
+                        }}
+                      >
+                        {sg.status === 'accepted' ? '承認済み' : '却下済み'}
+                      </span>
                     )}
-                    <p style={s.cardReason}>{sg.reasoning}</p>
                   </div>
+                  <h3 style={s.cardTitle}>{sg.title}</h3>
+                  <p style={s.cardDesc}>{sg.description}</p>
+                  {sg.start && sg.end && (
+                    <p style={s.cardTime}>
+                      {format(new Date(sg.start), 'M/d (E) HH:mm', { locale: ja })} -{' '}
+                      {format(new Date(sg.end), 'HH:mm')}
+                    </p>
+                  )}
+                  <p style={s.cardReason}>{sg.reasoning}</p>
                 </div>
-              );
-            })}
-          </div>
-        )}
-      </main>
-
+              </div>
+            );
+          })}
+        </div>
+      )}
       <style>{`
         @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
       `}</style>
-    </div>
+    </PageShell>
   );
 }
 
 const s: Record<string, React.CSSProperties> = {
-  page: { minHeight: '100vh', background: 'var(--color-bg)' },
-  main: { padding: '24px', maxWidth: '800px', margin: '0 auto' },
   header: {
     display: 'flex',
     justifyContent: 'space-between',

--- a/apps/web/src/app/calendar/calendar-content.tsx
+++ b/apps/web/src/app/calendar/calendar-content.tsx
@@ -1,26 +1,20 @@
 'use client';
 
-import { useState, useMemo, useCallback, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useState, useMemo, useCallback } from 'react';
 import { startOfMonth, endOfMonth, startOfWeek, endOfWeek } from 'date-fns';
 import type { View } from 'react-big-calendar';
-import { useAuth } from '../../components/AuthProvider';
+import { useRequireAuth } from '../../hooks/useRequireAuth';
 import { useCalendarEvents } from '../../hooks/useCalendarEvents';
 import { CalendarView } from '../../components/CalendarView';
 import { FreeSlotsPanel } from '../../components/FreeSlotsPanel';
-import { AppNav } from '../../components/AppNav';
+import { PageShell, PageLoading } from '../../components/PageShell';
 import type { CalendarEvent } from '@calendar-hub/shared';
 
 export function CalendarContent() {
-  const { user, loading } = useAuth();
-  const router = useRouter();
+  const { user, loading } = useRequireAuth();
   const [currentDate, setCurrentDate] = useState(new Date());
   const [view, setView] = useState<View>('week');
   const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login');
-  }, [user, loading, router]);
 
   const { rangeStart, rangeEnd } = useMemo(() => {
     switch (view) {
@@ -61,77 +55,69 @@ export function CalendarContent() {
   const handleViewChange = useCallback((newView: View) => setView(newView), []);
   const handleSelectEvent = useCallback((event: CalendarEvent) => setSelectedEvent(event), []);
 
-  if (loading) return <div style={s.loading}>Loading...</div>;
+  if (loading) return <PageLoading />;
   if (!user) return null;
 
   return (
-    <div style={s.page}>
-      <AppNav />
-      <main style={s.main}>
-        {error && <div style={s.error}>{error}</div>}
+    <PageShell maxWidth="wide">
+      {error && <div style={s.error}>{error}</div>}
 
-        <div style={s.grid}>
-          <div style={s.calendarWrap}>
-            {eventsLoading && <div style={s.loadingBar}>予定を読み込み中...</div>}
-            <CalendarView
-              events={events}
-              currentDate={currentDate}
-              view={view}
-              onNavigate={handleNavigate}
-              onViewChange={handleViewChange}
-              onSelectEvent={handleSelectEvent}
-            />
-          </div>
+      <div style={s.grid}>
+        <div style={s.calendarWrap}>
+          {eventsLoading && <div style={s.loadingBar}>予定を読み込み中...</div>}
+          <CalendarView
+            events={events}
+            currentDate={currentDate}
+            view={view}
+            onNavigate={handleNavigate}
+            onViewChange={handleViewChange}
+            onSelectEvent={handleSelectEvent}
+          />
+        </div>
 
-          <aside style={s.sidebar}>
-            <FreeSlotsPanel events={events} rangeStart={rangeStart} rangeEnd={rangeEnd} />
+        <aside style={s.sidebar}>
+          <FreeSlotsPanel events={events} rangeStart={rangeStart} rangeEnd={rangeEnd} />
 
-            {selectedEvent && (
-              <div style={s.eventDetail}>
-                <div style={s.eventHeader}>
-                  <span
-                    style={{
-                      ...s.sourceBadge,
-                      background:
-                        selectedEvent.source === 'google'
-                          ? 'rgba(66,133,244,0.15)'
-                          : 'rgba(76,175,80,0.15)',
-                      color: selectedEvent.source === 'google' ? '#6ea8fe' : '#81c784',
-                    }}
-                  >
-                    {selectedEvent.source === 'google' ? 'Google' : 'TimeTree'}
-                  </span>
-                  <button onClick={() => setSelectedEvent(null)} style={s.closeBtn}>
-                    ✕
-                  </button>
-                </div>
-                <h3 style={s.eventTitle}>{selectedEvent.title}</h3>
-                {selectedEvent.description && (
-                  <p style={s.eventDesc}>{selectedEvent.description}</p>
-                )}
-                {selectedEvent.location && <p style={s.eventLoc}>{selectedEvent.location}</p>}
+          {selectedEvent && (
+            <div style={s.eventDetail}>
+              <div style={s.eventHeader}>
+                <span
+                  style={{
+                    ...s.sourceBadge,
+                    background:
+                      selectedEvent.source === 'google'
+                        ? 'rgba(66,133,244,0.15)'
+                        : 'rgba(76,175,80,0.15)',
+                    color: selectedEvent.source === 'google' ? '#6ea8fe' : '#81c784',
+                  }}
+                >
+                  {selectedEvent.source === 'google' ? 'Google' : 'TimeTree'}
+                </span>
+                <button onClick={() => setSelectedEvent(null)} style={s.closeBtn}>
+                  ✕
+                </button>
               </div>
-            )}
-          </aside>
-        </div>
+              <h3 style={s.eventTitle}>{selectedEvent.title}</h3>
+              {selectedEvent.description && <p style={s.eventDesc}>{selectedEvent.description}</p>}
+              {selectedEvent.location && <p style={s.eventLoc}>{selectedEvent.location}</p>}
+            </div>
+          )}
+        </aside>
+      </div>
 
-        <div style={s.legend}>
-          <span style={s.legendItem}>
-            <span style={{ ...s.legendDot, background: '#4285f4' }} /> Google
-          </span>
-          <span style={s.legendItem}>
-            <span style={{ ...s.legendDot, background: '#4caf50' }} /> TimeTree
-          </span>
-        </div>
-      </main>
-    </div>
+      <div style={s.legend}>
+        <span style={s.legendItem}>
+          <span style={{ ...s.legendDot, background: '#4285f4' }} /> Google
+        </span>
+        <span style={s.legendItem}>
+          <span style={{ ...s.legendDot, background: '#4caf50' }} /> TimeTree
+        </span>
+      </div>
+    </PageShell>
   );
 }
 
 const s: Record<string, React.CSSProperties> = {
-  page: { minHeight: '100vh', background: 'var(--color-bg)' },
-  main: { padding: '20px 24px', maxWidth: '1400px', margin: '0 auto' },
-  loading: { padding: '2rem', color: 'var(--color-text-muted)' },
   error: {
     padding: '10px 14px',
     background: 'rgba(229,57,53,0.1)',

--- a/apps/web/src/app/settings/settings-content.tsx
+++ b/apps/web/src/app/settings/settings-content.tsx
@@ -4,23 +4,19 @@ import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { signOut } from 'firebase/auth';
 import { auth } from '../../lib/firebase';
-import { useAuth } from '../../components/AuthProvider';
+import { useRequireAuth } from '../../hooks/useRequireAuth';
 import { apiGet, apiPost, apiPut, apiDelete } from '../../lib/api';
-import { AppNav } from '../../components/AppNav';
+import { PageShell, PageLoading } from '../../components/PageShell';
 import type { ConnectedAccountPublic, NotificationSettings } from '@calendar-hub/shared';
 
 export function SettingsContent() {
-  const { user, loading } = useAuth();
+  const { user, loading } = useRequireAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
   const [accounts, setAccounts] = useState<ConnectedAccountPublic[]>([]);
   const [notifSettings, setNotifSettings] = useState<NotificationSettings | null>(null);
   const [testSending, setTestSending] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!loading && !user) router.push('/login');
-  }, [user, loading, router]);
 
   useEffect(() => {
     const success = searchParams.get('success');
@@ -107,118 +103,112 @@ export function SettingsContent() {
     router.push('/login');
   };
 
-  if (loading)
-    return <div style={{ padding: '2rem', color: 'var(--color-text-muted)' }}>Loading...</div>;
+  if (loading) return <PageLoading />;
   if (!user) return null;
 
   return (
-    <div style={s.page}>
-      <AppNav />
-      <main style={s.main}>
-        <h1 style={s.title}>設定</h1>
+    <PageShell maxWidth="compact">
+      <h1 style={s.title}>設定</h1>
 
-        {message && (
-          <div
-            style={{
-              ...s.toast,
-              borderColor: message.startsWith('エラー')
-                ? 'rgba(224,120,80,0.3)'
-                : 'rgba(90,154,106,0.3)',
-              background: message.startsWith('エラー')
-                ? 'rgba(224,120,80,0.06)'
-                : 'rgba(90,154,106,0.06)',
-            }}
-          >
-            {message}
+      {message && (
+        <div
+          style={{
+            ...s.toast,
+            borderColor: message.startsWith('エラー')
+              ? 'rgba(224,120,80,0.3)'
+              : 'rgba(90,154,106,0.3)',
+            background: message.startsWith('エラー')
+              ? 'rgba(224,120,80,0.06)'
+              : 'rgba(90,154,106,0.06)',
+          }}
+        >
+          {message}
+        </div>
+      )}
+
+      {/* アカウント */}
+      <section style={s.section}>
+        <div style={s.sectionHeader}>
+          <h2 style={s.sectionTitle}>アカウント</h2>
+        </div>
+        <div style={s.card}>
+          <p style={s.email}>{user.email}</p>
+          <button onClick={handleLogout} style={s.dangerBtn}>
+            ログアウト
+          </button>
+        </div>
+      </section>
+
+      {/* 連携アカウント */}
+      <section style={s.section}>
+        <div style={s.sectionHeader}>
+          <h2 style={s.sectionTitle}>連携アカウント</h2>
+          <button onClick={handleConnectGoogle} style={s.addBtn}>
+            + Google追加
+          </button>
+        </div>
+
+        {accounts.length === 0 ? (
+          <p style={s.empty}>連携中のアカウントはありません</p>
+        ) : (
+          <div style={s.accountList}>
+            {accounts.map((account) => (
+              <div key={account.id} style={s.accountItem}>
+                <div>
+                  <span style={s.accountEmail}>{account.email}</span>
+                  <span
+                    style={{
+                      ...s.providerBadge,
+                      background:
+                        account.provider === 'google'
+                          ? 'rgba(66,133,244,0.12)'
+                          : 'rgba(76,175,80,0.12)',
+                      color: account.provider === 'google' ? '#6ea8fe' : '#81c784',
+                    }}
+                  >
+                    {account.provider === 'google' ? 'Google' : 'TimeTree'}
+                  </span>
+                  {!account.isActive && <span style={s.inactiveBadge}>無効</span>}
+                </div>
+                <button onClick={() => handleDisconnect(account.id)} style={s.disconnectBtn}>
+                  解除
+                </button>
+              </div>
+            ))}
           </div>
         )}
+      </section>
 
-        {/* アカウント */}
-        <section style={s.section}>
-          <div style={s.sectionHeader}>
-            <h2 style={s.sectionTitle}>アカウント</h2>
-          </div>
+      {/* 通知設定 */}
+      <section style={s.section}>
+        <div style={s.sectionHeader}>
+          <h2 style={s.sectionTitle}>通知設定</h2>
+        </div>
+        {notifSettings && (
           <div style={s.card}>
-            <p style={s.email}>{user.email}</p>
-            <button onClick={handleLogout} style={s.dangerBtn}>
-              ログアウト
-            </button>
+            <label style={s.toggle}>
+              <input
+                type="checkbox"
+                checked={notifSettings.enabled}
+                onChange={(e) => handleToggleNotifications(e.target.checked)}
+                style={s.checkbox}
+              />
+              <span>メール通知を有効にする</span>
+            </label>
+            <p style={s.toggleHint}>AI提案の結果をメールで受け取ります</p>
+            {notifSettings.enabled && (
+              <button onClick={handleTestNotification} disabled={testSending} style={s.testBtn}>
+                {testSending ? '送信中...' : 'テスト通知を送信'}
+              </button>
+            )}
           </div>
-        </section>
-
-        {/* 連携アカウント */}
-        <section style={s.section}>
-          <div style={s.sectionHeader}>
-            <h2 style={s.sectionTitle}>連携アカウント</h2>
-            <button onClick={handleConnectGoogle} style={s.addBtn}>
-              + Google追加
-            </button>
-          </div>
-
-          {accounts.length === 0 ? (
-            <p style={s.empty}>連携中のアカウントはありません</p>
-          ) : (
-            <div style={s.accountList}>
-              {accounts.map((account) => (
-                <div key={account.id} style={s.accountItem}>
-                  <div>
-                    <span style={s.accountEmail}>{account.email}</span>
-                    <span
-                      style={{
-                        ...s.providerBadge,
-                        background:
-                          account.provider === 'google'
-                            ? 'rgba(66,133,244,0.12)'
-                            : 'rgba(76,175,80,0.12)',
-                        color: account.provider === 'google' ? '#6ea8fe' : '#81c784',
-                      }}
-                    >
-                      {account.provider === 'google' ? 'Google' : 'TimeTree'}
-                    </span>
-                    {!account.isActive && <span style={s.inactiveBadge}>無効</span>}
-                  </div>
-                  <button onClick={() => handleDisconnect(account.id)} style={s.disconnectBtn}>
-                    解除
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-        </section>
-
-        {/* 通知設定 */}
-        <section style={s.section}>
-          <div style={s.sectionHeader}>
-            <h2 style={s.sectionTitle}>通知設定</h2>
-          </div>
-          {notifSettings && (
-            <div style={s.card}>
-              <label style={s.toggle}>
-                <input
-                  type="checkbox"
-                  checked={notifSettings.enabled}
-                  onChange={(e) => handleToggleNotifications(e.target.checked)}
-                  style={s.checkbox}
-                />
-                <span>メール通知を有効にする</span>
-              </label>
-              <p style={s.toggleHint}>AI提案の結果をメールで受け取ります</p>
-              {notifSettings.enabled && (
-                <button onClick={handleTestNotification} disabled={testSending} style={s.testBtn}>
-                  {testSending ? '送信中...' : 'テスト通知を送信'}
-                </button>
-              )}
-            </div>
-          )}
-        </section>
-      </main>
-    </div>
+        )}
+      </section>
+    </PageShell>
   );
 }
 
 const s: Record<string, React.CSSProperties> = {
-  page: { minHeight: '100vh', background: 'var(--color-bg)' },
-  main: { padding: '24px', maxWidth: '640px', margin: '0 auto' },
   title: {
     fontFamily: 'var(--font-display)',
     fontSize: '24px',

--- a/apps/web/src/components/PageShell.tsx
+++ b/apps/web/src/components/PageShell.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { AppNav } from './AppNav';
+
+const MAX_WIDTH = {
+  compact: '640px',
+  medium: '800px',
+  wide: '1400px',
+} as const;
+
+interface PageShellProps {
+  children: ReactNode;
+  maxWidth?: keyof typeof MAX_WIDTH;
+}
+
+export function PageShell({ children, maxWidth = 'medium' }: PageShellProps) {
+  return (
+    <div style={s.page}>
+      <AppNav />
+      <main style={{ ...s.main, maxWidth: MAX_WIDTH[maxWidth] }}>{children}</main>
+    </div>
+  );
+}
+
+export function PageLoading() {
+  return <div style={s.loading}>Loading...</div>;
+}
+
+const s: Record<string, React.CSSProperties> = {
+  page: { minHeight: '100vh', background: 'var(--color-bg)' },
+  main: { padding: '24px', margin: '0 auto' },
+  loading: { padding: '2rem', color: 'var(--color-text-muted)' },
+};

--- a/apps/web/src/hooks/useRequireAuth.ts
+++ b/apps/web/src/hooks/useRequireAuth.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '../components/AuthProvider';
+
+export function useRequireAuth() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !user) router.push('/login');
+  }, [user, loading, router]);
+
+  return { user, loading };
+}


### PR DESCRIPTION
## Summary
- `PageShell` コンポーネント: ページラッパー + AppNav + maxWidth バリエーション (compact/medium/wide)
- `PageLoading` コンポーネント: 統一ローディング表示
- `useRequireAuth` hook: 認証チェック + 未認証時リダイレクト
- calendar, ai, settings の3ページに適用、重複コード約40行削減

## Test plan
- [x] ビルド成功（静的ページ 8/8）
- [x] テスト 74件全PASS
- [x] Lint エラーなし

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated authentication handling across pages with a unified approach
  * Standardized loading states using a shared component for consistency
  * Unified page layout structure with configurable width options (compact, medium, wide)
  * Streamlined page composition and navigation patterns across AI, calendar, and settings pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->