### PR TITLE
fix: timezone handling for booking slot calculation

### DIFF
--- a/apps/api/src/routes/public-booking.ts
+++ b/apps/api/src/routes/public-booking.ts
@@ -174,6 +174,9 @@ publicBookingRoutes.get('/:linkId/slots', async (c) => {
     getConfirmedBookingEventsForOwner(link.ownerUid, rangeStart, rangeEnd),
   ]);
 
+  // サーバーはUTCで動作するため、JST (UTC+9) オフセットを指定
+  const JST_OFFSET = 540;
+
   const freeSlots = calculateFreeSlots(
     [...calendarEvents, ...bookingEvents],
     rangeStart,
@@ -182,12 +185,15 @@ publicBookingRoutes.get('/:linkId/slots', async (c) => {
       dayStartHour: link.freeTimeOptions.dayStartHour,
       dayEndHour: link.freeTimeOptions.dayEndHour,
       minSlotMinutes: link.durationMinutes,
+      timezoneOffsetMinutes: JST_OFFSET,
     },
   );
 
-  const filteredSlots = freeSlots.filter((slot) =>
-    link.availableDays.includes(slot.start.getDay()),
-  );
+  // availableDaysはJSTの曜日で判定する必要がある
+  const filteredSlots = freeSlots.filter((slot) => {
+    const jstDay = new Date(slot.start.getTime() + JST_OFFSET * 60000).getUTCDay();
+    return link.availableDays.includes(jstDay);
+  });
 
   const slots = splitFreeIntoBookingSlots(filteredSlots, link.durationMinutes, link.bufferMinutes);
 
@@ -239,11 +245,15 @@ publicBookingRoutes.post('/:linkId/book', async (c) => {
     return c.json({ error: 'Cannot book a slot in the past' }, 400);
   }
 
-  const slotHour = slotStart.getHours();
+  // JST基準で営業時間・曜日チェック
+  const JST_OFFSET_BOOK = 540;
+  const slotInJst = new Date(slotStart.getTime() + JST_OFFSET_BOOK * 60000);
+  const slotHour = slotInJst.getUTCHours();
+  const slotDay = slotInJst.getUTCDay();
   if (
     slotHour < link.freeTimeOptions.dayStartHour ||
     slotHour >= link.freeTimeOptions.dayEndHour ||
-    !link.availableDays.includes(slotStart.getDay())
+    !link.availableDays.includes(slotDay)
   ) {
     return c.json({ error: 'Slot is outside available hours/days' }, 400);
   }

--- a/packages/shared/src/free-time.ts
+++ b/packages/shared/src/free-time.ts
@@ -10,6 +10,49 @@ export interface FreeTimeOptions {
   dayStartHour?: number; // デフォルト 8
   dayEndHour?: number; // デフォルト 22
   minSlotMinutes?: number; // 最小スロット長（デフォルト 30分）
+  /** タイムゾーンのUTCオフセット（分）。例: JST = 540, EST = -300。未指定時はローカルTZ */
+  timezoneOffsetMinutes?: number;
+}
+
+/**
+ * 指定のタイムゾーンで「その日の指定時刻」をUTC Dateとして生成する。
+ * timezoneOffsetMinutesが未指定の場合はローカルTZのsetHoursを使用（後方互換）。
+ */
+function setDayHour(date: Date, hour: number, timezoneOffsetMinutes: number | undefined): Date {
+  if (timezoneOffsetMinutes !== undefined) {
+    // UTCベースで計算: その日のUTC 00:00を求め、ローカル時刻のhourをUTCに変換
+    const d = new Date(date);
+    // dateのUTC日付を基準にする
+    d.setUTCHours(0, 0, 0, 0);
+    // ローカルのhour時をUTCに変換: UTC = local - offset
+    return new Date(d.getTime() + (hour * 60 - timezoneOffsetMinutes) * 60000);
+  }
+  // 後方互換: ローカルTZ
+  const d = new Date(date);
+  d.setHours(hour, 0, 0, 0);
+  return d;
+}
+
+function startOfDayUTC(date: Date, timezoneOffsetMinutes: number | undefined): Date {
+  if (timezoneOffsetMinutes !== undefined) {
+    const d = new Date(date);
+    d.setUTCHours(0, 0, 0, 0);
+    return d;
+  }
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function nextDayUTC(date: Date, timezoneOffsetMinutes: number | undefined): Date {
+  if (timezoneOffsetMinutes !== undefined) {
+    const d = new Date(date);
+    d.setUTCDate(d.getUTCDate() + 1);
+    return d;
+  }
+  const d = new Date(date);
+  d.setDate(d.getDate() + 1);
+  return d;
 }
 
 /**
@@ -22,7 +65,7 @@ export function calculateFreeSlots(
   rangeEnd: Date,
   options: FreeTimeOptions = {},
 ): FreeSlot[] {
-  const { dayStartHour = 8, dayEndHour = 22, minSlotMinutes = 30 } = options;
+  const { dayStartHour = 8, dayEndHour = 22, minSlotMinutes = 30, timezoneOffsetMinutes } = options;
 
   const slots: FreeSlot[] = [];
   const sortedEvents = [...events]
@@ -30,14 +73,11 @@ export function calculateFreeSlots(
     .sort((a, b) => a.start.getTime() - b.start.getTime());
 
   // 日ごとに計算
-  const current = new Date(rangeStart);
-  current.setHours(0, 0, 0, 0);
+  let current = startOfDayUTC(rangeStart, timezoneOffsetMinutes);
 
   while (current < rangeEnd) {
-    const dayStart = new Date(current);
-    dayStart.setHours(dayStartHour, 0, 0, 0);
-    const dayEnd = new Date(current);
-    dayEnd.setHours(dayEndHour, 0, 0, 0);
+    const dayStart = setDayHour(current, dayStartHour, timezoneOffsetMinutes);
+    const dayEnd = setDayHour(current, dayEndHour, timezoneOffsetMinutes);
 
     // この日のイベントを抽出
     const dayEvents = sortedEvents.filter((e) => {
@@ -78,7 +118,7 @@ export function calculateFreeSlots(
     }
 
     // 翌日へ
-    current.setDate(current.getDate() + 1);
+    current = nextDayUTC(current, timezoneOffsetMinutes);
   }
 
   return slots;


### PR DESCRIPTION
## Summary

- Cloud Run（UTC）でのスロット計算がJST基準になっていなかった問題を修正
- `calculateFreeSlots` に `timezoneOffsetMinutes` オプション追加（後方互換）
- 公開予約APIで JST offset (540) を渡すように修正
- `availableDays` フィルタと営業時間チェックもJST基準に修正

### 問題
`dayStartHour=9, dayEndHour=18` がUTC 09:00-18:00として計算され、JST 18:00-03:00のスロットが表示されていた。

## Test plan
- [x] `pnpm test` — 116件全PASS
- [x] `pnpm turbo build` — 5/5成功
- [x] `pnpm lint` — 全PASS
- [ ] 本番デプロイ後: 空き時間パネルと公開ページのスロットが一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Fixed timezone handling for booking availability—available days and time windows are now correctly interpreted using Japan Standard Time (JST) instead of server-local time, ensuring accurate slot generation and booking validation across all configurations.
  * Enhanced booking system to properly account for timezone offsets during slot calculation and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->