### PR TITLE
feat: add rate limiting for public booking API

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,6 +8,7 @@ import { aiRoutes } from './routes/ai.js';
 import { notificationRoutes } from './routes/notifications.js';
 import { bookingLinkRoutes } from './routes/booking-links.js';
 import { publicBookingRoutes } from './routes/public-booking.js';
+import { rateLimit } from './middleware/rate-limit.js';
 import type { AppEnv } from './types.js';
 
 export const app = new Hono<AppEnv>();
@@ -30,6 +31,10 @@ app.use(
     credentials: true,
   }),
 );
+
+// 公開APIのレート制限
+app.use('/api/public/booking/*/slots', rateLimit({ windowMs: 60_000, max: 30 }));
+app.use('/api/public/booking/*/book', rateLimit({ windowMs: 60_000, max: 5 }));
 
 app.get('/health', (c) => c.json({ status: 'ok' }));
 

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,0 +1,62 @@
+import { createMiddleware } from 'hono/factory';
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+/**
+ * インメモリIPベースレートリミッター。
+ * Cloud Run 1-3インスタンスでは厳密なグローバル制限にはならないが、
+ * 単一インスタンスへのバースト攻撃を防ぐには十分。
+ */
+export function rateLimit(opts: { windowMs: number; max: number }) {
+  const store = new Map<string, RateLimitEntry>();
+
+  // 期限切れエントリを定期クリーンアップ（メモリリーク防止）
+  const CLEANUP_INTERVAL = 60_000;
+  let lastCleanup = Date.now();
+
+  function cleanup() {
+    const now = Date.now();
+    if (now - lastCleanup < CLEANUP_INTERVAL) return;
+    lastCleanup = now;
+    for (const [key, entry] of store) {
+      if (entry.resetAt <= now) store.delete(key);
+    }
+  }
+
+  return createMiddleware(async (c, next) => {
+    cleanup();
+
+    const ip =
+      c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ??
+      c.req.header('x-real-ip') ??
+      'unknown';
+
+    const now = Date.now();
+    const entry = store.get(ip);
+
+    if (!entry || entry.resetAt <= now) {
+      store.set(ip, { count: 1, resetAt: now + opts.windowMs });
+      c.header('X-RateLimit-Limit', String(opts.max));
+      c.header('X-RateLimit-Remaining', String(opts.max - 1));
+      await next();
+      return;
+    }
+
+    entry.count++;
+
+    if (entry.count > opts.max) {
+      const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+      c.header('Retry-After', String(retryAfter));
+      c.header('X-RateLimit-Limit', String(opts.max));
+      c.header('X-RateLimit-Remaining', '0');
+      return c.json({ error: 'Too many requests' }, 429);
+    }
+
+    c.header('X-RateLimit-Limit', String(opts.max));
+    c.header('X-RateLimit-Remaining', String(opts.max - entry.count));
+    await next();
+  });
+}


### PR DESCRIPTION
## Summary

- 公開予約APIにIPベースのレート制限を追加
- `GET /slots`: 30 req/min/IP
- `POST /book`: 5 req/min/IP
- 429 Too Many Requests + Retry-After ヘッダー返却
- インメモリMap + 定期クリーンアップ（メモリリーク防止）

## Test plan
- [x] `pnpm turbo build` — 5/5成功
- [x] `pnpm test` — 116件全PASS
- [x] `pnpm lint` — 全PASS
- [ ] デプロイ後: 短時間連打で429返却を確認

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate limiting applied to public booking API endpoints:
    * `/api/public/booking/*/slots`: 30 requests per minute
    * `/api/public/booking/*/book`: 5 requests per minute
  * Exceeding limits returns HTTP 429 error with retry timing information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->