### PR TITLE
docs: update handoff - recurring events sync (#61), 200 tests

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,15 +1,10 @@
-# Calendar Hub ハンドオフ (2026-03-27)
+# Calendar Hub ハンドオフ (2026-04-13)
 
 ## 最近の完了作業（直近1週間）
 
-| PR  | Issue | 内容                                                                |
-| --- | ----- | ------------------------------------------------------------------- |
-| #59 | #58   | 全日イベント同期のタイムゾーン対応（toDateString→UTC変換）          |
-| #57 | #56   | TimeTree→Google sync で isAllDay フラグを保持                       |
-| -   | -     | sync比較でGoogle Meet メタデータを除去                              |
-| -   | -     | 重複イベント処理・全日フォールバックマッチの修正（未PRコミット3件） |
-| #55 | #52   | extendedProperties タグによる同期済みイベント識別                   |
-| -   | #51   | Google Calendar API呼び出しで originalId を使用                     |
+| PR  | Issue | 内容                                                       |
+| --- | ----- | ---------------------------------------------------------- |
+| #61 | -     | TimeTree繰り返しイベント（RRULE）のGoogle Calendar同期対応 |
 
 （それ以前の詳細は `docs/handoff/archive/` を参照）
 
@@ -27,12 +22,13 @@
 | 全日イベント同期（TZ対応）         | ✅ 完了（#58/#59） |
 | syncIntervalMinutes スケジューラ   | ✅ 完了（#53）     |
 | timeMax 月末バグ                   | ✅ 完了（dd241df） |
+| 繰り返しイベント同期（RRULE展開）  | ✅ 完了（#61）     |
 
 ## 品質状態
 
-- テスト: 178件全PASS（最終確認: 2026-03-27）
+- テスト: 200件全PASS（最終確認: 2026-04-13）
 - ビルド: 全5パッケージ成功
-- CI: GitHub Actions グリーン（最新: main 104c9c7 / 2026-03-27）
+- CI: GitHub Actions グリーン（最新: main 35e0748 / 2026-04-13）
 - PRテンプレート: Quality Gateチェックリスト強制
 
 ## 本番環境
@@ -48,15 +44,26 @@
 - OAuth redirect URI: 設定済み
 - CORS: localhost + Cloud Run Web URL
 - Firestoreインデックス: bookingLinks, bookings 各種 READY
+- API最新リビジョン: calendar-hub-api-00032-ftb（繰り返しイベント対応済み、手動デプロイ）
 
 ## オープンIssue
 
-なし（2026-03-27時点）
+なし（2026-04-13時点）
 
 ## 次セッションの推奨アクション
 
 1. 公開予約ページで実際に予約テスト（スロット選択 → フォーム入力 → 予約確定 → メール受信確認）
 2. fetchOwnerEvents / getGmailAuthForUser の3ファイル横断共通化（calendars.ts, ai.ts, public-booking.ts）
+3. CI/CDパイプライン構築（mainマージ時に自動デプロイ）— 現在は手動 `bash infra/deploy-api.sh`
+
+## 技術メモ（今セッション）
+
+### TimeTree繰り返しイベント同期（#61）
+
+- **根本原因**: TimeTree API `/events/sync` は繰り返しイベントをマスター1件のみ返す。`recurrences`フィールドにRRULE文字列を格納。アダプターがこれを無視し、`start_at`（初回日時、多くは数年前）で時間範囲フィルタしていたため全除外。
+- **修正**: `rrule`ライブラリでRRULE/EXDATEを解析、同期期間内のインスタンスを個別イベントとして展開。ID形式: `{masterId}_R{YYYYMMDD}`（決定論的）。
+- **注意**: `rrule`はCJSモジュールのためデフォルトインポート必須（`import pkg from 'rrule'`）。無効なRRULE/日付は`try-catch`でスキップ。
+- **GCPアカウント**: gcloud操作時は `hy.unimail.11@gmail.com` に切り替え必要（.envrcの`sasaki.system0801`にはcalendar-hub-prodの権限なし）
 
 ## アカウント情報
 


### PR DESCRIPTION
## Summary
- ハンドオフドキュメントを2026-04-13セッション内容で更新
- 繰り返しイベント同期（#61）の技術メモ追加
- テスト数200件、品質状態更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project handoff documentation with latest status, quality metrics, and deployment information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->