### PR TITLE
chore(sync): redeploy #61 recurring fix + add [SYNC-STATS] log

### DIFF
--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -85,7 +85,11 @@ syncRoutes.post('/timetree-to-google', async (c) => {
           tagMap,
         } = await fetchGoogleEvents(ggAdapter, config.googleCalendarId, timeMin, timeMax);
 
+        const ttRecurring = ttEvents.filter((e) => /_R\d{8}/.test(e.originalId)).length;
         const actions = buildSyncActions(ttEvents, ggEvents, taggedGoogleIds, tagMap);
+        console.log(
+          `[SYNC-STATS] tt=${ttEvents.length} (recurring=${ttRecurring}) gg=${ggEvents.length} tagged=${taggedGoogleIds.size} actions: c=${actions.toCreate.length} u=${actions.toUpdate.length} d=${actions.toDelete.length}`,
+        );
         const stats = await executeSyncActions(ggAdapter, config.googleCalendarId, actions);
 
         totalCreated += stats.created;

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,10 +1,11 @@
-# Calendar Hub ハンドオフ (2026-04-13)
+# Calendar Hub ハンドオフ (2026-04-14)
 
 ## 最近の完了作業（直近1週間）
 
-| PR  | Issue | 内容                                                       |
-| --- | ----- | ---------------------------------------------------------- |
-| #61 | -     | TimeTree繰り返しイベント（RRULE）のGoogle Calendar同期対応 |
+| PR  | Issue | 内容                                                                   |
+| --- | ----- | ---------------------------------------------------------------------- |
+| -   | -     | PR #61の本番再デプロイ + `[SYNC-STATS]` 観測ログ追加（revision 00035） |
+| #61 | -     | TimeTree繰り返しイベント（RRULE）のGoogle Calendar同期対応             |
 
 （それ以前の詳細は `docs/handoff/archive/` を参照）
 
@@ -26,9 +27,9 @@
 
 ## 品質状態
 
-- テスト: 200件全PASS（最終確認: 2026-04-13）
+- テスト: 200件全PASS（最終確認: 2026-04-14）
 - ビルド: 全5パッケージ成功
-- CI: GitHub Actions グリーン（最新: main 35e0748 / 2026-04-13）
+- CI: GitHub Actions グリーン（最新: main d686622 / 2026-04-13）
 - PRテンプレート: Quality Gateチェックリスト強制
 
 ## 本番環境
@@ -44,7 +45,8 @@
 - OAuth redirect URI: 設定済み
 - CORS: localhost + Cloud Run Web URL
 - Firestoreインデックス: bookingLinks, bookings 各種 READY
-- API最新リビジョン: calendar-hub-api-00032-ftb（繰り返しイベント対応済み、手動デプロイ）
+- API最新リビジョン: calendar-hub-api-00035（PR #61修正含む、commit d686622、手動デプロイ 2026-04-14）
+  - 注: 00032-ftb は実態として commit 4f75b61（#61修正を含まない旧コード）だった。前回ハンドオフ誤記。2026-04-14に 00033→00035 で再デプロイ済み。
 
 ## オープンIssue
 
@@ -57,6 +59,12 @@
 3. CI/CDパイプライン構築（mainマージ時に自動デプロイ）— 現在は手動 `bash infra/deploy-api.sh`
 
 ## 技術メモ（今セッション）
+
+### 観測ログ `[SYNC-STATS]`（2026-04-14 追加）
+
+- 場所: `apps/api/src/routes/sync.ts` の `/timetree-to-google` ハンドラ内
+- 形式: `[SYNC-STATS] tt=N (recurring=M) gg=K tagged=T actions: c=X u=Y d=Z`
+- 用途: 同期が0件のとき、「TT側に無い」「既に全マッチ」「タグ欠落」のどれかを判別可能。
 
 ### TimeTree繰り返しイベント同期（#61）
 


### PR DESCRIPTION
## Summary

- Redeploy PR #61 (RRULE expansion) to production. The previous handoff incorrectly claimed it was deployed, but revision 00032-ftb was actually built from commit 4f75b61 (pre-#61 code).
- Add compact `[SYNC-STATS]` log line in the scheduler handler for future observability.
- Update `docs/handoff/LATEST.md` to correct the revision record.

## Root cause of "recurring events not synced"

The user reported that TimeTree recurring events from 2026-04-14 onward were missing on Google Calendar. Investigation showed:

1. Image tag `4f75b61` was deployed as revision 00032-ftb — this commit predates PR #61 and has no RRULE expansion.
2. Handoff LATEST.md incorrectly stated 00032-ftb contained the fix.
3. Redeployed HEAD (commit d686622 → revision 00035) via `bash infra/deploy-api.sh`.

## Verification

Post-deploy `[SYNC-STATS]` diagnostic log confirmed all recurring events are synced:

```
[SYNC-STATS] tt=173 (recurring=98) gg=211 tagged=173 actions: c=0 u=0 d=0
```

Sampled 54 recurring instances with `start >= 2026-04-14` — all `matched=true` against Google's tagged events (AUTOCARE MTG, 【専門学校】グローバルIT, 介護ITオンライン勉強会, 統括隊長MTG, etc.).

## Test plan

- [x] `pnpm test` — 200/200 PASS
- [x] `pnpm turbo type-check` — green
- [x] `pnpm lint` — green
- [x] Production deploy to revision 00035 completed
- [x] Post-deploy sync cycle verified with `[SYNC-STATS]` log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sync operation logging now displays comprehensive metrics, including total and recurring event counts from TimeTree and Google Calendar, plus a breakdown of synchronization actions (create, update, delete).

* **Chores**
  * Updated deployment documentation with latest production environment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->