### PR TITLE
fix(sync): handle comma-separated EXDATE values from TimeTree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ coverage/
 # Misc
 *.log
 .playwright-mcp/
+.serena/

--- a/packages/calendar-sdk/src/__tests__/timetree-recurrence.test.ts
+++ b/packages/calendar-sdk/src/__tests__/timetree-recurrence.test.ts
@@ -115,6 +115,26 @@ describe('expandRecurringEvent', () => {
     expect(result.length).toBe(3);
   });
 
+  it('カンマ区切りEXDATE: 1行に複数除外日をRFC5545準拠で指定', () => {
+    // TimeTree APIが実際に返す形式: EXDATE:日付1,日付2,日付3
+    const masterStart = new Date('2026-04-14T00:00:00Z'); // 火曜
+    const masterEnd = new Date('2026-04-14T01:00:00Z');
+    const recurrences = [
+      'RRULE:FREQ=WEEKLY;BYDAY=TU;UNTIL=20260601',
+      'EXDATE:20260421T000000Z,20260505T000000Z,20260519T000000Z',
+    ];
+
+    const result = expandRecurringEvent(recurrences, masterStart, masterEnd, timeMin, timeMax);
+
+    // 4/14, 4/28, 5/12, 5/26 = 4週（4/21, 5/5, 5/19除外）
+    expect(result.length).toBe(4);
+    const startDates = result.map((r) => r.start.toISOString());
+    expect(startDates).not.toContain('2026-04-21T00:00:00.000Z');
+    expect(startDates).not.toContain('2026-05-05T00:00:00.000Z');
+    expect(startDates).not.toContain('2026-05-19T00:00:00.000Z');
+    expect(startDates).toContain('2026-04-14T00:00:00.000Z');
+  });
+
   it('空のrecurrencesは空配列を返す', () => {
     const result = expandRecurringEvent([], new Date(), new Date(), timeMin, timeMax);
     expect(result).toEqual([]);

--- a/packages/calendar-sdk/src/adapters/timetree-recurrence.ts
+++ b/packages/calendar-sdk/src/adapters/timetree-recurrence.ts
@@ -29,8 +29,12 @@ export function expandRecurringEvent(
       const rule = rrulestr(line, { dtstart: masterStart });
       rruleSet.rrule(rule as InstanceType<typeof pkg.RRule>);
     } else if (line.startsWith('EXDATE:')) {
+      // TimeTreeは1行のEXDATEに複数日をカンマで並べる（RFC 5545準拠）
       const dateStr = line.replace('EXDATE:', '');
-      rruleSet.exdate(parseExdate(dateStr));
+      for (const d of dateStr.split(',')) {
+        const trimmed = d.trim();
+        if (trimmed) rruleSet.exdate(parseExdate(trimmed));
+      }
     }
   }
 

--- a/packages/calendar-sdk/src/adapters/timetree.ts
+++ b/packages/calendar-sdk/src/adapters/timetree.ts
@@ -229,8 +229,13 @@ export class TimeTreeAdapter implements CalendarAdapter {
         let instances: { start: Date; end: Date }[];
         try {
           instances = expandRecurringEvent(recurrences, masterStart, masterEnd, timeMin, timeMax);
-        } catch {
-          // 無効なRRULEや日付のイベントはスキップ
+        } catch (err) {
+          // 無効なRRULEや日付のイベントはスキップ。同じ失敗の再発検知のため最小情報を残す
+          console.error(
+            `[RRULE-SKIP] calendar=${calendarId} event=${ev.id} title="${ev.title}" recurrences=${JSON.stringify(
+              recurrences,
+            )} err=${err instanceof Error ? err.message : String(err)}`,
+          );
           continue;
         }
 


### PR DESCRIPTION
## Summary

Fix silent skip of TimeTree recurring events that use RFC 5545 comma-separated EXDATE syntax (e.g. `EXDATE:20260505T000000Z,20260526T000000Z,...`). The old parser treated the whole comma-joined string as one date, produced `Invalid Date`, and rrule threw `Invalid date passed to DateWithZone` during iteration — the `try/catch` in `listEvents` then silently dropped every instance of that recurring master.

## Root cause

User-reported example: `【専門学校】専攻生` weekly on Tuesday starting 2026-04-14 with 13 EXDATEs packed into one line. All weekly instances were missing from Google Calendar.

`packages/calendar-sdk/src/adapters/timetree-recurrence.ts` parseExdate assumed one date per EXDATE line. Real TimeTree payloads pack many.

## Fix

- Split `EXDATE:` line on `,` and feed each date to `rruleSet.exdate()`.
- Surface the previously-swallowed expansion error via `console.error('[RRULE-SKIP] ...')` so future regressions are visible in logs.
- Added regression test covering `EXDATE:date1,date2,date3` format.

## Verification (production)

Deployed to revision 00036. Observed before/after:

```
Before: [SYNC-STATS] tt=173 (recurring=98)  actions: c=0 u=0 d=0
After:  [SYNC-STATS] tt=183 (recurring=108) actions: c=10 u=0 d=0
        Sync completed: 10 created, 0 updated, 0 deleted
```

10 previously-skipped recurring instances are now synced to Google.

## Test plan

- [x] `pnpm test` — 201/201 PASS (added 1 new test for multi-value EXDATE)
- [x] `pnpm turbo type-check` — green
- [x] `pnpm lint` — green
- [x] Production deploy to revision 00036 completed
- [x] Post-deploy sync verified: 10 new creates observed via `[SYNC-STATS]`
- [ ] User confirms `【専門学校】専攻生` 2026-04-14+ visible on Google Calendar

🤖 Generated with [Claude Code](https://claude.com/claude-code)