### PR TITLE
fix(monitoring): correct verification email guidance

### DIFF
--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -93,13 +93,47 @@ VERIFY_STATUS=$(gcloud alpha monitoring channels describe "$CHANNEL_NAME" \
   --project="$PROJECT_ID" --format="value(verificationStatus)" 2>/dev/null || echo "UNKNOWN")
 if [ "$VERIFY_STATUS" != "VERIFIED" ]; then
   echo ""
-  echo "⚠️  WARNING: Notification channel is NOT verified (status='$VERIFY_STATUS')"
-  echo "   GCP sent a verification email to $NOTIFICATION_EMAIL on channel creation."
-  echo "   Click the link in that email to enable delivery."
-  echo "   Until verified, alert policies fire but emails are silently dropped."
-  echo "   Status check:"
-  echo "     gcloud alpha monitoring channels describe $CHANNEL_NAME --project=$PROJECT_ID --format='value(verificationStatus)'"
-  echo ""
+  echo "⚠️  Notification channel is NOT verified (status='$VERIFY_STATUS')"
+  echo "   Sending verification code to $NOTIFICATION_EMAIL ..."
+
+  # sendVerificationCode API を明示的に呼ぶ（GCP は channel 作成時に自動送信しない）
+  ACCESS_TOKEN=$(gcloud auth print-access-token 2>/dev/null)
+  if [ -z "$ACCESS_TOKEN" ]; then
+    echo "   ERROR: Failed to obtain access token; cannot trigger verification email." >&2
+  else
+    if curl -sSf -X POST \
+      -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+      -H "Content-Type: application/json" \
+      "https://monitoring.googleapis.com/v3/${CHANNEL_NAME}:sendVerificationCode" \
+      -d '{}' >/dev/null; then
+      echo "   ✓ Verification email sent."
+    else
+      echo "   ERROR: sendVerificationCode API call failed." >&2
+    fi
+  fi
+
+  cat <<EOF
+
+   Next steps:
+   1. Check inbox of $NOTIFICATION_EMAIL for a mail from "Google Cloud Alerting"
+      (subject: "Your alerting verification code").
+   2. Extract the code (format: G-XXXXXX) and submit it:
+
+      CODE=G-XXXXXX
+      curl -X POST \\
+        -H "Authorization: Bearer \$(gcloud auth print-access-token)" \\
+        -H "Content-Type: application/json" \\
+        "https://monitoring.googleapis.com/v3/${CHANNEL_NAME}:verify" \\
+        -d "{\\"code\\": \\"\$CODE\\"}"
+
+   3. Confirm verified:
+        gcloud alpha monitoring channels describe ${CHANNEL_NAME} \\
+          --project=${PROJECT_ID} --format='value(verificationStatus)'
+      Expected output: VERIFIED
+
+   Until VERIFIED, alert policies fire but emails are silently dropped.
+
+EOF
 fi
 
 # --- 3. Alert policies ---
@@ -158,5 +192,6 @@ echo "Verify:"
 echo "  gcloud logging metrics list --project=$PROJECT_ID --filter='name:calendar_hub'"
 echo "  gcloud alpha monitoring policies list --project=$PROJECT_ID --filter='displayName:Calendar Hub'"
 echo ""
-echo "Verification: check inbox of $NOTIFICATION_EMAIL and click the GCP verification link."
-echo "  Status check: gcloud alpha monitoring channels describe $CHANNEL_NAME --project=$PROJECT_ID"
+echo "Channel verification (if not already VERIFIED above):"
+echo "  Status check: gcloud alpha monitoring channels describe $CHANNEL_NAME \\"
+echo "    --project=$PROJECT_ID --format='value(verificationStatus)'"


### PR DESCRIPTION
## Summary

`infra/setup-monitoring.sh` のverification案内に誤りがあったため修正。

## Background

PR #70 マージ後、通知チャネルが `verificationStatus=''`（空文字 = NOT VERIFIED）のまま。
ユーザーから「認証メールはいつ来るのか」と問われて判明:

**GCPは email notification channel 作成時に認証メールを自動送信しない。** `sendVerificationCode` API を明示的に呼ぶ必要がある。alphaコマンドの `verify` サブコマンドは既に削除されており、REST API 直叩きのみが手段。

## Fix

- `VERIFY_STATUS != VERIFIED` の場合、スクリプト内で `sendVerificationCode` API を自動呼び出し
- ユーザーへの案内を「（勝手に送信されたメールの）リンクをクリック」→「今送信されたメールのコードを抽出してAPIに投げる」に訂正
- curl コマンド例を次ステップ案内に明示

## Test plan

- [x] `bash -n` 構文チェック
- [x] 既に VERIFIED 状態での実行で警告分岐に入らないこと確認
- [ ] 新規チャネル作成ケースの検証は、既存チャネルがverify済みのため本PRでは検証不可（次回チャネル再作成時に確認）

## Evidence

セッション中の手動検証:
```
curl -X POST ".../sendVerificationCode" -d '{}'  → 送信成功
（メール受信: "Your alerting verification code" G-244849）
curl -X POST ".../verify" -d '{"code":"G-244849"}'  → VERIFIED
```

現状本番の通知チャネルは既に VERIFIED 完了（PR #70 マージ後の手動操作で確定済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Channel verification now automatically triggers email verification when required.
  * Updated verification guidance with clear step-by-step instructions, sample commands, and explicit status checking to improve the user verification experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->