### PR TITLE
feat(monitoring): alert verification helper + E2E results (#72)

### DIFF
--- a/docs/adr/006-monitoring-alerts.md
+++ b/docs/adr/006-monitoring-alerts.md
@@ -147,14 +147,17 @@ bash infra/inject-test-alert-log.sh rrule-skip    # 最大1時間で発火
 ```
 
 **SYNC-GAP の持続注入**: `duration=900s` の設計により1回の注入では発火しない。
-20分間の持続信号を作るため5分間隔で4回注入:
+境界で逃さないために 3分間隔で6回注入（18分の sustained signal を生成）:
 
 ```bash
-for i in 1 2 3 4; do
+for i in 1 2 3 4 5 6; do
   bash infra/inject-test-alert-log.sh sync-gap
-  [ $i -lt 4 ] && sleep 300
+  [ $i -lt 6 ] && sleep 180
 done
 ```
+
+実測: 5分間隔で4回注入は発火しないケースあり（アラート評価の境界条件）。
+3分間隔で6回注入は 2026-04-15 の E2E で確実に発火確認済み（下記の検証結果参照）。
 
 メトリクス集計確認:
 
@@ -191,9 +194,9 @@ https://console.cloud.google.com/monitoring/alerting?project=calendar-hub-prod
    log-based metric フィルタ `cloud_run_revision` と不一致）。再発防止のため
    `infra/inject-test-alert-log.sh` を追加した（REST API で cloud_run_revision を明示指定）。
 2. **SYNC-GAP は 1回注入では発火しない**（設計通り）。`duration=900s` の条件を満たすには
-   3分間隔で6回程度（18分の sustained signal）の注入が必要。4回注入（5分間隔）では
-   境界条件で発火を逃すケースがあり、実運用では連続3サイクル以上の持続欠落時のみ発火する
-   設計意図と整合する。
+   3分間隔で6回（18分の sustained signal）の注入が必要。4回注入（5分間隔）は境界条件で
+   発火を逃したケースがあり、実運用では連続3サイクル以上の持続欠落時のみ発火する設計意図
+   と整合する。
 
 ### 無効化（障害対応時）
 

--- a/docs/adr/006-monitoring-alerts.md
+++ b/docs/adr/006-monitoring-alerts.md
@@ -129,12 +129,71 @@ gcloud alpha monitoring policies list --project=calendar-hub-prod --filter='disp
 
 ### 手動トリガテスト
 
+**⚠️ `gcloud logging write` は使えない**: デフォルトで `resource.type=global` で書き込むが、
+log-based metric の filter は `resource.type="cloud_run_revision"` を要求するため、
+メトリクスがカウントされず alert は発火しない（Issue #72 で判明）。
+
+代わりに `infra/inject-test-alert-log.sh` を使う（Cloud Logging REST API で
+`cloud_run_revision` リソースを明示指定する実装）:
+
 ```bash
-# sync API に手動で不整合を起こさず、ログのみで疎通確認する場合:
-gcloud logging write calendar-hub-api "[SYNC-GAP] calendar=test tt=99 diff=1 skipped=0" \
-  --severity=ERROR --project=calendar-hub-prod
-# 5〜10分後に Monitoring > Alerts で incident が立ち上がるか確認
+# 3種すべて注入
+bash infra/inject-test-alert-log.sh
+
+# 個別注入
+bash infra/inject-test-alert-log.sh sync-failed   # 1-5分で発火
+bash infra/inject-test-alert-log.sh sync-gap      # 持続注入が必要（次項参照）
+bash infra/inject-test-alert-log.sh rrule-skip    # 最大1時間で発火
 ```
+
+**SYNC-GAP の持続注入**: `duration=900s` の設計により1回の注入では発火しない。
+20分間の持続信号を作るため5分間隔で4回注入:
+
+```bash
+for i in 1 2 3 4; do
+  bash infra/inject-test-alert-log.sh sync-gap
+  [ $i -lt 4 ] && sleep 300
+done
+```
+
+メトリクス集計確認:
+
+```bash
+# 最新のmetric値を確認（value=1 が出ればログ検知成功）
+ACCESS_TOKEN=$(gcloud auth print-access-token)
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+FROM=$(date -u -v-10M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+curl -sS -G -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  "https://monitoring.googleapis.com/v3/projects/calendar-hub-prod/timeSeries" \
+  --data-urlencode 'filter=metric.type="logging.googleapis.com/user/calendar_hub_sync_failed"' \
+  --data-urlencode "interval.endTime=${NOW}" \
+  --data-urlencode "interval.startTime=${FROM}" \
+  --data-urlencode "aggregation.alignmentPeriod=60s" \
+  --data-urlencode "aggregation.perSeriesAligner=ALIGN_SUM"
+```
+
+Incident/メール着弾は Cloud Console で確認:
+https://console.cloud.google.com/monitoring/alerting?project=calendar-hub-prod
+
+### E2E 発火検証結果（Issue #72, 2026-04-15）
+
+通知メール受信結果（`hy.unimail.11@gmail.com`）:
+
+| アラート    | 注入方法          | 発火 (UTC) | メール受信 (JST) | Recovery 通知         |
+| ----------- | ----------------- | ---------- | ---------------- | --------------------- |
+| RRULE-SKIP  | 1回注入           | 00:47      | 09:47            | ✅ 01:47 (59分54秒後) |
+| Sync failed | 1回注入           | 00:48      | 09:48            | ✅ 00:48:41 (41秒後)  |
+| SYNC-GAP    | 6回注入 (3分間隔) | 02:46      | 11:46            | auto-close 24h        |
+
+**知見**:
+
+1. **Issue #72 原文の `gcloud logging write` 例は動作しない**（resource.type=global で
+   log-based metric フィルタ `cloud_run_revision` と不一致）。再発防止のため
+   `infra/inject-test-alert-log.sh` を追加した（REST API で cloud_run_revision を明示指定）。
+2. **SYNC-GAP は 1回注入では発火しない**（設計通り）。`duration=900s` の条件を満たすには
+   3分間隔で6回程度（18分の sustained signal）の注入が必要。4回注入（5分間隔）では
+   境界条件で発火を逃すケースがあり、実運用では連続3サイクル以上の持続欠落時のみ発火する
+   設計意図と整合する。
 
 ### 無効化（障害対応時）
 

--- a/infra/inject-test-alert-log.sh
+++ b/infra/inject-test-alert-log.sh
@@ -37,6 +37,11 @@ if [ -z "$REVISION" ]; then
   exit 1
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not found in PATH" >&2
+  exit 1
+fi
+
 ACCESS_TOKEN=$(gcloud auth print-access-token)
 
 echo "Injecting with:"
@@ -46,49 +51,53 @@ echo "  revision = $REVISION"
 echo "  test_id  = $TEST_ID"
 echo ""
 
+# jq で JSON を構築することで、変数値に含まれる特殊文字による payload 破損を防ぐ。
 write_entry() {
-  local payload="$1"
+  local text_payload="$1"
+  local body
+  body=$(jq -nc \
+    --arg project "$PROJECT_ID" \
+    --arg service "$SERVICE_NAME" \
+    --arg revision "$REVISION" \
+    --arg region "$REGION" \
+    --arg text "$text_payload" \
+    '{
+      entries: [{
+        logName: ("projects/" + $project + "/logs/run.googleapis.com%2Fstderr"),
+        resource: {
+          type: "cloud_run_revision",
+          labels: {
+            project_id: $project,
+            service_name: $service,
+            revision_name: $revision,
+            location: $region,
+            configuration_name: $service
+          }
+        },
+        severity: "ERROR",
+        textPayload: $text
+      }]
+    }')
   curl -sSf -X POST \
     -H "Authorization: Bearer ${ACCESS_TOKEN}" \
     -H "Content-Type: application/json" \
     "https://logging.googleapis.com/v2/entries:write" \
-    -d "$(cat <<EOF
-{
-  "entries": [
-    {
-      "logName": "projects/${PROJECT_ID}/logs/run.googleapis.com%2Fstderr",
-      "resource": {
-        "type": "cloud_run_revision",
-        "labels": {
-          "project_id": "${PROJECT_ID}",
-          "service_name": "${SERVICE_NAME}",
-          "revision_name": "${REVISION}",
-          "location": "${REGION}",
-          "configuration_name": "${SERVICE_NAME}"
-        }
-      },
-      "severity": "ERROR",
-      "textPayload": ${payload}
-    }
-  ]
-}
-EOF
-)" > /dev/null
+    -d "$body" > /dev/null
 }
 
 inject_sync_gap() {
-  echo "-> [SYNC-GAP] (発火目安: 15-20分)"
-  write_entry "\"[SYNC-GAP] calendar=TEST-${TEST_ID} tt=99 taggedBefore=90 diff=9 created=0 deleted=0 skipped=0\""
+  echo "-> [SYNC-GAP] (sustained 18分+ が必要、次項参照)"
+  write_entry "[SYNC-GAP] calendar=TEST-${TEST_ID} tt=99 taggedBefore=90 diff=9 created=0 deleted=0 skipped=0"
 }
 
 inject_sync_failed() {
   echo "-> Sync failed (発火目安: 1-5分)"
-  write_entry "\"Sync failed for TEST-${TEST_ID}: injected for alert E2E verification\""
+  write_entry "Sync failed for TEST-${TEST_ID}: injected for alert E2E verification"
 }
 
 inject_rrule_skip() {
   echo "-> [RRULE-SKIP] (発火目安: 最大1時間)"
-  write_entry "\"[RRULE-SKIP] calendar=TEST-${TEST_ID} event=test-evt title=\\\"e2e verification\\\" recurrences=[FREQ=INVALID] err=injected for alert E2E verification\""
+  write_entry "[RRULE-SKIP] calendar=TEST-${TEST_ID} event=test-evt title=\"e2e verification\" recurrences=[FREQ=INVALID] err=injected for alert E2E verification"
 }
 
 case "$TARGET" in

--- a/infra/inject-test-alert-log.sh
+++ b/infra/inject-test-alert-log.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -euo pipefail
+
+# Cloud Monitoring アラート発火のE2Eテスト用ログ注入スクリプト（Issue #72）
+#
+# 注意: `gcloud logging write` は resource.type=global で書き込むため、
+# log-based metric の filter (`resource.type="cloud_run_revision"`) と一致せず
+# アラートは発火しない。このスクリプトは Cloud Logging REST API を直接叩いて
+# cloud_run_revision リソースを明示指定する。
+#
+# 使用例:
+#   bash infra/inject-test-alert-log.sh              # 3種すべて注入
+#   bash infra/inject-test-alert-log.sh sync-gap     # SYNC-GAPのみ
+#   bash infra/inject-test-alert-log.sh sync-failed  # Sync failedのみ
+#   bash infra/inject-test-alert-log.sh rrule-skip   # RRULE-SKIPのみ
+
+PROJECT_ID="${GCP_PROJECT_ID:-calendar-hub-prod}"
+SERVICE_NAME="${SERVICE_NAME:-calendar-hub-api}"
+REGION="${GCP_REGION:-asia-northeast1}"
+TARGET="${1:-all}"
+TEST_ID="e2e-$(date +%s)"
+
+case "$TARGET" in
+  all | sync-gap | sync-failed | rrule-skip) ;;
+  *)
+    echo "Usage: $0 [all|sync-gap|sync-failed|rrule-skip]" >&2
+    exit 2
+    ;;
+esac
+
+REVISION=$(gcloud run services describe "$SERVICE_NAME" \
+  --project="$PROJECT_ID" --region="$REGION" \
+  --format="value(status.latestReadyRevisionName)")
+
+if [ -z "$REVISION" ]; then
+  echo "ERROR: could not resolve latest revision for $SERVICE_NAME" >&2
+  exit 1
+fi
+
+ACCESS_TOKEN=$(gcloud auth print-access-token)
+
+echo "Injecting with:"
+echo "  project  = $PROJECT_ID"
+echo "  service  = $SERVICE_NAME"
+echo "  revision = $REVISION"
+echo "  test_id  = $TEST_ID"
+echo ""
+
+write_entry() {
+  local payload="$1"
+  curl -sSf -X POST \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+    -H "Content-Type: application/json" \
+    "https://logging.googleapis.com/v2/entries:write" \
+    -d "$(cat <<EOF
+{
+  "entries": [
+    {
+      "logName": "projects/${PROJECT_ID}/logs/run.googleapis.com%2Fstderr",
+      "resource": {
+        "type": "cloud_run_revision",
+        "labels": {
+          "project_id": "${PROJECT_ID}",
+          "service_name": "${SERVICE_NAME}",
+          "revision_name": "${REVISION}",
+          "location": "${REGION}",
+          "configuration_name": "${SERVICE_NAME}"
+        }
+      },
+      "severity": "ERROR",
+      "textPayload": ${payload}
+    }
+  ]
+}
+EOF
+)" > /dev/null
+}
+
+inject_sync_gap() {
+  echo "-> [SYNC-GAP] (発火目安: 15-20分)"
+  write_entry "\"[SYNC-GAP] calendar=TEST-${TEST_ID} tt=99 taggedBefore=90 diff=9 created=0 deleted=0 skipped=0\""
+}
+
+inject_sync_failed() {
+  echo "-> Sync failed (発火目安: 1-5分)"
+  write_entry "\"Sync failed for TEST-${TEST_ID}: injected for alert E2E verification\""
+}
+
+inject_rrule_skip() {
+  echo "-> [RRULE-SKIP] (発火目安: 最大1時間)"
+  write_entry "\"[RRULE-SKIP] calendar=TEST-${TEST_ID} event=test-evt title=\\\"e2e verification\\\" recurrences=[FREQ=INVALID] err=injected for alert E2E verification\""
+}
+
+case "$TARGET" in
+  all)
+    inject_sync_gap
+    inject_sync_failed
+    inject_rrule_skip
+    ;;
+  sync-gap)
+    inject_sync_gap
+    ;;
+  sync-failed)
+    inject_sync_failed
+    ;;
+  rrule-skip)
+    inject_rrule_skip
+    ;;
+esac
+
+echo ""
+echo "=== Injection complete ==="
+echo "確認コマンド:"
+echo "  gcloud logging read 'textPayload:\"TEST-${TEST_ID}\"' --project=${PROJECT_ID} --limit=5"
+echo ""
+echo "Incident/メール着弾は Monitoring > Alerts で確認（${NOTIFICATION_EMAIL:-hy.unimail.11@gmail.com} 宛）"


### PR DESCRIPTION
## Summary

- `infra/inject-test-alert-log.sh` 追加: Cloud Logging REST API を直接叩いて
  `resource.type=cloud_run_revision` を明示指定する。`gcloud logging write` では
  `resource.type=global` になり log-based metric のフィルタと不一致で alert が発火しないため。
- ADR-006 に E2E 検証結果（RRULE-SKIP / Sync failed / SYNC-GAP 3種すべて発火確認済）と
  `gcloud logging write` 例が動かない知見を追記。

## E2E 結果

| アラート    | 注入              | 発火 (UTC) | メール (JST) |
| ----------- | ----------------- | ---------- | ------------ |
| RRULE-SKIP  | 1回               | 00:47      | 09:47        |
| Sync failed | 1回               | 00:48      | 09:48        |
| SYNC-GAP    | 6回 (3分間隔)     | 02:46      | 11:46        |

## Test plan

- [x] `bash -n infra/inject-test-alert-log.sh` syntax check
- [x] 引数検証が revision 取得より先に走ることを確認（不正引数で UX OK）
- [x] 本番環境で3種すべて発火 + メール到着確認済
- [x] `npx prettier --check docs/adr/006-monitoring-alerts.md` PASS
- [x] lint 全パッケージ PASS

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated monitoring and alert testing procedures with improved verification methods and end-to-end validation steps.

* **Tests**
  * Added new alert injection testing tool to support system alert verification workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->