### PR TITLE
feat(infra): Firestore PITR + daily backups (#73)

### DIFF
--- a/docs/adr/007-firestore-backup-restore.md
+++ b/docs/adr/007-firestore-backup-restore.md
@@ -1,0 +1,150 @@
+# ADR-007: Firestore バックアップ・PITR 設定
+
+- Status: Accepted
+- Date: 2026-04-15
+- Issue: #73
+
+## Context
+
+Firestore にバックアップ・Point-in-Time Recovery (PITR) が未設定だった。
+予約データ (`bookings`)、同期設定 (`syncConfig`)、暗号化トークン (`connectedAccounts`)、
+ownerUid 紐付けなど**再生成不可の情報が多数**あり、誤操作・コードバグ・ransomware 等で
+データ損失した場合に**リカバリ手段がない**状態だった。
+
+本番運用として許容できず、以下3層のバックアップ体制を整備する（#73）。
+
+## Decision
+
+| 層          | 対象               | リテンション               | 用途                               |
+| ----------- | ------------------ | -------------------------- | ---------------------------------- |
+| PITR        | 全コレクション     | 7日                        | 直近の誤操作・バグからの即時復旧   |
+| 日次BK      | 全コレクション     | 30日                       | 日次スナップショットから任意点復旧 |
+| GCSバケット | 手動エクスポート用 | 30日（lifecycle 自動削除） | 長期保管・ダンプ用                 |
+
+### リソース構成
+
+- **Database**: `projects/calendar-hub-prod/databases/(default)` (asia-northeast1, FIRESTORE_NATIVE)
+- **PITR**: `POINT_IN_TIME_RECOVERY_ENABLED`, `versionRetentionPeriod=604800s` (7日)
+- **Backup schedule**: daily, retention 2,592,000s (30日)
+- **GCS bucket**: `gs://calendar-hub-prod-firestore-backup` (asia-northeast1, Standard, 30日 lifecycle delete)
+
+### セットアップ
+
+```bash
+bash infra/setup-firestore-backup.sh
+# 環境変数で上書き可: GCP_PROJECT_ID, GCP_REGION, BACKUP_BUCKET, BACKUP_RETENTION_DAYS
+```
+
+冪等。既存リソースは作成せずスキップ、lifecycle は毎回 set（同内容なら実質no-op）。
+
+## Alternatives Considered
+
+| 案                                       | 採否   | 理由                                                                                 |
+| ---------------------------------------- | ------ | ------------------------------------------------------------------------------------ |
+| Terraform で IaC 化                      | 不採用 | 本リポジトリは gcloud スクリプト主体（ADR-006 と同じ方針）。冪等性が確保できれば十分 |
+| バケットを Nearline/Coldline             | 不採用 | 30日リテンションなら Standard で実質同コスト、復元のアクセスコストが不要             |
+| weekly + monthly の多段スケジュール      | 不採用 | Firestore の制約上バックアップ最大リテンション90日、複雑化に対し得られるRPOが同等    |
+| 別リージョン (multi-region) バケット複製 | 見送り | 現段階では asia-northeast1 単一運用を許容（災対は将来課題）                          |
+
+## Consequences
+
+### Positive
+
+- 7日以内の誤操作は PITR で分単位復旧可能
+- 30日分の日次バックアップで任意時点の完全復旧可能
+- 30日以上前のデータは自動削除されストレージコスト抑制
+
+### Negative
+
+- PITR 有効化後、Firestore 料金プランで version storage 分の課金が発生（free tier 内は無料）
+- GCS バケット月額: 5GiB 想定で数十円/月程度（Standard asia-northeast1）
+- `setup-firestore-backup.sh` は `jq` に依存（chaos なしで失敗停止）
+
+### Restore Procedure（復元手順）
+
+#### A) PITR による point-in-time 復元（直近7日以内）
+
+```bash
+# 復元先: 新しい database を作成して復元（本番 (default) を上書きしない）
+# earliestVersionTime 以降のタイムスタンプを指定
+RESTORE_TIME="2026-04-14T12:00:00Z"   # 復元したいUTC時刻
+RESTORE_DB="default-restore-$(date +%Y%m%d-%H%M)"
+
+gcloud firestore databases restore \
+  --source-database='projects/calendar-hub-prod/databases/(default)' \
+  --snapshot-time="$RESTORE_TIME" \
+  --destination-database="$RESTORE_DB" \
+  --project=calendar-hub-prod
+```
+
+復元 DB でデータ確認後、必要分を手動マイグレーション or app を切り替える。
+
+#### B) 日次バックアップからの復元
+
+```bash
+# バックアップID一覧
+gcloud firestore backups list --project=calendar-hub-prod
+
+# 復元（新規 database として）
+gcloud firestore databases restore \
+  --source-backup='projects/calendar-hub-prod/locations/asia-northeast1/backups/<BACKUP_ID>' \
+  --destination-database='default-restore-<TIMESTAMP>' \
+  --project=calendar-hub-prod
+```
+
+#### C) 手動エクスポート → GCS → 別環境にインポート
+
+```bash
+# エクスポート（on-demand）
+gcloud firestore export gs://calendar-hub-prod-firestore-backup/manual/$(date +%Y%m%d) \
+  --project=calendar-hub-prod
+
+# 別プロジェクト/DB にインポート
+gcloud firestore import gs://calendar-hub-prod-firestore-backup/manual/<DATE> \
+  --project=<TARGET_PROJECT>
+```
+
+### 復元後の orchestration 注意
+
+- **暗号化トークン** (`connectedAccounts`): `TOKEN_ENCRYPTION_KEY` が一致する環境にのみ復元可能
+  （Secret Manager の key をローテートしたあとは復元前のトークンは復号できない）
+- **Firebase Auth ユーザー**: Firestore のバックアップに含まれない。別途 `gcloud firebase auth:export` が必要（本 ADR の対象外、追加対応は Issue #74 以降で検討）
+- **アプリ切り替え**: 新 database を `(default)` に昇格する手段はない。切り替えるなら
+  (1) 既存 `(default)` を一時 rename する運用は不可 → (2) 新 DB を別 project に復元 or
+  (3) 復元 DB からアプリを読み込むよう一時的に設定変更 → データ差分をマージ、が現実解。
+
+## Operations
+
+### 確認コマンド
+
+```bash
+# PITR 状態
+gcloud firestore databases describe --database='(default)' --project=calendar-hub-prod \
+  --format='value(pointInTimeRecoveryEnablement,versionRetentionPeriod,earliestVersionTime)'
+
+# バックアップスケジュール
+gcloud firestore backups schedules list --database='(default)' --project=calendar-hub-prod
+
+# 既存バックアップ一覧
+gcloud firestore backups list --project=calendar-hub-prod
+
+# GCS バケット lifecycle
+gsutil lifecycle get gs://calendar-hub-prod-firestore-backup
+```
+
+### 停止（障害対応時）
+
+```bash
+# PITR 無効化（version storage 課金停止、過去バージョンは失われる）
+gcloud firestore databases update --database='(default)' --no-enable-pitr --project=calendar-hub-prod
+
+# スケジュール削除
+gcloud firestore backups schedules delete <SCHEDULE_ID> \
+  --database='(default)' --project=calendar-hub-prod
+```
+
+## Related
+
+- Issue #73: Firestore バックアップ・PITR設定（本ADR）
+- ADR-006: 同期ヘルスチェックの自動アラート化（IaC 方針を踏襲）
+- Issue #78: ロールバック手順の実地確認（本 ADR の復元手順を実地検証予定）

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -4,6 +4,7 @@
 
 | PR  | Issue | 内容                                                                                    |
 | --- | ----- | --------------------------------------------------------------------------------------- |
+| TBD | #73   | Firestore PITR + 日次バックアップ + `infra/setup-firestore-backup.sh` + ADR-007         |
 | #83 | #72   | アラート3種の E2E 発火検証 + `infra/inject-test-alert-log.sh` 追加                      |
 | #70 | #65   | 同期ヘルスチェック自動アラート（RRULE-SKIP / Sync failed / SYNC-GAP）                   |
 | #68 | #66   | CI/CD自動デプロイ化（GitHub Actions + WIF、main push→Cloud Run自動反映）                |
@@ -56,6 +57,11 @@
   - Log metrics: `calendar_hub_rrule_skip` / `calendar_hub_sync_failed` / `calendar_hub_sync_gap`
   - Alert policies（3件）→ Email 通知 `hy.unimail.11@gmail.com`
   - セットアップ: `bash infra/setup-monitoring.sh`（冪等）
+- Firestore Backup（ADR-007, #73）:
+  - PITR 有効（7日 `versionRetentionPeriod=604800s`）
+  - 日次バックアップスケジュール（30日保持）
+  - GCS: `gs://calendar-hub-prod-firestore-backup`（30日 lifecycle delete）
+  - セットアップ: `bash infra/setup-firestore-backup.sh`（冪等）
 
 ## オープンIssue
 
@@ -65,10 +71,9 @@
 
 | #                                                              | タイトル                                                   |
 | -------------------------------------------------------------- | ---------------------------------------------------------- |
-| [#73](https://github.com/yasushi-honda/Calendar-Hub/issues/73) | Firestore バックアップ・PITR設定                           |
 | [#74](https://github.com/yasushi-honda/Calendar-Hub/issues/74) | Gmail OAuth トークン失効時の可視化（静かな送信失敗の検知） |
 
-（#72 は PR #83 で完了）
+（#72 は PR #83 で完了 / #73 は本PRで完了予定）
 
 ### P1（次週対応）
 
@@ -87,17 +92,26 @@
 | [#80](https://github.com/yasushi-honda/Calendar-Hub/issues/80) | 依存ライブラリ脆弱性監視（Dependabot）          |
 | [#81](https://github.com/yasushi-honda/Calendar-Hub/issues/81) | ログ保持期間・SLO 定義                          |
 
-**本番運用として #73/#74 の P0 2件は優先対応**する。
+**本番運用として #74 の P0 残 1件は優先対応**する。
 
 ## 次セッションの推奨アクション
 
-1. **#73 Firestore PITR + 日次バックアップ** — データ損失時のリカバリ手段確立
-2. **#74 Gmail 送信失敗の可視化** — 静かに失敗する通知の検知
-3. P1 群（予約E2E / 予算アラート / エラー率監視 / ロールバック検証）
-4. fetchOwnerEvents / getGmailAuthForUser の3ファイル横断共通化
-5. Node.js 20 → Node.js 24 移行（2026-09-16 まで）
+1. **#74 Gmail 送信失敗の可視化** — 静かに失敗する通知の検知
+2. P1 群（予約E2E / 予算アラート / エラー率監視 / ロールバック検証）
+3. fetchOwnerEvents / getGmailAuthForUser の3ファイル横断共通化
+4. Node.js 20 → Node.js 24 移行（2026-09-16 まで）
 
 ## 技術メモ（今セッション）
+
+### Firestore Backup セットアップの落とし穴（2026-04-15, #73）
+
+1. **`gcloud firestore backups schedules list --filter=...` で `dailyRecurrence` を検出できない**:
+   `dailyRecurrence: {}` は空オブジェクトで filter の `:*` マッチが機能しない。
+   冪等判定には `--format=json | jq '.[] | select(.dailyRecurrence != null)'` が必要。
+2. **PITR の `earliestVersionTime` は有効化時刻から進行**: 有効化直後は直近まで、
+   7日分のウィンドウが埋まるまで最大 7 日かかる（version_retention_period=604800s）。
+3. **復元は新 DB へ**: `gcloud firestore databases restore` は常に新しい database を作成する。
+   `(default)` を直接上書きする手段はない（ADR-007 復元後 orchestration 節参照）。
 
 ### アラート E2E 検証の落とし穴（2026-04-15, #72 / PR #83）
 

--- a/infra/setup-firestore-backup.sh
+++ b/infra/setup-firestore-backup.sh
@@ -62,9 +62,12 @@ gsutil lifecycle set "$LIFECYCLE_JSON" "gs://${BACKUP_BUCKET}"
 
 # --- 2. PITR 有効化（直近7日間のpoint-in-time restore） ---
 
-PITR_STATUS=$(gcloud firestore databases describe \
+# パイプライン化せず2段に分けることで、gcloud 失敗を set -e で確実に捕捉する
+# （`gcloud ... | head` 等にすると pipefail でも後段の成功が優先され silent fallback する）
+PITR_DESCRIBE=$(gcloud firestore databases describe \
   --database="$DATABASE" --project="$PROJECT_ID" \
   --format="value(pointInTimeRecoveryEnablement)")
+PITR_STATUS="$PITR_DESCRIBE"
 
 if [ "$PITR_STATUS" = "POINT_IN_TIME_RECOVERY_ENABLED" ]; then
   echo "✓ PITR already enabled"
@@ -83,10 +86,13 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-# `--filter` は dailyRecurrence:{} (空オブジェクト) を認識できないため jq で判定する
-SCHEDULE_EXISTS=$(gcloud firestore backups schedules list \
-  --database="$DATABASE" --project="$PROJECT_ID" --format=json \
-  | jq -r '.[] | select(.dailyRecurrence != null) | .name' | head -n 1)
+# `--filter` は dailyRecurrence:{} (空オブジェクト) を認識できないため jq で判定する。
+# gcloud を一旦変数に受けて、失敗を set -e で捕捉（パイプライン化すると
+# gcloud auth エラー等で空を返した場合に silent fallback する）。
+SCHEDULES_JSON=$(gcloud firestore backups schedules list \
+  --database="$DATABASE" --project="$PROJECT_ID" --format=json)
+SCHEDULE_EXISTS=$(printf '%s' "$SCHEDULES_JSON" \
+  | jq -r '.[]? | select(.dailyRecurrence != null) | .name' | head -n 1)
 
 if [ -n "$SCHEDULE_EXISTS" ]; then
   echo "✓ Daily backup schedule already exists: $(basename "$SCHEDULE_EXISTS")"

--- a/infra/setup-firestore-backup.sh
+++ b/infra/setup-firestore-backup.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -euo pipefail
+
+# Firestore バックアップ・PITR セットアップ（Issue #73）
+#
+# 冪等: 既存リソースは再作成せずスキップ/更新する。
+# 前提: gcloud 認証済み（hy.unimail.11@gmail.com）+ 必要APIが有効化されている。
+#
+# 作成リソース:
+#   1. GCS バケット (asia-northeast1, Standard, 30日ライフサイクル)
+#   2. Firestore PITR 有効化（直近7日のpoint-in-time restore）
+#   3. Firestore 日次バックアップスケジュール（30日保持）
+
+PROJECT_ID="${GCP_PROJECT_ID:-calendar-hub-prod}"
+REGION="${GCP_REGION:-asia-northeast1}"
+DATABASE="${FIRESTORE_DATABASE:-(default)}"
+BACKUP_BUCKET="${BACKUP_BUCKET:-${PROJECT_ID}-firestore-backup}"
+RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "=== Setting up Firestore backup & PITR ==="
+echo "Project:  $PROJECT_ID"
+echo "Region:   $REGION"
+echo "Database: $DATABASE"
+echo "Bucket:   gs://${BACKUP_BUCKET}"
+echo "Retention: ${RETENTION_DAYS} days"
+echo ""
+
+# 必要APIの有効化（冪等）
+gcloud services enable \
+  firestore.googleapis.com \
+  storage.googleapis.com \
+  --project="$PROJECT_ID" --quiet
+
+# --- 1. GCS バケット（手動エクスポート配置先、長期保管用） ---
+
+if gsutil ls -b "gs://${BACKUP_BUCKET}" >/dev/null 2>&1; then
+  echo "✓ Bucket exists: gs://${BACKUP_BUCKET}"
+else
+  echo "Creating bucket: gs://${BACKUP_BUCKET}"
+  gsutil mb -p "$PROJECT_ID" -l "$REGION" -c STANDARD "gs://${BACKUP_BUCKET}"
+fi
+
+# ライフサイクル: RETENTION_DAYS 日以上前のオブジェクトを自動削除
+LIFECYCLE_JSON=$(mktemp)
+trap 'rm -f "$LIFECYCLE_JSON"' EXIT
+cat > "$LIFECYCLE_JSON" <<EOF
+{
+  "lifecycle": {
+    "rule": [
+      {
+        "action": {"type": "Delete"},
+        "condition": {"age": ${RETENTION_DAYS}}
+      }
+    ]
+  }
+}
+EOF
+
+echo "Applying lifecycle (delete objects older than ${RETENTION_DAYS} days)"
+gsutil lifecycle set "$LIFECYCLE_JSON" "gs://${BACKUP_BUCKET}"
+
+# --- 2. PITR 有効化（直近7日間のpoint-in-time restore） ---
+
+PITR_STATUS=$(gcloud firestore databases describe \
+  --database="$DATABASE" --project="$PROJECT_ID" \
+  --format="value(pointInTimeRecoveryEnablement)")
+
+if [ "$PITR_STATUS" = "POINT_IN_TIME_RECOVERY_ENABLED" ]; then
+  echo "✓ PITR already enabled"
+else
+  echo "Enabling PITR (pointInTimeRecoveryEnablement=ENABLED)"
+  gcloud firestore databases update \
+    --database="$DATABASE" \
+    --enable-pitr \
+    --project="$PROJECT_ID" --quiet
+fi
+
+# --- 3. 日次バックアップスケジュール ---
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not found in PATH" >&2
+  exit 1
+fi
+
+# `--filter` は dailyRecurrence:{} (空オブジェクト) を認識できないため jq で判定する
+SCHEDULE_EXISTS=$(gcloud firestore backups schedules list \
+  --database="$DATABASE" --project="$PROJECT_ID" --format=json \
+  | jq -r '.[] | select(.dailyRecurrence != null) | .name' | head -n 1)
+
+if [ -n "$SCHEDULE_EXISTS" ]; then
+  echo "✓ Daily backup schedule already exists: $(basename "$SCHEDULE_EXISTS")"
+else
+  echo "Creating daily backup schedule (retention=${RETENTION_DAYS}d)"
+  gcloud firestore backups schedules create \
+    --database="$DATABASE" \
+    --recurrence=daily \
+    --retention="${RETENTION_DAYS}d" \
+    --project="$PROJECT_ID"
+fi
+
+echo ""
+echo "=== Setup complete ==="
+echo "Verify:"
+echo "  gcloud firestore databases describe --database='${DATABASE}' --project=${PROJECT_ID} --format='value(pointInTimeRecoveryEnablement)'"
+echo "  gcloud firestore backups schedules list --database='${DATABASE}' --project=${PROJECT_ID}"
+echo "  gsutil ls -L -b gs://${BACKUP_BUCKET}"
+echo ""
+echo "Restore procedure: see docs/adr/007-firestore-backup-restore.md"


### PR DESCRIPTION
## Summary

- Enable Firestore PITR（7日 `versionRetentionPeriod=604800s`）
- 日次バックアップスケジュール（30日保持）
- GCS バケット `gs://calendar-hub-prod-firestore-backup`（asia-northeast1, 30日 lifecycle delete）
- 冪等セットアップスクリプト `infra/setup-firestore-backup.sh`（jqベース）
- ADR-007: 復元手順3通り（PITR / 日次BK / 手動エクスポート）+ 復元後の orchestration 注意

Closes #73.

## 本番適用結果（calendar-hub-prod）

```
pointInTimeRecoveryEnablement=POINT_IN_TIME_RECOVERY_ENABLED
versionRetentionPeriod=604800s
schedule 5f4dc32b-40da-4756-a2c8-7639f45ecdcf retention=2592000s dailyRecurrence={}
gs://calendar-hub-prod-firestore-backup lifecycle: age=30 delete
```

冪等性検証: 連続2回実行で「already exists / already enabled」を正しく検出。

## 落とし穴メモ（handoff更新済）

- `gcloud firestore backups schedules list --filter="dailyRecurrence:*"` は空オブジェクトにマッチしない → `--format=json | jq` で検出
- PITR 有効化直後の `earliestVersionTime` は現在時刻、7日分のウィンドウが埋まるまで最大7日

## Test plan

- [x] `bash -n infra/setup-firestore-backup.sh` 構文OK
- [x] 冪等実行（連続2回で差分なし、ADRの確認コマンドで状態一致）
- [ ] 次回 sync サイクル後、Cloud Logging でエラーがないことを確認（docs-only な PR ではないが、既存機能には非影響）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture decision and operational guide for Firestore backup and Point-in-Time Recovery configuration.
  * Updated project tracking documentation with backup implementation details.

* **Chores**
  * Introduced automated setup script for Firestore backup infrastructure, enabling multiple retention layers for production data resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->