### PR TITLE
docs: handoff fixup after #73 merge

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -4,7 +4,7 @@
 
 | PR  | Issue | 内容                                                                                    |
 | --- | ----- | --------------------------------------------------------------------------------------- |
-| TBD | #73   | Firestore PITR + 日次バックアップ + `infra/setup-firestore-backup.sh` + ADR-007         |
+| #85 | #73   | Firestore PITR + 日次バックアップ + `infra/setup-firestore-backup.sh` + ADR-007         |
 | #83 | #72   | アラート3種の E2E 発火検証 + `infra/inject-test-alert-log.sh` 追加                      |
 | #70 | #65   | 同期ヘルスチェック自動アラート（RRULE-SKIP / Sync failed / SYNC-GAP）                   |
 | #68 | #66   | CI/CD自動デプロイ化（GitHub Actions + WIF、main push→Cloud Run自動反映）                |
@@ -73,7 +73,7 @@
 | -------------------------------------------------------------- | ---------------------------------------------------------- |
 | [#74](https://github.com/yasushi-honda/Calendar-Hub/issues/74) | Gmail OAuth トークン失効時の可視化（静かな送信失敗の検知） |
 
-（#72 は PR #83 で完了 / #73 は本PRで完了予定）
+（#72 は PR #83、#73 は PR #85 で完了）
 
 ### P1（次週対応）
 


### PR DESCRIPTION
## Summary

- handoff の `TBD` を `#85` に更新（Issue #73 完了 PR 番号の確定）

Docs-only、影響範囲なし。

## Test plan

- [x] 次セッションの起点ドキュメントが正しく参照可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)