### PR TITLE
feat(infra): GCP budget alert ¥10/month (#76)

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -4,6 +4,7 @@
 
 | PR  | Issue | 内容                                                                                    |
 | --- | ----- | --------------------------------------------------------------------------------------- |
+| TBD | #76   | GCP 予算アラート（¥10/月、50%/90%/100%）+ `infra/setup-budget.sh`                       |
 | #87 | #74   | `[MAIL-FAIL]` プレフィックスログ + `calendar_hub_mail_fail` metric/alert                |
 | #85 | #73   | Firestore PITR + 日次バックアップ + `infra/setup-firestore-backup.sh` + ADR-007         |
 | #83 | #72   | アラート3種の E2E 発火検証 + `infra/inject-test-alert-log.sh` 追加                      |
@@ -58,6 +59,10 @@
   - Log metrics: `calendar_hub_rrule_skip` / `calendar_hub_sync_failed` / `calendar_hub_sync_gap` / `calendar_hub_mail_fail`
   - Alert policies（4件）→ Email 通知 `hy.unimail.11@gmail.com`
   - セットアップ: `bash infra/setup-monitoring.sh`（冪等）
+- Budget Alert（#76）:
+  - Calendar Hub Monthly: **¥10/月**（検知用の最小設定、50%/90%/100% threshold）
+  - 通知先: `hy.unimail.11@gmail.com`（`disableDefaultIamRecipients=true` でチャネル指定のみ）
+  - セットアップ: `bash infra/setup-budget.sh`（冪等、REST API 直接呼び出し）
 - Firestore Backup（ADR-007, #73）:
   - PITR 有効（7日 `versionRetentionPeriod=604800s`）
   - 日次バックアップスケジュール（30日保持）
@@ -77,9 +82,10 @@ _すべて完了_（#72: PR #83 / #73: PR #85 / #74: PR #87）。
 | #                                                              | タイトル                                 |
 | -------------------------------------------------------------- | ---------------------------------------- |
 | [#75](https://github.com/yasushi-honda/Calendar-Hub/issues/75) | 公開予約ページ E2E テスト                |
-| [#76](https://github.com/yasushi-honda/Calendar-Hub/issues/76) | GCP 予算アラート・コストモニタリング     |
 | [#77](https://github.com/yasushi-honda/Calendar-Hub/issues/77) | API エラー率・レイテンシ監視（sync以外） |
 | [#78](https://github.com/yasushi-honda/Calendar-Hub/issues/78) | ロールバック手順の実地確認               |
+
+（#76 は本PRで完了予定）
 
 ### P2（中期対応）
 

--- a/infra/setup-budget.sh
+++ b/infra/setup-budget.sh
@@ -36,12 +36,28 @@ gcloud services enable billingbudgets.googleapis.com --project="$PROJECT_ID" --q
 ACCESS_TOKEN=$(gcloud auth print-access-token)
 API_BASE="https://billingbudgets.googleapis.com/v1/billingAccounts/${BILLING_ACCOUNT}/budgets"
 
-# 1. 既存 budget を displayName で検索
-BUDGETS_JSON=$(curl -sSf -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-    -H "x-goog-user-project: ${PROJECT_ID}" "${API_BASE}")
-EXISTING=$(printf '%s' "$BUDGETS_JSON" \
-  | jq -r --arg name "$DISPLAY_NAME" '.budgets[]? | select(.displayName == $name) | .name' \
-  | head -n 1)
+# 1. 既存 budget を displayName で検索（ページング対応）
+# billing account 全体の budget 数が 1 ページに収まらなくなる可能性があるため、
+# nextPageToken を追いかけて全件走査する。
+EXISTING=""
+PAGE_TOKEN=""
+while :; do
+  URL="${API_BASE}?pageSize=100"
+  if [ -n "$PAGE_TOKEN" ]; then
+    URL="${URL}&pageToken=${PAGE_TOKEN}"
+  fi
+  BUDGETS_JSON=$(curl -sSf -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+      -H "x-goog-user-project: ${PROJECT_ID}" "$URL")
+  MATCH=$(printf '%s' "$BUDGETS_JSON" \
+    | jq -r --arg name "$DISPLAY_NAME" '.budgets[]? | select(.displayName == $name) | .name' \
+    | head -n 1)
+  if [ -n "$MATCH" ]; then
+    EXISTING="$MATCH"
+    break
+  fi
+  PAGE_TOKEN=$(printf '%s' "$BUDGETS_JSON" | jq -r '.nextPageToken // empty')
+  [ -z "$PAGE_TOKEN" ] && break
+done
 
 # 2. body を jq で構築（閾値展開・資源名・フィルタの quote を安全に）
 IFS=',' read -r -a THR_ARR <<< "$THRESHOLDS"
@@ -73,21 +89,38 @@ BODY=$(jq -nc \
     }
   }')
 
+# API 呼び出しを body + HTTP ステータスに分離し、非 2xx なら body をログして exit する。
+# `curl -sSf | jq '.name // "updated"'` だと -f + pipefail で失敗自体は検知するが、
+# API エラー body が消えて原因追跡が難しい。明示的に status を確認する。
+call_api() {
+  local method="$1"
+  local url="$2"
+  local payload="$3"
+  local http_code response_file
+  response_file=$(mktemp)
+  http_code=$(curl -sS -o "$response_file" -w '%{http_code}' -X "$method" \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+    -H "x-goog-user-project: ${PROJECT_ID}" \
+    -H "Content-Type: application/json" \
+    "$url" -d "$payload")
+  if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+    echo "ERROR: $method $url failed (HTTP $http_code)" >&2
+    cat "$response_file" >&2
+    rm -f "$response_file"
+    exit 1
+  fi
+  jq -r '.name // "ok"' < "$response_file"
+  rm -f "$response_file"
+}
+
 if [ -n "$EXISTING" ]; then
   echo "Updating budget: $(basename "$EXISTING")"
-  curl -sSf -X PATCH \
-    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-    -H "x-goog-user-project: ${PROJECT_ID}" \
-    -H "Content-Type: application/json" \
+  call_api PATCH \
     "https://billingbudgets.googleapis.com/v1/${EXISTING}?updateMask=displayName,budgetFilter,amount,thresholdRules,notificationsRule" \
-    -d "$(jq -n --argjson b "$BODY" '$b')" | jq -r '.name // "updated"'
+    "$BODY"
 else
   echo "Creating budget"
-  curl -sSf -X POST \
-    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-    -H "x-goog-user-project: ${PROJECT_ID}" \
-    -H "Content-Type: application/json" \
-    "${API_BASE}" -d "$BODY" | jq -r '.name // "created"'
+  call_api POST "$API_BASE" "$BODY"
 fi
 
 echo ""

--- a/infra/setup-budget.sh
+++ b/infra/setup-budget.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -euo pipefail
+
+# GCP 予算アラート セットアップ（Issue #76）
+#
+# 冪等: 既存 budget (displayName 一致) は update、無ければ create。
+# 前提: gcloud 認証済み（hy.unimail.11@gmail.com）+ billing API 有効化済み。
+#
+# 通貨は billing account の currencyCode に従う（calendar-hub-prod は JPY）。
+# 金額・閾値は環境変数で上書き可能。
+
+PROJECT_ID="${GCP_PROJECT_ID:-calendar-hub-prod}"
+BILLING_ACCOUNT="${BILLING_ACCOUNT:-01817F-AFD15C-E57676}"
+DISPLAY_NAME="${BUDGET_DISPLAY_NAME:-Calendar Hub Monthly}"
+BUDGET_UNITS="${BUDGET_UNITS:-10}"         # 10 単位（JPY の場合 ¥10）
+THRESHOLDS="${THRESHOLDS:-0.5,0.9,1.0}"   # 50% / 90% / 100%
+NOTIFICATION_CHANNEL="${NOTIFICATION_CHANNEL:-projects/calendar-hub-prod/notificationChannels/11987628746704320713}"
+
+echo "=== Setting up GCP budget alert ==="
+echo "Project:  $PROJECT_ID"
+echo "Billing:  $BILLING_ACCOUNT"
+echo "Amount:   ${BUDGET_UNITS} (billing account currency)"
+echo "Channel:  $NOTIFICATION_CHANNEL"
+echo "Thresholds: $THRESHOLDS"
+echo ""
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required" >&2
+  exit 1
+fi
+
+gcloud services enable billingbudgets.googleapis.com --project="$PROJECT_ID" --quiet
+
+# `gcloud billing budgets` は alpha/beta で挙動・フラグが揺れるため、REST API を直接叩く。
+# この方が冪等制御も書きやすい。
+ACCESS_TOKEN=$(gcloud auth print-access-token)
+API_BASE="https://billingbudgets.googleapis.com/v1/billingAccounts/${BILLING_ACCOUNT}/budgets"
+
+# 1. 既存 budget を displayName で検索
+BUDGETS_JSON=$(curl -sSf -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+    -H "x-goog-user-project: ${PROJECT_ID}" "${API_BASE}")
+EXISTING=$(printf '%s' "$BUDGETS_JSON" \
+  | jq -r --arg name "$DISPLAY_NAME" '.budgets[]? | select(.displayName == $name) | .name' \
+  | head -n 1)
+
+# 2. body を jq で構築（閾値展開・資源名・フィルタの quote を安全に）
+IFS=',' read -r -a THR_ARR <<< "$THRESHOLDS"
+THRESHOLD_JSON=$(printf '%s\n' "${THR_ARR[@]}" \
+  | jq -R -c 'tonumber | {spendBasis: "CURRENT_SPEND", thresholdPercent: .}' \
+  | jq -s '.')
+
+BODY=$(jq -nc \
+  --arg display "$DISPLAY_NAME" \
+  --arg units "$BUDGET_UNITS" \
+  --arg project "projects/${PROJECT_ID}" \
+  --arg channel "$NOTIFICATION_CHANNEL" \
+  --argjson thresholds "$THRESHOLD_JSON" \
+  '{
+    displayName: $display,
+    budgetFilter: {
+      projects: [$project],
+      calendarPeriod: "MONTH"
+    },
+    amount: {
+      specifiedAmount: {
+        units: $units
+      }
+    },
+    thresholdRules: $thresholds,
+    notificationsRule: {
+      monitoringNotificationChannels: [$channel],
+      disableDefaultIamRecipients: true
+    }
+  }')
+
+if [ -n "$EXISTING" ]; then
+  echo "Updating budget: $(basename "$EXISTING")"
+  curl -sSf -X PATCH \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+    -H "x-goog-user-project: ${PROJECT_ID}" \
+    -H "Content-Type: application/json" \
+    "https://billingbudgets.googleapis.com/v1/${EXISTING}?updateMask=displayName,budgetFilter,amount,thresholdRules,notificationsRule" \
+    -d "$(jq -n --argjson b "$BODY" '$b')" | jq -r '.name // "updated"'
+else
+  echo "Creating budget"
+  curl -sSf -X POST \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+    -H "x-goog-user-project: ${PROJECT_ID}" \
+    -H "Content-Type: application/json" \
+    "${API_BASE}" -d "$BODY" | jq -r '.name // "created"'
+fi
+
+echo ""
+echo "=== Setup complete ==="
+echo "Verify:"
+echo "  gcloud billing budgets list --billing-account=${BILLING_ACCOUNT}"
+echo "  または: https://console.cloud.google.com/billing/${BILLING_ACCOUNT}/budgets"


### PR DESCRIPTION
## Summary

- `infra/setup-budget.sh` 新規: GCP 予算アラートの冪等セットアップ
- ¥10/月、閾値 50%/90%/100%、既存 Cloud Monitoring チャネルで Email 通知
- `x-goog-user-project` header で ADC quota project を明示

Closes #76.

## 本番適用済

- Budget: `billingAccounts/01817F-AFD15C-E57676/budgets/ed8c26d9-...`
- displayName: `Calendar Hub Monthly`
- 冪等: 再実行で update（jq で displayName 一致検出）

## 設計判断

- **REST API 直呼び**: `gcloud billing budgets` CLI は alpha/beta で仕様揺らぎが大きいため `billingbudgets.googleapis.com` を直接叩く。
- **閾値 3段階**: Issue 要件の 50/90/100%。±300% 前日比の異常検知は現段階のトラフィック量では誤検知多く先送り。
- **`disableDefaultIamRecipients=true`**: 請求管理者全員ではなく、指定チャネルのみに通知（本番運用チャネル一元化の方針）。

## Test plan

- [x] `bash -n infra/setup-budget.sh` 構文OK
- [x] 本番 create 成功（新規 budget 作成確認）
- [x] 冪等実行（再実行で update パスへ分岐、API 200 返答）
- [ ] 実課金発生時のアラート配信は ¥10 到達時に初めて検証可能（次セッションで Cloud Console から疑似発火確認する手順を記録）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GCP Cloud Billing Budget alert system with monthly spending limits and automated alerts at 50%, 90%, and 100% threshold points.

* **Documentation**
  * Updated setup documentation with complete Budget Alert configuration guide and automated setup script for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->