### PR TITLE
feat(infra): rollback.sh + verified prod rollback (#78)

### DIFF
--- a/docs/adr/005-ci-cd-auto-deploy.md
+++ b/docs/adr/005-ci-cd-auto-deploy.md
@@ -103,10 +103,39 @@ type-check / test が再検証される構造。
 Cloud Runコンソールから過去リビジョンにトラフィック切替、または:
 
 ```bash
-gcloud run services update-traffic calendar-hub-api \
-  --project=calendar-hub-prod --region=asia-northeast1 \
-  --to-revisions=calendar-hub-api-00036=100
+# 直前のリビジョンへ（引数省略時は 2 番目に新しいものを選択）
+bash infra/rollback.sh api
+bash infra/rollback.sh web
+
+# 特定リビジョンへ（suffix だけでも、完全名でも可）
+bash infra/rollback.sh api 00048-tvv
+bash infra/rollback.sh api calendar-hub-api-00048-tvv
+
+# 候補一覧
+bash infra/rollback.sh api --list
 ```
+
+`infra/rollback.sh` が裏で `gcloud run services update-traffic ... --to-revisions=...=100`
+を実行する。現在のアクティブは `status.traffic[0].revisionName` で取得しており、
+`latestReadyRevisionName` はデプロイ最新を指すだけなので rollback 後の再判定には使えない。
+
+#### 実地検証済み（2026-04-15, Issue #78）
+
+| サービス         | 切替元 → 切替先              | 所要時間 | ヘルス                          | 復元時間 |
+| ---------------- | ---------------------------- | -------- | ------------------------------- | -------- |
+| calendar-hub-api | 00049-nfd → 00048-tvv → 戻す | 7s, 4s   | `/health` 200 `{"status":"ok"}` | —        |
+| calendar-hub-web | 00024-thk → 00023-r6n → 戻す | 5s, 4s   | `/` 200                         | —        |
+
+4 操作すべて単発コマンドで完結。所要時間は `gcloud run services update-traffic` の
+返り時間のみで、Cloud Run 内部のトラフィック切替はさらに短い（実測体感で数秒以内）。
+
+#### 台本（障害時の実際の流れ）
+
+1. `gh run list --workflow=deploy.yml --limit 5` で直近デプロイ履歴確認（怪しい PR を特定）
+2. `bash infra/rollback.sh api --list` で候補リビジョン確認
+3. `bash infra/rollback.sh api <suffix>` で切替
+4. `/health` と主要 UI 動作を目視確認
+5. 復旧後、原因特定 → 新しい commit で forward-fix（revert は最終手段）
 
 ## Related
 

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -4,7 +4,8 @@
 
 | PR  | Issue | 内容                                                                                    |
 | --- | ----- | --------------------------------------------------------------------------------------- |
-| TBD | #76   | GCP 予算アラート（¥10/月、50%/90%/100%）+ `infra/setup-budget.sh`                       |
+| TBD | #78   | ロールバック実地検証 + `infra/rollback.sh` + ADR-005 更新                               |
+| #90 | #76   | GCP 予算アラート（¥10/月、50%/90%/100%）+ `infra/setup-budget.sh`                       |
 | #87 | #74   | `[MAIL-FAIL]` プレフィックスログ + `calendar_hub_mail_fail` metric/alert                |
 | #85 | #73   | Firestore PITR + 日次バックアップ + `infra/setup-firestore-backup.sh` + ADR-007         |
 | #83 | #72   | アラート3種の E2E 発火検証 + `infra/inject-test-alert-log.sh` 追加                      |
@@ -83,9 +84,8 @@ _すべて完了_（#72: PR #83 / #73: PR #85 / #74: PR #87）。
 | -------------------------------------------------------------- | ---------------------------------------- |
 | [#75](https://github.com/yasushi-honda/Calendar-Hub/issues/75) | 公開予約ページ E2E テスト                |
 | [#77](https://github.com/yasushi-honda/Calendar-Hub/issues/77) | API エラー率・レイテンシ監視（sync以外） |
-| [#78](https://github.com/yasushi-honda/Calendar-Hub/issues/78) | ロールバック手順の実地確認               |
 
-（#76 は本PRで完了予定）
+（#76 は PR #90、#78 は本PRで完了予定）
 
 ### P2（中期対応）
 
@@ -99,10 +99,11 @@ _すべて完了_（#72: PR #83 / #73: PR #85 / #74: PR #87）。
 
 ## 次セッションの推奨アクション
 
-1. P1 群（予約E2E #75 / 予算アラート #76 / エラー率監視 #77 / ロールバック検証 #78）
-2. fetchOwnerEvents / getGmailAuthForUser の3ファイル横断共通化
-3. Node.js 20 → Node.js 24 移行（2026-09-16 まで）
-4. `[MAIL-FAIL] kind=AUTH` 発生時の UI 通知昇格（#74 の追加課題、別Issue化検討）
+1. 残 P1: **#75 予約 E2E テスト** / **#77 sync 以外の API エラー率監視**
+2. P2 (任意): #79 TimeTree session 自動検知 / #80 Dependabot / #81 SLO
+3. fetchOwnerEvents / getGmailAuthForUser の3ファイル横断共通化
+4. Node.js 20 → Node.js 24 移行（2026-09-16 まで）
+5. `[MAIL-FAIL] kind=AUTH` 発生時の UI 通知昇格（#74 の追加課題、別Issue化検討）
 
 ## 技術メモ（今セッション）
 

--- a/infra/rollback.sh
+++ b/infra/rollback.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -euo pipefail
+
+# Cloud Run サービスのロールバックユーティリティ（Issue #78）
+#
+# 使用例:
+#   bash infra/rollback.sh api                    # API を直前のリビジョンへ
+#   bash infra/rollback.sh web                    # Web を直前のリビジョンへ
+#   bash infra/rollback.sh api 00047-qcm          # API を指定リビジョンへ
+#   bash infra/rollback.sh api --list             # API の候補リビジョン表示
+#
+# サービス指定の suffix はオプション（`00047-qcm` または `calendar-hub-api-00047-qcm` どちらも可）。
+
+PROJECT_ID="${GCP_PROJECT_ID:-calendar-hub-prod}"
+REGION="${GCP_REGION:-asia-northeast1}"
+
+TARGET_SVC="${1:-}"
+case "$TARGET_SVC" in
+  api) SERVICE="calendar-hub-api" ;;
+  web) SERVICE="calendar-hub-web" ;;
+  *)
+    echo "Usage: $0 <api|web> [<revision-suffix>|--list]" >&2
+    exit 2
+    ;;
+esac
+
+shift
+ARG="${1:-}"
+
+if [ "$ARG" = "--list" ]; then
+  gcloud run revisions list --service="$SERVICE" \
+    --region="$REGION" --project="$PROJECT_ID" \
+    --format="table(name,creationTimestamp.date('%Y-%m-%d %H:%M'),metadata.labels.'serving.knative.dev/routeCurrentlyAssignedRevisionLabel')" \
+    --limit=10
+  exit 0
+fi
+
+# 現行 active revision（traffic が 100% 流れている先を取る。`latestReadyRevisionName`
+# はデプロイ最新を指すだけで、rollback 後も値は変わらないため使えない）。
+CURRENT=$(gcloud run services describe "$SERVICE" \
+  --region="$REGION" --project="$PROJECT_ID" \
+  --format="value(status.traffic[0].revisionName)")
+
+if [ -z "$CURRENT" ]; then
+  echo "ERROR: could not resolve current traffic revision for $SERVICE" >&2
+  exit 1
+fi
+
+# ターゲット revision を決定
+if [ -n "$ARG" ]; then
+  # ユーザー指定（suffix または完全名）。先頭に service prefix 付ける
+  case "$ARG" in
+    "$SERVICE"-*) TARGET="$ARG" ;;
+    *) TARGET="${SERVICE}-${ARG}" ;;
+  esac
+else
+  # 引数なし: 直前（2番目に新しい）リビジョン
+  TARGET=$(gcloud run revisions list --service="$SERVICE" \
+    --region="$REGION" --project="$PROJECT_ID" \
+    --format="value(name)" --sort-by="~creationTimestamp" --limit=2 \
+    | sed -n '2p')
+  if [ -z "$TARGET" ]; then
+    echo "ERROR: no previous revision found for $SERVICE" >&2
+    exit 1
+  fi
+fi
+
+if [ "$CURRENT" = "$TARGET" ]; then
+  echo "No-op: $SERVICE is already on $TARGET"
+  exit 0
+fi
+
+echo "Rolling back $SERVICE:"
+echo "  current → $CURRENT"
+echo "  target  → $TARGET"
+echo ""
+
+START=$(date +%s)
+gcloud run services update-traffic "$SERVICE" \
+  --project="$PROJECT_ID" --region="$REGION" \
+  --to-revisions="${TARGET}=100" --quiet
+
+ELAPSED=$(( $(date +%s) - START ))
+
+NEW=$(gcloud run services describe "$SERVICE" \
+  --region="$REGION" --project="$PROJECT_ID" \
+  --format="value(status.traffic[0].revisionName)")
+
+echo ""
+echo "=== Rollback complete ==="
+echo "  service       = $SERVICE"
+echo "  active now    = $NEW (previous: $CURRENT)"
+echo "  elapsed       = ${ELAPSED}s"
+
+SERVICE_URL=$(gcloud run services describe "$SERVICE" \
+  --region="$REGION" --project="$PROJECT_ID" \
+  --format="value(status.url)")
+echo "  verify health = curl -sSf ${SERVICE_URL}/health || echo 'FAILED'"
+echo "  restore with  = bash $0 ${TARGET_SVC} ${CURRENT#${SERVICE}-}"

--- a/infra/rollback.sh
+++ b/infra/rollback.sh
@@ -54,13 +54,15 @@ if [ -n "$ARG" ]; then
     *) TARGET="${SERVICE}-${ARG}" ;;
   esac
 else
-  # 引数なし: 直前（2番目に新しい）リビジョン
+  # 引数なし: "現行以外で最新" のリビジョン。単純に "2番目に新しい" を選ぶと、
+  # 前回ロールバック後で traffic が既にその revision に乗っているケースで
+  # No-op になってしまうため、現行を除外してから最新を取る。
   TARGET=$(gcloud run revisions list --service="$SERVICE" \
     --region="$REGION" --project="$PROJECT_ID" \
-    --format="value(name)" --sort-by="~creationTimestamp" --limit=2 \
-    | sed -n '2p')
+    --format="value(name)" --sort-by="~creationTimestamp" --limit=10 \
+    | grep -v -x "$CURRENT" | head -n 1)
   if [ -z "$TARGET" ]; then
-    echo "ERROR: no previous revision found for $SERVICE" >&2
+    echo "ERROR: no other revision found to roll back to for $SERVICE" >&2
     exit 1
   fi
 fi
@@ -82,18 +84,42 @@ gcloud run services update-traffic "$SERVICE" \
 
 ELAPSED=$(( $(date +%s) - START ))
 
+# 切替が想定先に適用されたか検証（gcloud が部分的に失敗しても exit 0 することがあるため）。
 NEW=$(gcloud run services describe "$SERVICE" \
   --region="$REGION" --project="$PROJECT_ID" \
   --format="value(status.traffic[0].revisionName)")
+
+if [ "$NEW" != "$TARGET" ]; then
+  echo "ERROR: traffic did not move to expected target" >&2
+  echo "  expected = $TARGET" >&2
+  echo "  observed = $NEW" >&2
+  exit 1
+fi
+
+# 切替先への疎通確認。API は /health、Web は / を探る。失敗しても exit はしない
+# （rollback 目的の時点で元も壊れている可能性があり、情報を出すに留める）。
+SERVICE_URL=$(gcloud run services describe "$SERVICE" \
+  --region="$REGION" --project="$PROJECT_ID" \
+  --format="value(status.url)")
+PROBE_PATH="/health"
+[ "$TARGET_SVC" = "web" ] && PROBE_PATH="/"
+if HEALTH_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "${SERVICE_URL}${PROBE_PATH}"); then
+  HEALTH_STATUS="HTTP ${HEALTH_CODE}"
+else
+  HEALTH_STATUS="probe failed"
+fi
 
 echo ""
 echo "=== Rollback complete ==="
 echo "  service       = $SERVICE"
 echo "  active now    = $NEW (previous: $CURRENT)"
 echo "  elapsed       = ${ELAPSED}s"
-
-SERVICE_URL=$(gcloud run services describe "$SERVICE" \
-  --region="$REGION" --project="$PROJECT_ID" \
-  --format="value(status.url)")
-echo "  verify health = curl -sSf ${SERVICE_URL}/health || echo 'FAILED'"
+echo "  probe         = ${SERVICE_URL}${PROBE_PATH} → ${HEALTH_STATUS}"
 echo "  restore with  = bash $0 ${TARGET_SVC} ${CURRENT#${SERVICE}-}"
+
+if [ "$HEALTH_STATUS" != "HTTP 200" ]; then
+  echo ""
+  echo "⚠️  Health probe did not return 200. Target revision may be unhealthy." >&2
+  echo "   Consider restoring immediately with the command above." >&2
+  exit 2
+fi


### PR DESCRIPTION
## Summary

- `infra/rollback.sh` 新規: Cloud Run ロールバックラッパー
  - `api|web` + 直前 or 指定 revision + `--list` モード
  - `latestReadyRevisionName` ではなく `status.traffic[0].revisionName` で現行判定
  - 切替前後を表示、復元コマンドを提示
- ADR-005 更新: 実地検証結果 + 障害時の台本

Closes #78.

## 本番実地検証（2026-04-15）

| サービス         | 切替元 → 切替先              | 所要時間 | ヘルス |
| ---------------- | ---------------------------- | -------- | ------ |
| calendar-hub-api | 00049-nfd → 00048-tvv → 戻す | 7s, 4s   | `/health` 200 |
| calendar-hub-web | 00024-thk → 00023-r6n → 戻す | 5s, 4s   | `/` 200 |

API/Web 双方ロールバック→復元まで完走、すべて単発コマンドで完結。

## 設計判断

- **`status.traffic[0]` を使用**: 初実装で `latestReadyRevisionName` を使った際、
  rollback 後の復元で `No-op` になるバグが出た。traffic ルーティングと
  デプロイ順序が乖離するのが原因。traffic 側を正とする。
- **wrapper スクリプト化**: 直接 `gcloud` を打つ障害対応は手順ミスしがち。
  `api|web` の 2 サービスに限定した薄いラッパで Typo 事故を防ぐ。

## Test plan

- [x] `bash -n infra/rollback.sh` 構文OK
- [x] API/Web それぞれ rollback → 復元の 4 操作完走
- [x] `/health` / `/` の 200 応答確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)