### PR TITLE
feat(security): Dependabot security-only config (#80)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot 設定（最小構成: 安定性のための脆弱性検知のみ）
+#
+# 方針:
+# - 脆弱性検知 (Dependabot security updates) は repo 設定で有効化済み
+# - npm は version 更新を抑止 (open-pull-requests-limit: 0) し、
+#   security 更新 PR のみ発行。個人利用のためバージョン更新ノイズを回避。
+# - GitHub Actions は使用アクション数が少ないため月次で version 更新も許可。
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    open-pull-requests-limit: 3
+    labels:
+      - 'dependencies'
+      - 'github-actions'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    open-pull-requests-limit: 0
+    labels:
+      - 'dependencies'
+      - 'security'


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml` を追加（最小構成）
- Repo 設定で Vulnerability alerts + Automated security fixes を有効化済み
- 個人利用の安定性優先方針: CVE 対応 PR のみ発行、version 更新ノイズを回避

## 設計方針
| ecosystem | version 更新 | security 更新 | 理由 |
|-----------|------------|-------------|------|
| npm | ❌ (limit: 0) | ✅ | 推移的依存が多く、version PR は手動タイミングで統合したい |
| github-actions | ✅ monthly (limit: 3) | ✅ | 使用アクション数が少なく、ノイズになりにくい |

## 現状確認
push 時に GitHub から 24 件の既存脆弱性検知（9 high / 13 moderate / 2 low）。
マージ後、Dependabot が順次 security PR を生成。

## Test plan
- [x] `.github/dependabot.yml` の YAML syntax 検証（git commit 時 prettier pass）
- [x] Vulnerability alerts API で enabled 確認
- [x] Automated security fixes API で enabled 確認
- [ ] マージ後、Security タブで Dependabot タブが見えること（次セッションで確認）

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency management to monitor npm packages and GitHub Actions for security patches and updates on a monthly schedule, improving project security and stability while strategically managing updates to minimize disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->