### PR TITLE
feat(timetree): session 切れ可視化ログ + ADR-009 (#79 Phase A)

### DIFF
--- a/docs/adr/009-timetree-session-management.md
+++ b/docs/adr/009-timetree-session-management.md
@@ -1,0 +1,81 @@
+# ADR-009: TimeTree session 切れの可視化と運用手順
+
+- Status: Accepted
+- Date: 2026-05-03
+- Issue: #79
+
+## Context
+
+TimeTree は非公式 Web API 利用のため、`_session_id` cookie が約 14 日で期限切れになる。session 切れの兆候は `TimeTreeAdapter` 内では既に 401/403/400 を捕捉して再ログイン経路を持つが、本番運用上以下が未整備だった。
+
+1. **可視化欠落**: 401/403 検出時のログが無く、Cloud Logging から「session 切れ」を抽出できない
+2. **再ログインの実行経路が不明瞭**: `reLoginFn` を渡せる API 設計だが、`apps/api/src/lib/adapter-factory.ts:36` では `new TimeTreeAdapter(session)` と `reLoginFn` 未注入
+3. **構造的制約**: `/connect/timetree` 経由の本番認証は **ユーザーが email/password を都度入力** する設計で、password は永続化しない（`apps/api/src/routes/auth.ts:162-176`）。したがって session 切れ時の **自動再ログインは技術的に不可能**
+
+### 採れない選択肢
+
+- ❌ password を Firestore に encrypted で保存して reLoginFn 経由で再ログイン
+  → 不可逆な認証情報の長期保管はリスク増、既存設計の意図とも反する
+- ❌ password を Secret Manager で集約管理
+  → ユーザーごとに異なる、Secret Manager の用途と合わない
+
+## Decision
+
+### 1. 観測点プロトコル
+
+`TimeTreeAdapter.fetchWithRetry` / `refreshSession` で以下の構造化ログを必ず出力する。
+
+| ログプレフィックス             | レベル | 出力タイミング                      | 含めるフィールド                                                                   |
+| ------------------------------ | ------ | ----------------------------------- | ---------------------------------------------------------------------------------- |
+| `[TT-SESSION-EXPIRED]`         | warn   | `expiresAt` 経過 / 400/401/403 受信 | `reason=expiresAt\|httpStatus`, `url`, `status`(httpStatus 時), `reLoginAvailable` |
+| `[TT-SESSION-RELOGIN-ATTEMPT]` | info   | `reLoginFn` 起動直前                | —                                                                                  |
+| `[TT-SESSION-RELOGIN-OK]`      | info   | `reLoginFn` 成功                    | `expiresAt`                                                                        |
+| `[TT-SESSION-RELOGIN-FAIL]`    | error  | `reLoginFn` 失敗                    | `error` メッセージ                                                                 |
+
+ログは `console.warn/info/error` で stdout/stderr に出し、Cloud Logging に自動収集される（既存の `[RRULE-SKIP]` パターンを踏襲）。
+
+### 2. 本番運用手順（再ログイン）
+
+session 切れが検出された場合のユーザー対応フロー:
+
+1. ユーザーが Web アプリ「連携アカウント設定」画面を開く
+2. TimeTree アカウントを **再連携**（既存の `/connect/timetree` ルートが新規 session を上書き保存）
+3. session 切れ後の同期ジョブは次回スケジューリング時に新 session で復帰
+
+### 3. Secret 配置
+
+| Secret 名           | 用途                          | 補足                                   |
+| ------------------- | ----------------------------- | -------------------------------------- |
+| `timetree-password` | 開発/管理者テストアカウント用 | プロダクション一般ユーザーには使わない |
+| ユーザー password   | **永続化しない**              | `/connect/timetree` で都度入力         |
+
+### 4. reLoginFn の wiring 方針（現状）
+
+`apps/api/src/lib/adapter-factory.ts` では `reLoginFn` を **意図的に渡さない**（永続化された再ログイン情報がないため）。`refreshSession` は呼ばれず、上位レイヤー（sync ジョブ）で 401 由来の例外をハンドリングし、ユーザー再連携を待つ運用とする。
+
+将来、管理者テストアカウント用に `timetree-password` を使った reLoginFn を限定的に注入する場合は、accountId 単位で識別したうえで wiring する。
+
+## Consequences
+
+### 期待される効果
+
+- Cloud Logging で `[TT-SESSION-EXPIRED]` を抽出すれば期限切れ件数を時系列で把握できる
+- ログベースメトリクス + アラートポリシー（次セッション以降で実装）の前提が整う
+- ADR 化により再ログイン UI 経路がコード読まずに把握できる
+
+### トレードオフ
+
+- 自動再ログインは依然不可能（password 永続化しない設計の延長）
+- ユーザーには 14 日ごとの再連携が暗黙的に必要
+
+## Future Work
+
+- ログベースメトリクス（`logging.googleapis.com/user/timetree_session_expired`）作成
+- アラートポリシー: 単一ユーザーで 24h 以内に `[TT-SESSION-EXPIRED]` 連続発生 → 通知
+- Web UI の連携アカウント設定画面で **session 残日数バッジ**表示（`expiresAt` を Firestore に保存して算出）
+- session 切れ通知メール（任意機能）
+
+## 関連
+
+- Issue #79
+- 過去 Issue #24（closed）: TimeTree session 有効期限管理の初期検討

--- a/docs/adr/009-timetree-session-management.md
+++ b/docs/adr/009-timetree-session-management.md
@@ -75,6 +75,14 @@ session 切れが検出された場合のユーザー対応フロー:
 - Web UI の連携アカウント設定画面で **session 残日数バッジ**表示（`expiresAt` を Firestore に保存して算出）
 - session 切れ通知メール（任意機能）
 
+### 既存ロジックの強化候補（本 ADR スコープ外、将来検討）
+
+PR #111 のレビューで silent-failure-hunter が指摘した既存実装の改善候補。本 ADR の観測点追加スコープでは触らないが、別 Issue 化候補として記録する。
+
+- **再ログイン後 fetch のステータスチェック追加**: `fetchWithRetry` の `return fetch(url, ...)`（再試行側）で `res.ok` を検証していない。reLogin 後も 401 等が返る場合、呼び出し側は成功扱いで JSON parse して別エラーになる。`[TT-SESSION-RELOGIN-INEFFECTIVE]` のようなログ + 例外化が望ましい
+- **400/401/403 のエラー分類精緻化**: 現状 3 値を一律 reLogin 試行している。本来 `400` は request malformed（permanent）、`403` は権限不足の可能性（permanent）で、reLogin は `401` 限定が `rules/error-handling.md §3` の transient/permanent 分類に整合する
+- **reLoginFn 不在時の 401 を明示 throw**: 現状は `res` をそのまま返却するため、上位で「session 失効」を識別できない。エラー ID 付きで throw すれば運用時の切り分けが容易になる
+
 ## 関連
 
 - Issue #79

--- a/packages/calendar-sdk/src/__tests__/timetree-adapter.test.ts
+++ b/packages/calendar-sdk/src/__tests__/timetree-adapter.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TimeTreeAdapter, type TimeTreeSession } from '../adapters/timetree.js';
 
 // TimeTree内部APIのレスポンス型・パース検証（外部APIモック不要の単体テスト）
 
@@ -161,5 +162,117 @@ describe('TimeTree login body format', () => {
     expect(parsed.uid).toBe(email);
     expect(parsed.email).toBeUndefined();
     expect(parsed.password).toBe(password);
+  });
+});
+
+describe('TimeTreeAdapter session expiry observability', () => {
+  const validSession: TimeTreeSession = {
+    sessionId: 'sid',
+    csrfToken: 'csrf',
+    expiresAt: Date.now() + 60 * 60 * 1000, // 1時間後
+  };
+  const expiredSession: TimeTreeSession = {
+    sessionId: 'sid',
+    csrfToken: 'csrf',
+    expiresAt: Date.now() - 60 * 60 * 1000, // 1時間前
+  };
+
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockFetchOk(payload: unknown): ReturnType<typeof vi.fn> {
+    return vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    } as Response);
+  }
+
+  function mockFetchSequence(responses: Array<{ status: number; payload?: unknown }>) {
+    const fn = vi.fn();
+    for (const r of responses) {
+      fn.mockResolvedValueOnce({
+        ok: r.status >= 200 && r.status < 300,
+        status: r.status,
+        json: async () => r.payload ?? {},
+      } as Response);
+    }
+    return fn;
+  }
+
+  it('should log [TT-SESSION-EXPIRED] reason=httpStatus when 401 received without reLoginFn', async () => {
+    fetchSpy = mockFetchSequence([{ status: 401 }]);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const adapter = new TimeTreeAdapter(validSession);
+    await expect(adapter.listCalendars()).rejects.toThrow(/TimeTree listCalendars failed: 401/);
+
+    const warned = warnSpy.mock.calls.flat().join(' ');
+    expect(warned).toContain('[TT-SESSION-EXPIRED]');
+    expect(warned).toContain('reason=httpStatus');
+    expect(warned).toContain('status=401');
+    expect(warned).toContain('reLoginAvailable=false');
+  });
+
+  it('should log [TT-SESSION-EXPIRED] reason=expiresAt when session is past expiresAt', async () => {
+    fetchSpy = mockFetchOk({ calendars: [] });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const adapter = new TimeTreeAdapter(expiredSession);
+    await adapter.listCalendars();
+
+    const warned = warnSpy.mock.calls.flat().join(' ');
+    expect(warned).toContain('[TT-SESSION-EXPIRED]');
+    expect(warned).toContain('reason=expiresAt');
+    expect(warned).toContain('reLoginAvailable=false');
+  });
+
+  it('should log RELOGIN-ATTEMPT and RELOGIN-OK when reLoginFn succeeds after 401', async () => {
+    fetchSpy = mockFetchSequence([{ status: 401 }, { status: 200, payload: { calendars: [] } }]);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const reLoginFn = vi.fn().mockResolvedValue({
+      sessionId: 'new-sid',
+      csrfToken: 'new-csrf',
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    });
+
+    const adapter = new TimeTreeAdapter(validSession, reLoginFn);
+    await adapter.listCalendars();
+
+    const warned = warnSpy.mock.calls.flat().join(' ');
+    const informed = infoSpy.mock.calls.flat().join(' ');
+    expect(warned).toContain('[TT-SESSION-EXPIRED]');
+    expect(warned).toContain('reLoginAvailable=true');
+    expect(informed).toContain('[TT-SESSION-RELOGIN-ATTEMPT]');
+    expect(informed).toContain('[TT-SESSION-RELOGIN-OK]');
+    expect(reLoginFn).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should log RELOGIN-FAIL and rethrow when reLoginFn throws', async () => {
+    fetchSpy = mockFetchSequence([{ status: 401 }]);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const reLoginFn = vi.fn().mockRejectedValue(new Error('login server down'));
+
+    const adapter = new TimeTreeAdapter(validSession, reLoginFn);
+    await expect(adapter.listCalendars()).rejects.toThrow(/login server down/);
+
+    const errored = errorSpy.mock.calls.flat().join(' ');
+    expect(errored).toContain('[TT-SESSION-RELOGIN-FAIL]');
+    expect(errored).toContain('login server down');
   });
 });

--- a/packages/calendar-sdk/src/__tests__/timetree-adapter.test.ts
+++ b/packages/calendar-sdk/src/__tests__/timetree-adapter.test.ts
@@ -212,19 +212,24 @@ describe('TimeTreeAdapter session expiry observability', () => {
     return fn;
   }
 
-  it('should log [TT-SESSION-EXPIRED] reason=httpStatus when 401 received without reLoginFn', async () => {
-    fetchSpy = mockFetchSequence([{ status: 401 }]);
-    vi.stubGlobal('fetch', fetchSpy);
+  it.each([400, 401, 403])(
+    'should log [TT-SESSION-EXPIRED] reason=httpStatus when %i received without reLoginFn',
+    async (status) => {
+      fetchSpy = mockFetchSequence([{ status }]);
+      vi.stubGlobal('fetch', fetchSpy);
 
-    const adapter = new TimeTreeAdapter(validSession);
-    await expect(adapter.listCalendars()).rejects.toThrow(/TimeTree listCalendars failed: 401/);
+      const adapter = new TimeTreeAdapter(validSession);
+      await expect(adapter.listCalendars()).rejects.toThrow(
+        new RegExp(`TimeTree listCalendars failed: ${status}`),
+      );
 
-    const warned = warnSpy.mock.calls.flat().join(' ');
-    expect(warned).toContain('[TT-SESSION-EXPIRED]');
-    expect(warned).toContain('reason=httpStatus');
-    expect(warned).toContain('status=401');
-    expect(warned).toContain('reLoginAvailable=false');
-  });
+      const warned = warnSpy.mock.calls.flat().join(' ');
+      expect(warned).toContain('[TT-SESSION-EXPIRED]');
+      expect(warned).toContain('reason=httpStatus');
+      expect(warned).toContain(`status=${status}`);
+      expect(warned).toContain('reLoginAvailable=false');
+    },
+  );
 
   it('should log [TT-SESSION-EXPIRED] reason=expiresAt when session is past expiresAt', async () => {
     fetchSpy = mockFetchOk({ calendars: [] });
@@ -260,6 +265,30 @@ describe('TimeTreeAdapter session expiry observability', () => {
     expect(informed).toContain('[TT-SESSION-RELOGIN-OK]');
     expect(reLoginFn).toHaveBeenCalledTimes(1);
     expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should auto-refresh and retry when expiresAt has passed and reLoginFn is provided', async () => {
+    fetchSpy = mockFetchOk({ calendars: [] });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const reLoginFn = vi.fn().mockResolvedValue({
+      sessionId: 'new-sid',
+      csrfToken: 'new-csrf',
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    });
+
+    const adapter = new TimeTreeAdapter(expiredSession, reLoginFn);
+    await adapter.listCalendars();
+
+    const warned = warnSpy.mock.calls.flat().join(' ');
+    const informed = infoSpy.mock.calls.flat().join(' ');
+    expect(warned).toContain('[TT-SESSION-EXPIRED]');
+    expect(warned).toContain('reason=expiresAt');
+    expect(warned).toContain('reLoginAvailable=true');
+    expect(informed).toContain('[TT-SESSION-RELOGIN-ATTEMPT]');
+    expect(informed).toContain('[TT-SESSION-RELOGIN-OK]');
+    expect(reLoginFn).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should log RELOGIN-FAIL and rethrow when reLoginFn throws', async () => {

--- a/packages/calendar-sdk/src/adapters/timetree.ts
+++ b/packages/calendar-sdk/src/adapters/timetree.ts
@@ -86,16 +86,26 @@ export class TimeTreeAdapter implements CalendarAdapter {
    */
   private async fetchWithRetry(url: string, init?: RequestInit): Promise<Response> {
     // session期限切れチェック
-    if (this.reLoginFn && Date.now() > this.expiresAt) {
-      await this.refreshSession();
+    if (Date.now() > this.expiresAt) {
+      console.warn(
+        `[TT-SESSION-EXPIRED] reason=expiresAt url=${url} expiresAt=${new Date(this.expiresAt).toISOString()} reLoginAvailable=${Boolean(this.reLoginFn)}`,
+      );
+      if (this.reLoginFn) {
+        await this.refreshSession();
+      }
     }
 
     const res = await fetch(url, { ...init, headers: { ...this.headers, ...init?.headers } });
 
     // 401/403で再ログイン試行（1回のみ）
-    if ((res.status === 400 || res.status === 401 || res.status === 403) && this.reLoginFn) {
-      await this.refreshSession();
-      return fetch(url, { ...init, headers: { ...this.headers, ...init?.headers } });
+    if (res.status === 400 || res.status === 401 || res.status === 403) {
+      console.warn(
+        `[TT-SESSION-EXPIRED] reason=httpStatus url=${url} status=${res.status} reLoginAvailable=${Boolean(this.reLoginFn)}`,
+      );
+      if (this.reLoginFn) {
+        await this.refreshSession();
+        return fetch(url, { ...init, headers: { ...this.headers, ...init?.headers } });
+      }
     }
 
     return res;
@@ -104,11 +114,19 @@ export class TimeTreeAdapter implements CalendarAdapter {
   private async refreshSession(): Promise<void> {
     if (!this.reLoginFn)
       throw new Error('TimeTree session expired and no re-login function provided');
-    const newSession = await this.reLoginFn();
-    this.sessionId = newSession.sessionId;
-    this.csrfToken = newSession.csrfToken;
-    this.expiresAt = newSession.expiresAt ?? Date.now() + 14 * 24 * 60 * 60 * 1000;
-    this.headers = this.buildHeaders(newSession);
+    console.info('[TT-SESSION-RELOGIN-ATTEMPT]');
+    try {
+      const newSession = await this.reLoginFn();
+      this.sessionId = newSession.sessionId;
+      this.csrfToken = newSession.csrfToken;
+      this.expiresAt = newSession.expiresAt ?? Date.now() + 14 * 24 * 60 * 60 * 1000;
+      this.headers = this.buildHeaders(newSession);
+      console.info(`[TT-SESSION-RELOGIN-OK] expiresAt=${new Date(this.expiresAt).toISOString()}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[TT-SESSION-RELOGIN-FAIL] error=${msg}`);
+      throw err;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Issue #79 Phase A 対応。

- **可視化**: TimeTreeAdapter で session 切れに関する 3 種類の構造化ログを追加（`[TT-SESSION-EXPIRED]` / `[TT-SESSION-RELOGIN-ATTEMPT/OK/FAIL]`）
- **ADR-009**: Secret 配置、再ログイン UI 経路（既存 `/connect/timetree` 再使用）、自動再ログインが構造的に不可能な理由（password を永続化しない設計）を明文化
- **テスト**: 4 件追加（期限切れ + reLoginFn 有/無 + reLogin 成功/失敗）

## Closes 条件は満たしていない（Phase A 範囲）

#79 完了条件:
- [x] 期限切れ検知ログ
- [ ] alert policy（**Phase B 別 PR**: ログベースメトリクス + アラート、本番 GCP 適用必要）
- [x] 再ログイン運用手順の ADR 化

`Refs #79`（auto-close せず）。alert policy は Phase B として別セッションでユーザー認可下で実装予定。

## 実装スコープ外（ADR で明文化）

- 自動再ログイン: ユーザーごとに password を持たない設計のため不可能（既存 `apps/api/src/routes/auth.ts` の方針を継承）
- `apps/api/src/lib/adapter-factory.ts` での `reLoginFn` 注入: 渡せる情報が無いため意図的に未注入

## Test plan

- [x] `pnpm test` → 280 → 284 PASS（+4 新規）
- [x] `pnpm turbo type-check` → 8/8 success
- [x] `pnpm lint` → 8/8 success
- [x] CI quality job が PR で SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proactive TimeTree session expiration detection with standardized logging for monitoring
  * Users must manually re-link TimeTree accounts when sessions expire to restore synchronization

* **Documentation**
  * Added architecture decision record documenting TimeTree session management strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->