### PR TITLE
fix(deploy): Cloud Run trafficSplit を新 revision に明示昇格 (Closes #119)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,12 +114,32 @@ jobs:
             --max-instances=3 \
             --set-env-vars="GCP_PROJECT_ID=${GCP_PROJECT_ID},FRONTEND_URL=${WEB_URL}" \
             --set-secrets="GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,TOKEN_ENCRYPTION_KEY=token-encryption-key:latest,SYNC_SCHEDULER_TOKEN=sync-scheduler-token:latest"
+          # Cloud Run のトラフィックが過去のピン留め (--to-revisions=X=100 等) で
+          # 特定 revision に固定されていると `gcloud run deploy` でも自動昇格されない。
+          # 明示的に LATEST に切り替えて冪等化する (Issue #119)
+          gcloud run services update-traffic calendar-hub-api \
+            --project="$GCP_PROJECT_ID" \
+            --region="$GCP_REGION" \
+            --to-latest
           URL=$(gcloud run services describe calendar-hub-api \
             --project="$GCP_PROJECT_ID" \
             --region="$GCP_REGION" \
             --format="value(status.url)")
           if [ -z "$URL" ]; then
             echo "::error::API URL empty after deploy; aborting"
+            exit 1
+          fi
+          # トラフィックが latest revision に 100% 昇格されたことを検証 (Issue #119)
+          LATEST_PERCENT=$(gcloud run services describe calendar-hub-api \
+            --project="$GCP_PROJECT_ID" \
+            --region="$GCP_REGION" \
+            --format="value(status.traffic[?latestRevision=true].percent)")
+          if [ "$LATEST_PERCENT" != "100" ]; then
+            echo "::error::traffic not promoted to latest revision (got: ${LATEST_PERCENT:-none}); aborting"
+            gcloud run services describe calendar-hub-api \
+              --project="$GCP_PROJECT_ID" \
+              --region="$GCP_REGION" \
+              --format="value(status.traffic)"
             exit 1
           fi
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
@@ -180,3 +200,22 @@ jobs:
             --min-instances=0 \
             --max-instances=3 \
             --set-env-vars="NEXT_PUBLIC_API_URL=${API_URL},NEXT_PUBLIC_FIREBASE_PROJECT_ID=${GCP_PROJECT_ID}"
+          # Cloud Run のトラフィックが過去のピン留めで固定されていると
+          # `gcloud run deploy` でも自動昇格されない。明示的に LATEST に切り替え (Issue #119)
+          gcloud run services update-traffic calendar-hub-web \
+            --project="$GCP_PROJECT_ID" \
+            --region="$GCP_REGION" \
+            --to-latest
+          # トラフィックが latest revision に 100% 昇格されたことを検証 (Issue #119)
+          LATEST_PERCENT=$(gcloud run services describe calendar-hub-web \
+            --project="$GCP_PROJECT_ID" \
+            --region="$GCP_REGION" \
+            --format="value(status.traffic[?latestRevision=true].percent)")
+          if [ "$LATEST_PERCENT" != "100" ]; then
+            echo "::error::traffic not promoted to latest revision (got: ${LATEST_PERCENT:-none}); aborting"
+            gcloud run services describe calendar-hub-web \
+              --project="$GCP_PROJECT_ID" \
+              --region="$GCP_REGION" \
+              --format="value(status.traffic)"
+            exit 1
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,32 +114,15 @@ jobs:
             --max-instances=3 \
             --set-env-vars="GCP_PROJECT_ID=${GCP_PROJECT_ID},FRONTEND_URL=${WEB_URL}" \
             --set-secrets="GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,TOKEN_ENCRYPTION_KEY=token-encryption-key:latest,SYNC_SCHEDULER_TOKEN=sync-scheduler-token:latest"
-          # Cloud Run のトラフィックが過去のピン留め (--to-revisions=X=100 等) で
-          # 特定 revision に固定されていると `gcloud run deploy` でも自動昇格されない。
-          # 明示的に LATEST に切り替えて冪等化する (Issue #119)
-          gcloud run services update-traffic calendar-hub-api \
-            --project="$GCP_PROJECT_ID" \
-            --region="$GCP_REGION" \
-            --to-latest
+          # Cloud Run の traffic ピン留め回避 (Issue #119) — 詳細は infra/promote-traffic.sh
+          PROJECT_ID="$GCP_PROJECT_ID" REGION="$GCP_REGION" \
+            bash infra/promote-traffic.sh calendar-hub-api
           URL=$(gcloud run services describe calendar-hub-api \
             --project="$GCP_PROJECT_ID" \
             --region="$GCP_REGION" \
             --format="value(status.url)")
           if [ -z "$URL" ]; then
             echo "::error::API URL empty after deploy; aborting"
-            exit 1
-          fi
-          # トラフィックが latest revision に 100% 昇格されたことを検証 (Issue #119)
-          LATEST_PERCENT=$(gcloud run services describe calendar-hub-api \
-            --project="$GCP_PROJECT_ID" \
-            --region="$GCP_REGION" \
-            --format="value(status.traffic[?latestRevision=true].percent)")
-          if [ "$LATEST_PERCENT" != "100" ]; then
-            echo "::error::traffic not promoted to latest revision (got: ${LATEST_PERCENT:-none}); aborting"
-            gcloud run services describe calendar-hub-api \
-              --project="$GCP_PROJECT_ID" \
-              --region="$GCP_REGION" \
-              --format="value(status.traffic)"
             exit 1
           fi
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
@@ -200,22 +183,6 @@ jobs:
             --min-instances=0 \
             --max-instances=3 \
             --set-env-vars="NEXT_PUBLIC_API_URL=${API_URL},NEXT_PUBLIC_FIREBASE_PROJECT_ID=${GCP_PROJECT_ID}"
-          # Cloud Run のトラフィックが過去のピン留めで固定されていると
-          # `gcloud run deploy` でも自動昇格されない。明示的に LATEST に切り替え (Issue #119)
-          gcloud run services update-traffic calendar-hub-web \
-            --project="$GCP_PROJECT_ID" \
-            --region="$GCP_REGION" \
-            --to-latest
-          # トラフィックが latest revision に 100% 昇格されたことを検証 (Issue #119)
-          LATEST_PERCENT=$(gcloud run services describe calendar-hub-web \
-            --project="$GCP_PROJECT_ID" \
-            --region="$GCP_REGION" \
-            --format="value(status.traffic[?latestRevision=true].percent)")
-          if [ "$LATEST_PERCENT" != "100" ]; then
-            echo "::error::traffic not promoted to latest revision (got: ${LATEST_PERCENT:-none}); aborting"
-            gcloud run services describe calendar-hub-web \
-              --project="$GCP_PROJECT_ID" \
-              --region="$GCP_REGION" \
-              --format="value(status.traffic)"
-            exit 1
-          fi
+          # Cloud Run の traffic ピン留め回避 (Issue #119) — 詳細は infra/promote-traffic.sh
+          PROJECT_ID="$GCP_PROJECT_ID" REGION="$GCP_REGION" \
+            bash infra/promote-traffic.sh calendar-hub-web

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -46,25 +46,9 @@ gcloud run deploy "$SERVICE_NAME" \
   --set-env-vars="GCP_PROJECT_ID=$PROJECT_ID,FRONTEND_URL=$WEB_URL" \
   --set-secrets="GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,TOKEN_ENCRYPTION_KEY=token-encryption-key:latest,SYNC_SCHEDULER_TOKEN=sync-scheduler-token:latest"
 
-# Cloud Run のトラフィックが過去のピン留めで固定されていると
-# `gcloud run deploy` でも自動昇格されない。明示的に LATEST に切り替え (Issue #119)
-echo "Promoting traffic to latest revision..."
-gcloud run services update-traffic "$SERVICE_NAME" \
-  --project="$PROJECT_ID" \
-  --region="$REGION" \
-  --to-latest
-
-# トラフィックが latest revision に 100% 昇格されたことを検証 (Issue #119)
-LATEST_PERCENT=$(gcloud run services describe "$SERVICE_NAME" \
-  --project="$PROJECT_ID" --region="$REGION" \
-  --format="value(status.traffic[?latestRevision=true].percent)")
-if [ "$LATEST_PERCENT" != "100" ]; then
-  echo "ERROR: traffic not promoted to latest revision (got: ${LATEST_PERCENT:-none})" >&2
-  gcloud run services describe "$SERVICE_NAME" \
-    --project="$PROJECT_ID" --region="$REGION" \
-    --format="value(status.traffic)" >&2
-  exit 1
-fi
+# Cloud Run の traffic ピン留め回避 (Issue #119) — 詳細は infra/promote-traffic.sh
+PROJECT_ID="$PROJECT_ID" REGION="$REGION" \
+  bash "$(dirname "$0")/promote-traffic.sh" "$SERVICE_NAME"
 
 echo "=== API Deploy Complete ==="
 gcloud run services describe "$SERVICE_NAME" \

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -46,6 +46,26 @@ gcloud run deploy "$SERVICE_NAME" \
   --set-env-vars="GCP_PROJECT_ID=$PROJECT_ID,FRONTEND_URL=$WEB_URL" \
   --set-secrets="GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,TOKEN_ENCRYPTION_KEY=token-encryption-key:latest,SYNC_SCHEDULER_TOKEN=sync-scheduler-token:latest"
 
+# Cloud Run のトラフィックが過去のピン留めで固定されていると
+# `gcloud run deploy` でも自動昇格されない。明示的に LATEST に切り替え (Issue #119)
+echo "Promoting traffic to latest revision..."
+gcloud run services update-traffic "$SERVICE_NAME" \
+  --project="$PROJECT_ID" \
+  --region="$REGION" \
+  --to-latest
+
+# トラフィックが latest revision に 100% 昇格されたことを検証 (Issue #119)
+LATEST_PERCENT=$(gcloud run services describe "$SERVICE_NAME" \
+  --project="$PROJECT_ID" --region="$REGION" \
+  --format="value(status.traffic[?latestRevision=true].percent)")
+if [ "$LATEST_PERCENT" != "100" ]; then
+  echo "ERROR: traffic not promoted to latest revision (got: ${LATEST_PERCENT:-none})" >&2
+  gcloud run services describe "$SERVICE_NAME" \
+    --project="$PROJECT_ID" --region="$REGION" \
+    --format="value(status.traffic)" >&2
+  exit 1
+fi
+
 echo "=== API Deploy Complete ==="
 gcloud run services describe "$SERVICE_NAME" \
   --project="$PROJECT_ID" --region="$REGION" \

--- a/infra/deploy-web.sh
+++ b/infra/deploy-web.sh
@@ -38,6 +38,26 @@ gcloud run deploy "$SERVICE_NAME" \
   --max-instances=3 \
   --set-env-vars="NEXT_PUBLIC_API_URL=$API_URL,NEXT_PUBLIC_FIREBASE_PROJECT_ID=$PROJECT_ID"
 
+# Cloud Run のトラフィックが過去のピン留めで固定されていると
+# `gcloud run deploy` でも自動昇格されない。明示的に LATEST に切り替え (Issue #119)
+echo "Promoting traffic to latest revision..."
+gcloud run services update-traffic "$SERVICE_NAME" \
+  --project="$PROJECT_ID" \
+  --region="$REGION" \
+  --to-latest
+
+# トラフィックが latest revision に 100% 昇格されたことを検証 (Issue #119)
+LATEST_PERCENT=$(gcloud run services describe "$SERVICE_NAME" \
+  --project="$PROJECT_ID" --region="$REGION" \
+  --format="value(status.traffic[?latestRevision=true].percent)")
+if [ "$LATEST_PERCENT" != "100" ]; then
+  echo "ERROR: traffic not promoted to latest revision (got: ${LATEST_PERCENT:-none})" >&2
+  gcloud run services describe "$SERVICE_NAME" \
+    --project="$PROJECT_ID" --region="$REGION" \
+    --format="value(status.traffic)" >&2
+  exit 1
+fi
+
 echo "=== Web Deploy Complete ==="
 gcloud run services describe "$SERVICE_NAME" \
   --project="$PROJECT_ID" --region="$REGION" \

--- a/infra/deploy-web.sh
+++ b/infra/deploy-web.sh
@@ -38,25 +38,9 @@ gcloud run deploy "$SERVICE_NAME" \
   --max-instances=3 \
   --set-env-vars="NEXT_PUBLIC_API_URL=$API_URL,NEXT_PUBLIC_FIREBASE_PROJECT_ID=$PROJECT_ID"
 
-# Cloud Run のトラフィックが過去のピン留めで固定されていると
-# `gcloud run deploy` でも自動昇格されない。明示的に LATEST に切り替え (Issue #119)
-echo "Promoting traffic to latest revision..."
-gcloud run services update-traffic "$SERVICE_NAME" \
-  --project="$PROJECT_ID" \
-  --region="$REGION" \
-  --to-latest
-
-# トラフィックが latest revision に 100% 昇格されたことを検証 (Issue #119)
-LATEST_PERCENT=$(gcloud run services describe "$SERVICE_NAME" \
-  --project="$PROJECT_ID" --region="$REGION" \
-  --format="value(status.traffic[?latestRevision=true].percent)")
-if [ "$LATEST_PERCENT" != "100" ]; then
-  echo "ERROR: traffic not promoted to latest revision (got: ${LATEST_PERCENT:-none})" >&2
-  gcloud run services describe "$SERVICE_NAME" \
-    --project="$PROJECT_ID" --region="$REGION" \
-    --format="value(status.traffic)" >&2
-  exit 1
-fi
+# Cloud Run の traffic ピン留め回避 (Issue #119) — 詳細は infra/promote-traffic.sh
+PROJECT_ID="$PROJECT_ID" REGION="$REGION" \
+  bash "$(dirname "$0")/promote-traffic.sh" "$SERVICE_NAME"
 
 echo "=== Web Deploy Complete ==="
 gcloud run services describe "$SERVICE_NAME" \

--- a/infra/promote-traffic.sh
+++ b/infra/promote-traffic.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Cloud Run のトラフィックを LATEST revision に明示的に昇格し、結果を検証する。
+#
+# 背景 (Issue #119):
+#   `gcloud run services update-traffic --to-revisions=<rev>=100` 等で
+#   特定 revision にトラフィックがピン留めされていると、その後の
+#   `gcloud run deploy` は新 revision を作成しても自動的に昇格しない。
+#   このスクリプトを deploy 直後に呼び出すことで、過去のピン留め状態に
+#   依らず冪等にトラフィックを LATEST に切り替える。
+#
+# Usage:
+#   PROJECT_ID=... REGION=... bash infra/promote-traffic.sh <service-name>
+#
+# Exit codes:
+#   0  - LATEST revision に 100% 昇格完了
+#   1  - update-traffic 失敗 / describe 失敗 / 100% 未昇格
+
+set -euo pipefail
+
+SERVICE_NAME="${1:?service name required as first arg}"
+PROJECT_ID="${PROJECT_ID:?PROJECT_ID env var required}"
+REGION="${REGION:?REGION env var required}"
+
+echo "Promoting traffic to latest revision for ${SERVICE_NAME}..."
+gcloud run services update-traffic "$SERVICE_NAME" \
+  --project="$PROJECT_ID" \
+  --region="$REGION" \
+  --to-latest
+
+# update-traffic は eventual consistency 上 ok 返却後も traffic 反映に遅延がある
+# 可能性があるため、describe で実状態を検証する。
+# describe 失敗 (権限/NW/サービス未存在) と未昇格を区別するため exit code を分離。
+set +e
+TRAFFIC_JSON=$(gcloud run services describe "$SERVICE_NAME" \
+  --project="$PROJECT_ID" \
+  --region="$REGION" \
+  --format="json(status.traffic)" 2>/tmp/promote-traffic-err.log)
+DESCRIBE_EXIT=$?
+set -e
+
+if [ "$DESCRIBE_EXIT" -ne 0 ]; then
+  echo "ERROR: failed to describe ${SERVICE_NAME} after update-traffic (exit=${DESCRIBE_EXIT})" >&2
+  cat /tmp/promote-traffic-err.log >&2 || true
+  exit 1
+fi
+
+# latestRevision=true の entry の percent 合計を取得 (canary/tag 構成の複数 entry に対応)
+LATEST_PERCENT=$(echo "$TRAFFIC_JSON" \
+  | jq '[.status.traffic[]? | select(.latestRevision==true) | .percent // 0] | add // 0')
+
+if [ "$LATEST_PERCENT" != "100" ]; then
+  echo "ERROR: traffic not promoted to latest revision for ${SERVICE_NAME} (got: ${LATEST_PERCENT})" >&2
+  echo "--- Current traffic split ---" >&2
+  gcloud run services describe "$SERVICE_NAME" \
+    --project="$PROJECT_ID" \
+    --region="$REGION" \
+    --format="yaml(status.traffic)" >&2
+  exit 1
+fi
+
+echo "OK: ${SERVICE_NAME} traffic promoted to latest revision (100%)"


### PR DESCRIPTION
## Summary

- PR #109 マージ時に発覚した、`gcloud run deploy` 後に新 revision にトラフィックが昇格されない事象 (Issue #119, P1, bug) を修正
- `gcloud run deploy` 直後に `gcloud run services update-traffic --to-latest` を追加して**冪等化**
- 検証ロジックを **jq ベースに変更** (初版の JMESPath 風 filter は gcloud 未サポートで silent failure)
- 4 箇所重複を `infra/promote-traffic.sh` に **DRY 化**

## 原因

過去に `gcloud run services update-traffic --to-revisions=X=100` 等で
トラフィックが特定 revision にピン留めされていると、その後の
`gcloud run deploy` (`--no-traffic` 未指定でも) は新 revision に自動昇格しない。

PR #109 で実観測:
- 新 revision `00062-s85` Ready=True で作成
- traffic は旧 revision `00050-hhh` に 100% のまま固定
- 緊急対応として `gcloud run services update-traffic --to-latest` を手動実行で復旧

## 変更内容

| ファイル | 変更 |
|---|---|
| `infra/promote-traffic.sh` (新規) | `update-traffic --to-latest` + jq で latest percent 合計検証 + describe 失敗の権限/NW 区別 + yaml デバッグ出力 |
| `.github/workflows/deploy.yml` (deploy-api / deploy-web 両方) | helper 呼び出し 1 行 |
| `infra/deploy-api.sh` / `infra/deploy-web.sh` | helper 呼び出し 1 行 |

## レビュー反映 (PR 内 6 エージェント並列)

| 指摘 | 重大度 | 対応 |
|---|---|---|
| C1 (code-reviewer): `value(status.traffic[?latestRevision=true].percent)` の JMESPath 風 filter は gcloud 未サポート、常に空文字を返す → 検証ロジック必ず失敗 | Critical | jq に変更、実機検証で旧構文が空 / 新ロジックが `100` を返すことを確認 |
| C1 (silent-failure): describe 失敗 (権限/NW) と未昇格を区別できない | Critical | `set +e/-e` で exit code 分離、専用 err log |
| I1 (silent-failure): canary/tag 構成の複数 latest entry を `value()` projection が誤判定 | Important | jq の `add // 0` で合計化 |
| I2 (silent-failure): デバッグ出力が `value()` で構造潰れ | Important | `yaml(status.traffic)` で revision/percent/tag 保持 |
| I1 (code-reviewer) / S1 (silent-failure): 4 箇所 DRY 違反 | Important | `infra/promote-traffic.sh` に抽出 |

comment-analyzer は 1 件 acceptable / 大半 good。type-design-analyzer は型変更なしのためスキップ。

## Test plan (実機検証完了)

- [x] `bash -n infra/{deploy-api,deploy-web,promote-traffic}.sh` 構文 OK
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` deploy.yml YAML OK
- [x] `gcloud run services describe calendar-hub-api --format=json(status.traffic)` + jq ロジックで `LATEST_PERCENT=100` を取得確認 (api 側既に latest=true で 100%)
- [x] 旧バグ構文 `value(status.traffic[?latestRevision=true].percent)` が実機 calendar-hub-prod で空文字 (length=0) を返すことを再現確認
- [ ] マージ後の Deploy ジョブで `promote-traffic.sh` が実行され、新 revision に 100% 昇格することを確認

## 重要な副次発見

実機検証中に web 側で Issue #119 の症状が**現在進行中**であることを発見:

```
$ gcloud run services describe calendar-hub-web --format=json
{
  "status": {
    "latestCreatedRevisionName": "calendar-hub-web-00048-wdv",
    "latestReadyRevisionName":   "calendar-hub-web-00024-thk",
    "traffic": [
      { "percent": 100, "revisionName": "calendar-hub-web-00024-thk" }
    ]
  }
}
```

- `00046, 00047, 00048` が 0% traffic で作成 → scale-to-zero で `Retired` 状態
- traffic は古い `00024-thk` (2026-05-17 以前) に固定

本 PR マージ後の次回 deploy で `promote-traffic.sh` が自動的に `--to-latest` で解消する設計のため**手動介入は不要**。
(traffic 切替の手動実行は decision-maker 領分のため AI executor では実行しない)

## 参考

- Issue #119
- PR #109 (本事象が初発覚した PR)
- handoff/LATEST.md §139「TimeTree 日曜→月曜ずれバグ修正と CI/CD trafficSplit 昇格漏れ事故」
- [gcloud run services update-traffic --to-latest 公式](https://cloud.google.com/sdk/gcloud/reference/run/services/update-traffic#--to-latest)
- [gcloud topic projections](https://cloud.google.com/sdk/gcloud/reference/topic/projections) — `[?key=value]` 構文は未定義

🤖 Generated with [Claude Code](https://claude.com/claude-code)