### PR TITLE
docs(adr-011): TimeTree 2日間終日を判別不能の既知制限として確定 (Closes #118)

### DIFF
--- a/docs/adr/011-timetree-allday-end-normalization.md
+++ b/docs/adr/011-timetree-allday-end-normalization.md
@@ -51,13 +51,24 @@ export function normalizeAllDayEnd(startMs: number, endMs: number): number {
 2. `TimeTreeAdapter.listEvents` 内の **通常イベント分岐の時間範囲フィルタ**（raw end_at で判定すると終端日に取得した複数日終日が欠落するため、正規化後 end で判定）
 3. `TimeTreeAdapter.listEvents` 内の RRULE 展開時（`masterEnd` を正規化してから `expandRecurringEvent` に渡す。durationMs が `N*24h` となり、各インスタンスの end も自動的に exclusive 表現）
 
-### 既知の制限: 2日間終日は本修正の範囲外
+### 既知の制限: 2日間終日は判別不能 (確定)
 
 2日間終日 (raw diff=24h) は **単日終日 (raw diff=24h) と raw 値が同一**のため、`normalizeAllDayEnd` では判別不能。結果として 2日間終日は Google で 1日不足（最終日のみ表示）となる挙動が継続する。
 
-- 別 Issue で実機観測タスクとして起票する想定。観測項目: `start_timezone` / `end_timezone` / その他追加フィールドで判別可能か
-- ユーザー報告ケース（1〜3日終日）は N=3 のため本 PR で解消される
-- 暫定: 「TimeTree で 2日間終日を作る場合は、Google 側で末日のみ手動延長」をワークアラウンドとして案内する選択肢あり
+**Issue #118 (2026-05-18) で実機観測検討の結論**:
+
+- TimeTree 公式 API は 2023-12-22 に**完全シャットダウン済み** (developers.timetreeapp.com 廃止)、ドキュメント確認手段なし
+- リバースエンジニアリングの本家 [`eoleedi/TimeTree-Exporter`](https://github.com/eoleedi/TimeTree-Exporter) の `formatter.py:get_datetime` 実装も **all_day=true なら end_at を常に +1 日**しており、単日と多日を区別していない (Calendar Hub と逆方向の誤り = 単日終日を 2 日表示にする側に倒している)。本家が「区別不能」を前提に設計している事実は、internal API の raw レスポンスに判別フィールドが**存在しない**ことの強力な傍証
+- TimeTree-Exporter の `TimeTreeEvent` には Calendar Hub 型定義に欠落しているフィールド (`uuid` / `event_type` / `parent_id` / `label_id` / `alerts` / `url`) が含まれるが、本家実装でもこれらは all_day 判別に使われておらず、観測コストに見合うリターンが薄い
+- ユーザー報告ベースの実害ケースは **3 日以上** (PR #117 で解消済み) のみ。2 日間ケースは理論的に発生し得るが報告未確認
+
+**判断**: 実機観測タスクは**打ち切り**、2 日間終日は既知の制限として確定する。
+
+### ワークアラウンド (2 日間終日が必要なユーザー向け)
+
+- **推奨**: TimeTree 側で 2 日間ではなく 1 日 + 1 日の 2 件、または 3 日以上として作成する
+- **代替**: Google カレンダー側で同期後に末日を手動延長する
+- 反対方向の自動補正 (TimeTree-Exporter 方式) は単日終日が 2 日表示になる regression を生むため採用しない
 
 ### 副作用最小化の根拠
 
@@ -110,7 +121,7 @@ export function normalizeAllDayEnd(startMs: number, endMs: number): number {
 
 ## スコープ外
 
-- **2日間終日の判別**: raw 値が単日と同一のため、追加観測なしには対応不可。別 Issue で起票
+- **2日間終日の判別**: Issue #118 (2026-05-18) で実機観測検討した結果、リバースエンジニアリングの本家も区別していないため判別不能と確定 → §既知の制限 参照
 - **TimeTree への書込み (Google → TimeTree 逆同期)**: 現状の sync は単方向のため未対応。将来追加時に逆正規化が必要
 - **他タイムゾーン対応**: 現状は JST 固定。`ONE_DAY_MS = 24h` 固定は DST なしの JST に依存
 - **ユーザーが TimeTree 側で「終日」を解除した場合の整合**: 既存挙動を踏襲


### PR DESCRIPTION
## Summary

- Issue #118 (TimeTree 2日間終日が Google で 1日不足する P2 bug) の対応方針を「**判別不能の既知制限として確定 + ワークアラウンドのドキュメント化**」で決着
- 実機観測タスク (dev 環境で raw event 全フィールド観測) は ROI 不足のため**打ち切り**
- ADR-011 を更新し、根拠・ワークアラウンドを明文化

## 実機観測を打ち切る根拠

| 観点 | 状況 |
|---|---|
| TimeTree 公式 API ドキュメント | 2023-12-22 に**完全シャットダウン済み**、確認手段なし |
| リバースエンジニアリング本家の対応 | [`eoleedi/TimeTree-Exporter`](https://github.com/eoleedi/TimeTree-Exporter) の `formatter.py:get_datetime` は **all_day=true なら end_at を常に +1 日**しており、単日と多日を区別していない (Calendar Hub と逆方向の誤り = 単日終日が 2 日表示になる) |
| Calendar Hub 型定義の欠落フィールド | `uuid` / `event_type` / `parent_id` / `label_id` / `alerts` / `url` 等が欠落しているが、本家でもこれらは all_day 判別に使われておらず観測価値が薄い |
| 実害確証 | ユーザー報告は **3 日以上** (PR #117 で解消済み) のみ。2 日間ケースは理論的に発生し得るが報告未確認 |

**結論**: 「reverse-engineering の本家も区別不能を前提に設計している」事実は、internal API の raw レスポンスに判別フィールドが**存在しない**ことの強力な傍証。実機観測にコストをかけても判別フィールド発見の確率は低く、見つかったとしても TimeTree-Exporter の数百ユーザー規模で発見されていない点から見ても発見可能性は薄い。

## ADR-011 更新内容 (1 ファイル / +16 / -5 行)

- §既知の制限を「2日間終日は判別不能 (**確定**)」に改題、上記根拠を明記
- §**ワークアラウンド**を新設:
  - 推奨: TimeTree 側で 2 日間ではなく 1+1 件、または 3 日以上として作成
  - 代替: Google 側で同期後に末日を手動延長
  - TimeTree-Exporter 方式 (常に +1 日) を採用しない理由 (単日終日が 2 日表示になる regression) を明記
- §スコープ外を「判別不能と確定」に更新

## Test plan

- [x] 既存実装に変更なし、build/test 影響なし
- [x] ADR ファイルのみの変更 (markdown lint は prettier hook 通過)
- [ ] マージ後 Issue #118 が auto-close されることを確認

## 参考

- Issue #118
- ADR-011 (本 PR 更新対象)
- PR #117 (3 日以上のケースを解消)
- [eoleedi/TimeTree-Exporter](https://github.com/eoleedi/TimeTree-Exporter) — リバースエンジニアリングの本家
- [TimeTree API 終了告知 (2023-12-14)](https://timetreeapp.com/intl/en/newsroom/2023-12-14/connect-app-api-202312)

🤖 Generated with [Claude Code](https://claude.com/claude-code)