### PR TITLE
feat(booking): Google 予約スケジュール read-only ミラー

### DIFF
--- a/apps/api/src/__tests__/booking-link-utils.test.ts
+++ b/apps/api/src/__tests__/booking-link-utils.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import type { BookingLink } from '@calendar-hub/shared';
+import {
+  applyBookingLinkDefaults,
+  shouldCreateCalendarEvent,
+  filterCalendarsByIds,
+  validateBookingLinkInvariant,
+} from '../lib/booking-link-utils.js';
+
+// Helper: 完成形 BookingLink を組み立てるための baseLink
+function buildLink(overrides: Partial<BookingLink>): BookingLink {
+  return {
+    id: 'l1',
+    ownerUid: 'u1',
+    title: 't',
+    durationMinutes: 60,
+    accountIds: ['acc1'],
+    calendarIdForEvent: 'cal1',
+    accountIdForEvent: 'acc1',
+    freeTimeOptions: { dayStartHour: 9, dayEndHour: 18 },
+    availableDays: [1, 2, 3, 4, 5],
+    rangeDays: 14,
+    bufferMinutes: 0,
+    status: 'active',
+    expiresAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    autoCreateCalendarEvent: true,
+    calendarIdsForAvailability: null,
+    ...overrides,
+  };
+}
+
+describe('applyBookingLinkDefaults', () => {
+  it('AC-3: 既存 document に autoCreateCalendarEvent が無ければ true (既存挙動維持)', () => {
+    const result = applyBookingLinkDefaults({ title: 'old-link' });
+    expect(result.autoCreateCalendarEvent).toBe(true);
+  });
+
+  it('AC-4: 既存 document に calendarIdsForAvailability が無ければ null (全カレンダー対象)', () => {
+    const result = applyBookingLinkDefaults({ title: 'old-link' });
+    expect(result.calendarIdsForAvailability).toBeNull();
+  });
+
+  it('明示的に false が指定されていれば false を返す', () => {
+    const result = applyBookingLinkDefaults({ autoCreateCalendarEvent: false });
+    expect(result.autoCreateCalendarEvent).toBe(false);
+  });
+
+  it('明示的に配列が指定されていればその配列を返す', () => {
+    const result = applyBookingLinkDefaults({
+      calendarIdsForAvailability: ['x@example.com'],
+    });
+    expect(result.calendarIdsForAvailability).toEqual(['x@example.com']);
+  });
+
+  it('calendarIdForEvent / accountIdForEvent が無ければ両方 null', () => {
+    const result = applyBookingLinkDefaults({});
+    expect(result.calendarIdForEvent).toBeNull();
+    expect(result.accountIdForEvent).toBeNull();
+  });
+
+  it('calendarIdForEvent / accountIdForEvent が文字列指定ならそれを返す', () => {
+    const result = applyBookingLinkDefaults({
+      calendarIdForEvent: 'cal1@example.com',
+      accountIdForEvent: 'google_acc1',
+    });
+    expect(result.calendarIdForEvent).toBe('cal1@example.com');
+    expect(result.accountIdForEvent).toBe('google_acc1');
+  });
+});
+
+describe('shouldCreateCalendarEvent', () => {
+  it('AC-1: autoCreate=false なら false (event 作成 skip)', () => {
+    const link = buildLink({
+      autoCreateCalendarEvent: false,
+      calendarIdForEvent: null,
+      accountIdForEvent: null,
+    });
+    expect(shouldCreateCalendarEvent(link)).toBe(false);
+  });
+
+  it('AC-3 (補完後): autoCreate=true かつ両 ID あれば true', () => {
+    const link = buildLink({
+      autoCreateCalendarEvent: true,
+      calendarIdForEvent: 'cal1',
+      accountIdForEvent: 'acc1',
+    });
+    expect(shouldCreateCalendarEvent(link)).toBe(true);
+  });
+
+  it('autoCreate=true でも calendarIdForEvent が null なら false (defensive)', () => {
+    const link = buildLink({
+      autoCreateCalendarEvent: true,
+      calendarIdForEvent: null,
+      accountIdForEvent: 'acc1',
+    });
+    expect(shouldCreateCalendarEvent(link)).toBe(false);
+  });
+
+  it('autoCreate=true でも accountIdForEvent が null なら false (defensive)', () => {
+    const link = buildLink({
+      autoCreateCalendarEvent: true,
+      calendarIdForEvent: 'cal1',
+      accountIdForEvent: null,
+    });
+    expect(shouldCreateCalendarEvent(link)).toBe(false);
+  });
+});
+
+describe('filterCalendarsByIds', () => {
+  const calendars = [
+    { id: 'cal1', name: 'A' },
+    { id: 'cal2', name: 'B' },
+    { id: 'cal3', name: 'C' },
+  ];
+
+  it('AC-4: filter=null なら全 calendar を返す (既存挙動)', () => {
+    const result = filterCalendarsByIds(calendars, null);
+    expect(result).toHaveLength(3);
+  });
+
+  it('AC-2: filter=[cal2] なら cal2 のみ返す', () => {
+    const result = filterCalendarsByIds(calendars, ['cal2']);
+    expect(result).toEqual([{ id: 'cal2', name: 'B' }]);
+  });
+
+  it('AC-2: filter=[cal1, cal3] なら cal1 と cal3 を返す', () => {
+    const result = filterCalendarsByIds(calendars, ['cal1', 'cal3']);
+    expect(result).toEqual([
+      { id: 'cal1', name: 'A' },
+      { id: 'cal3', name: 'C' },
+    ]);
+  });
+
+  it('filter=[] なら空配列を返す', () => {
+    const result = filterCalendarsByIds(calendars, []);
+    expect(result).toEqual([]);
+  });
+
+  it('filter に存在しない ID が含まれていても無視される', () => {
+    const result = filterCalendarsByIds(calendars, ['cal2', 'nonexistent']);
+    expect(result).toEqual([{ id: 'cal2', name: 'B' }]);
+  });
+});
+
+describe('validateBookingLinkInvariant', () => {
+  it('AC-5: autoCreate=true で calendarIdForEvent=null だと NG', () => {
+    const result = validateBookingLinkInvariant({
+      autoCreateCalendarEvent: true,
+      calendarIdForEvent: null,
+      accountIdForEvent: 'acc1',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('AC-5: autoCreate=true で accountIdForEvent=null だと NG', () => {
+    const result = validateBookingLinkInvariant({
+      autoCreateCalendarEvent: true,
+      calendarIdForEvent: 'cal1',
+      accountIdForEvent: null,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('autoCreate=true で両 ID あれば OK', () => {
+    const result = validateBookingLinkInvariant({
+      autoCreateCalendarEvent: true,
+      calendarIdForEvent: 'cal1',
+      accountIdForEvent: 'acc1',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('autoCreate=false なら両 ID が null でも OK', () => {
+    const result = validateBookingLinkInvariant({
+      autoCreateCalendarEvent: false,
+      calendarIdForEvent: null,
+      accountIdForEvent: null,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('autoCreate=false なら両 ID が undefined でも OK', () => {
+    const result = validateBookingLinkInvariant({
+      autoCreateCalendarEvent: false,
+      calendarIdForEvent: undefined,
+      accountIdForEvent: undefined,
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/apps/api/src/__tests__/booking-link-utils.test.ts
+++ b/apps/api/src/__tests__/booking-link-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { BookingLink } from '@calendar-hub/shared';
 import {
   applyBookingLinkDefaults,
+  buildBookingLinkPatchUpdate,
   shouldCreateCalendarEvent,
   filterCalendarsByIds,
   validateBookingLinkInvariant,
@@ -141,6 +142,74 @@ describe('filterCalendarsByIds', () => {
   it('filter に存在しない ID が含まれていても無視される', () => {
     const result = filterCalendarsByIds(calendars, ['cal2', 'nonexistent']);
     expect(result).toEqual([{ id: 'cal2', name: 'B' }]);
+  });
+});
+
+describe('buildBookingLinkPatchUpdate (Partial Update: 更新対象外フィールドは含めない)', () => {
+  it('title のみ指定 → update に title のみ含まれる', () => {
+    const update = buildBookingLinkPatchUpdate({ title: 'new' });
+    expect(Object.keys(update)).toEqual(['title']);
+    expect(update.title).toBe('new');
+  });
+
+  it('autoCreateCalendarEvent のみ指定 → 他フィールドは update に含まれない', () => {
+    const update = buildBookingLinkPatchUpdate({ autoCreateCalendarEvent: false });
+    expect(Object.keys(update)).toEqual(['autoCreateCalendarEvent']);
+    expect(update.autoCreateCalendarEvent).toBe(false);
+    expect(update.title).toBeUndefined();
+    expect(update.calendarIdsForAvailability).toBeUndefined();
+    expect(update.bufferMinutes).toBeUndefined();
+    expect(update.calendarIdForEvent).toBeUndefined();
+  });
+
+  it('calendarIdsForAvailability のみ指定 → 他フィールドは update に含まれない', () => {
+    const update = buildBookingLinkPatchUpdate({
+      calendarIdsForAvailability: ['x@example.com'],
+    });
+    expect(Object.keys(update)).toEqual(['calendarIdsForAvailability']);
+    expect(update.calendarIdsForAvailability).toEqual(['x@example.com']);
+  });
+
+  it('calendarIdsForAvailability を null に明示指定 → null が含まれる', () => {
+    const update = buildBookingLinkPatchUpdate({ calendarIdsForAvailability: null });
+    expect(Object.keys(update)).toEqual(['calendarIdsForAvailability']);
+    expect(update.calendarIdsForAvailability).toBeNull();
+  });
+
+  it('description が null なら null として保存', () => {
+    const update = buildBookingLinkPatchUpdate({ description: null });
+    expect(update.description).toBeNull();
+  });
+
+  it('expiresAt 文字列 → Date に変換', () => {
+    const update = buildBookingLinkPatchUpdate({ expiresAt: '2026-12-31T23:59:59Z' });
+    expect(update.expiresAt).toBeInstanceOf(Date);
+  });
+
+  it('expiresAt が null なら null', () => {
+    const update = buildBookingLinkPatchUpdate({ expiresAt: null });
+    expect(update.expiresAt).toBeNull();
+  });
+
+  it('全フィールド未指定なら空オブジェクト', () => {
+    const update = buildBookingLinkPatchUpdate({});
+    expect(update).toEqual({});
+  });
+
+  it('autoCreate=false + calendarId=null を同時指定 → 両方含まれる (read-only ミラー化の典型ケース)', () => {
+    const update = buildBookingLinkPatchUpdate({
+      autoCreateCalendarEvent: false,
+      calendarIdForEvent: null,
+      accountIdForEvent: null,
+    });
+    expect(Object.keys(update).sort()).toEqual([
+      'accountIdForEvent',
+      'autoCreateCalendarEvent',
+      'calendarIdForEvent',
+    ]);
+    expect(update.autoCreateCalendarEvent).toBe(false);
+    expect(update.calendarIdForEvent).toBeNull();
+    expect(update.accountIdForEvent).toBeNull();
   });
 });
 

--- a/apps/api/src/lib/booking-link-utils.ts
+++ b/apps/api/src/lib/booking-link-utils.ts
@@ -1,0 +1,67 @@
+import type { BookingLink } from '@calendar-hub/shared';
+
+/**
+ * Firestore document data に新フィールドの default を補完するためのロジック。
+ *
+ * 既存 document に `autoCreateCalendarEvent` / `calendarIdsForAvailability` が
+ * 無い場合、それぞれ `true` / `null` として読み出して既存挙動を維持する。
+ */
+export function applyBookingLinkDefaults(
+  data: Record<string, unknown>,
+): Pick<
+  BookingLink,
+  | 'calendarIdForEvent'
+  | 'accountIdForEvent'
+  | 'autoCreateCalendarEvent'
+  | 'calendarIdsForAvailability'
+> {
+  return {
+    calendarIdForEvent: (data.calendarIdForEvent as string | null | undefined) ?? null,
+    accountIdForEvent: (data.accountIdForEvent as string | null | undefined) ?? null,
+    autoCreateCalendarEvent: (data.autoCreateCalendarEvent as boolean | undefined) ?? true,
+    calendarIdsForAvailability:
+      (data.calendarIdsForAvailability as string[] | null | undefined) ?? null,
+  };
+}
+
+/**
+ * 予約成立時に Google Calendar への event 自動作成を行うべきかを判定。
+ *
+ * autoCreate フラグが ON で、かつ書き込み先 (accountIdForEvent / calendarIdForEvent)
+ * の両方が設定されている場合のみ true。
+ */
+export function shouldCreateCalendarEvent(link: BookingLink): boolean {
+  return link.autoCreateCalendarEvent && !!link.accountIdForEvent && !!link.calendarIdForEvent;
+}
+
+/**
+ * `calendarIdsForAvailability` に基づいて calendar 配列を絞り込む。
+ * filter が null の場合は全件をそのまま返す (既存挙動)。
+ */
+export function filterCalendarsByIds<T extends { id: string }>(
+  calendars: T[],
+  filter: string[] | null,
+): T[] {
+  return filter ? calendars.filter((cal) => filter.includes(cal.id)) : calendars;
+}
+
+/**
+ * BookingLink 作成/更新入力の不変条件をチェック。
+ *
+ * `autoCreateCalendarEvent === true` (default) のときは
+ * `calendarIdForEvent` と `accountIdForEvent` が必須。false のときは null 許容。
+ */
+export function validateBookingLinkInvariant(input: {
+  autoCreateCalendarEvent: boolean;
+  calendarIdForEvent: string | null | undefined;
+  accountIdForEvent: string | null | undefined;
+}): { ok: true } | { ok: false; error: string } {
+  if (input.autoCreateCalendarEvent && (!input.calendarIdForEvent || !input.accountIdForEvent)) {
+    return {
+      ok: false,
+      error:
+        'calendarIdForEvent and accountIdForEvent are required when autoCreateCalendarEvent is true',
+    };
+  }
+  return { ok: true };
+}

--- a/apps/api/src/lib/booking-link-utils.ts
+++ b/apps/api/src/lib/booking-link-utils.ts
@@ -1,3 +1,4 @@
+import type { DocumentData } from 'firebase-admin/firestore';
 import type { BookingLink } from '@calendar-hub/shared';
 
 /**
@@ -22,6 +23,20 @@ export function applyBookingLinkDefaults(
     calendarIdsForAvailability:
       (data.calendarIdsForAvailability as string[] | null | undefined) ?? null,
   };
+}
+
+/**
+ * Firestore document data から BookingLink を構築する。
+ * Timestamp → Date 変換 + 新フィールドの default 補完を一括で行う。
+ */
+export function buildBookingLinkFromFirestoreData(data: DocumentData): BookingLink {
+  return {
+    ...data,
+    createdAt: data.createdAt?.toDate?.() ?? new Date(),
+    updatedAt: data.updatedAt?.toDate?.() ?? new Date(),
+    expiresAt: data.expiresAt?.toDate?.() ?? null,
+    ...applyBookingLinkDefaults(data),
+  } as BookingLink;
 }
 
 /**

--- a/apps/api/src/lib/booking-link-utils.ts
+++ b/apps/api/src/lib/booking-link-utils.ts
@@ -61,6 +61,45 @@ export function filterCalendarsByIds<T extends { id: string }>(
 }
 
 /**
+ * PATCH リクエスト body から Firestore update object を構築する (Partial Update)。
+ *
+ * undefined フィールドは update に含めず、Firestore 側で既存値を保持させる。
+ * `updatedAt` 等の serverTimestamp は呼出側で別途追加すること。
+ */
+export function buildBookingLinkPatchUpdate(body: {
+  title?: string;
+  description?: string | null;
+  status?: string;
+  availableDays?: number[];
+  rangeDays?: number;
+  bufferMinutes?: number;
+  freeTimeOptions?: { dayStartHour: number; dayEndHour: number };
+  expiresAt?: string | null;
+  autoCreateCalendarEvent?: boolean;
+  calendarIdsForAvailability?: string[] | null;
+  calendarIdForEvent?: string | null;
+  accountIdForEvent?: string | null;
+}): Record<string, unknown> {
+  const update: Record<string, unknown> = {};
+  if (body.title !== undefined) update.title = body.title;
+  if (body.description !== undefined) update.description = body.description ?? null;
+  if (body.status !== undefined) update.status = body.status;
+  if (body.availableDays !== undefined) update.availableDays = body.availableDays;
+  if (body.rangeDays !== undefined) update.rangeDays = body.rangeDays;
+  if (body.bufferMinutes !== undefined) update.bufferMinutes = body.bufferMinutes;
+  if (body.freeTimeOptions !== undefined) update.freeTimeOptions = body.freeTimeOptions;
+  if (body.expiresAt !== undefined)
+    update.expiresAt = body.expiresAt ? new Date(body.expiresAt) : null;
+  if (body.autoCreateCalendarEvent !== undefined)
+    update.autoCreateCalendarEvent = body.autoCreateCalendarEvent;
+  if (body.calendarIdsForAvailability !== undefined)
+    update.calendarIdsForAvailability = body.calendarIdsForAvailability;
+  if (body.calendarIdForEvent !== undefined) update.calendarIdForEvent = body.calendarIdForEvent;
+  if (body.accountIdForEvent !== undefined) update.accountIdForEvent = body.accountIdForEvent;
+  return update;
+}
+
+/**
  * BookingLink 作成/更新入力の不変条件をチェック。
  *
  * `autoCreateCalendarEvent === true` (default) のときは

--- a/apps/api/src/routes/booking-links.ts
+++ b/apps/api/src/routes/booking-links.ts
@@ -10,6 +10,7 @@ import {
   type BookingLink,
   type CreateBookingLinkInput,
 } from '@calendar-hub/shared';
+import { validateBookingLinkInvariant } from '../lib/booking-link-utils.js';
 
 function toBookingLink(data: FirebaseFirestore.DocumentData): BookingLink {
   return {
@@ -17,6 +18,10 @@ function toBookingLink(data: FirebaseFirestore.DocumentData): BookingLink {
     createdAt: data.createdAt?.toDate?.() ?? new Date(),
     updatedAt: data.updatedAt?.toDate?.() ?? new Date(),
     expiresAt: data.expiresAt?.toDate?.() ?? null,
+    calendarIdForEvent: data.calendarIdForEvent ?? null,
+    accountIdForEvent: data.accountIdForEvent ?? null,
+    autoCreateCalendarEvent: data.autoCreateCalendarEvent ?? true,
+    calendarIdsForAvailability: data.calendarIdsForAvailability ?? null,
   } as BookingLink;
 }
 
@@ -34,8 +39,25 @@ bookingLinkRoutes.post('/', requireAuth, async (c) => {
     return c.json({ error: `durationMinutes must be one of: ${DURATION_OPTIONS.join(', ')}` }, 400);
   }
 
-  if (!body.calendarIdForEvent || !body.accountIdForEvent) {
-    return c.json({ error: 'calendarIdForEvent and accountIdForEvent are required' }, 400);
+  const autoCreateCalendarEvent = body.autoCreateCalendarEvent ?? true;
+  const calendarIdsForAvailability = body.calendarIdsForAvailability ?? null;
+
+  const invariant = validateBookingLinkInvariant({
+    autoCreateCalendarEvent,
+    calendarIdForEvent: body.calendarIdForEvent,
+    accountIdForEvent: body.accountIdForEvent,
+  });
+  if (!invariant.ok) {
+    return c.json({ error: invariant.error }, 400);
+  }
+
+  if (calendarIdsForAvailability !== null) {
+    if (
+      !Array.isArray(calendarIdsForAvailability) ||
+      calendarIdsForAvailability.some((s) => typeof s !== 'string')
+    ) {
+      return c.json({ error: 'calendarIdsForAvailability must be array of strings or null' }, 400);
+    }
   }
 
   const id = nanoid(12);
@@ -48,8 +70,8 @@ bookingLinkRoutes.post('/', requireAuth, async (c) => {
     description: body.description ?? undefined,
     durationMinutes: body.durationMinutes,
     accountIds: body.accountIds,
-    calendarIdForEvent: body.calendarIdForEvent,
-    accountIdForEvent: body.accountIdForEvent,
+    calendarIdForEvent: body.calendarIdForEvent ?? null,
+    accountIdForEvent: body.accountIdForEvent ?? null,
     freeTimeOptions: {
       dayStartHour: body.freeTimeOptions?.dayStartHour ?? 9,
       dayEndHour: body.freeTimeOptions?.dayEndHour ?? 18,
@@ -61,6 +83,8 @@ bookingLinkRoutes.post('/', requireAuth, async (c) => {
     expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
     createdAt: now,
     updatedAt: now,
+    autoCreateCalendarEvent,
+    calendarIdsForAvailability,
   };
 
   const db = getDb();
@@ -105,6 +129,8 @@ bookingLinkRoutes.patch('/:linkId', requireAuth, async (c) => {
     return c.json({ error: 'Not found' }, 404);
   }
 
+  const existingLink = toBookingLink(doc.data()!);
+
   if (
     body.status !== undefined &&
     !(BOOKING_LINK_STATUSES as readonly string[]).includes(body.status)
@@ -128,6 +154,41 @@ bookingLinkRoutes.patch('/:linkId', requireAuth, async (c) => {
       return c.json({ error: 'dayStartHour must be less than dayEndHour' }, 400);
     }
   }
+  if (
+    body.autoCreateCalendarEvent !== undefined &&
+    typeof body.autoCreateCalendarEvent !== 'boolean'
+  ) {
+    return c.json({ error: 'autoCreateCalendarEvent must be boolean' }, 400);
+  }
+  if (body.calendarIdsForAvailability !== undefined && body.calendarIdsForAvailability !== null) {
+    if (
+      !Array.isArray(body.calendarIdsForAvailability) ||
+      body.calendarIdsForAvailability.some((s: unknown) => typeof s !== 'string')
+    ) {
+      return c.json({ error: 'calendarIdsForAvailability must be array of strings or null' }, 400);
+    }
+  }
+
+  // 不変条件: マージ後の autoCreate=true なら calendarIdForEvent/accountIdForEvent が non-null
+  const newAutoCreate =
+    body.autoCreateCalendarEvent !== undefined
+      ? body.autoCreateCalendarEvent
+      : existingLink.autoCreateCalendarEvent;
+  const newCalendarIdForEvent =
+    body.calendarIdForEvent !== undefined
+      ? body.calendarIdForEvent
+      : existingLink.calendarIdForEvent;
+  const newAccountIdForEvent =
+    body.accountIdForEvent !== undefined ? body.accountIdForEvent : existingLink.accountIdForEvent;
+
+  const patchInvariant = validateBookingLinkInvariant({
+    autoCreateCalendarEvent: newAutoCreate,
+    calendarIdForEvent: newCalendarIdForEvent,
+    accountIdForEvent: newAccountIdForEvent,
+  });
+  if (!patchInvariant.ok) {
+    return c.json({ error: patchInvariant.error }, 400);
+  }
 
   const update: Record<string, unknown> = {
     updatedAt: FieldValue.serverTimestamp(),
@@ -142,6 +203,12 @@ bookingLinkRoutes.patch('/:linkId', requireAuth, async (c) => {
   if (body.freeTimeOptions !== undefined) update.freeTimeOptions = body.freeTimeOptions;
   if (body.expiresAt !== undefined)
     update.expiresAt = body.expiresAt ? new Date(body.expiresAt) : null;
+  if (body.autoCreateCalendarEvent !== undefined)
+    update.autoCreateCalendarEvent = body.autoCreateCalendarEvent;
+  if (body.calendarIdsForAvailability !== undefined)
+    update.calendarIdsForAvailability = body.calendarIdsForAvailability;
+  if (body.calendarIdForEvent !== undefined) update.calendarIdForEvent = body.calendarIdForEvent;
+  if (body.accountIdForEvent !== undefined) update.accountIdForEvent = body.accountIdForEvent;
 
   await ref.update(update);
 

--- a/apps/api/src/routes/booking-links.ts
+++ b/apps/api/src/routes/booking-links.ts
@@ -10,20 +10,10 @@ import {
   type BookingLink,
   type CreateBookingLinkInput,
 } from '@calendar-hub/shared';
-import { validateBookingLinkInvariant } from '../lib/booking-link-utils.js';
-
-function toBookingLink(data: FirebaseFirestore.DocumentData): BookingLink {
-  return {
-    ...data,
-    createdAt: data.createdAt?.toDate?.() ?? new Date(),
-    updatedAt: data.updatedAt?.toDate?.() ?? new Date(),
-    expiresAt: data.expiresAt?.toDate?.() ?? null,
-    calendarIdForEvent: data.calendarIdForEvent ?? null,
-    accountIdForEvent: data.accountIdForEvent ?? null,
-    autoCreateCalendarEvent: data.autoCreateCalendarEvent ?? true,
-    calendarIdsForAvailability: data.calendarIdsForAvailability ?? null,
-  } as BookingLink;
-}
+import {
+  buildBookingLinkFromFirestoreData,
+  validateBookingLinkInvariant,
+} from '../lib/booking-link-utils.js';
 
 export const bookingLinkRoutes = new Hono<AppEnv>();
 
@@ -112,7 +102,7 @@ bookingLinkRoutes.get('/', requireAuth, async (c) => {
     .orderBy('createdAt', 'desc')
     .get();
 
-  const links = snap.docs.map((doc) => toBookingLink(doc.data()));
+  const links = snap.docs.map((doc) => buildBookingLinkFromFirestoreData(doc.data()));
   return c.json({ links });
 });
 
@@ -129,7 +119,7 @@ bookingLinkRoutes.patch('/:linkId', requireAuth, async (c) => {
     return c.json({ error: 'Not found' }, 404);
   }
 
-  const existingLink = toBookingLink(doc.data()!);
+  const existingLink = buildBookingLinkFromFirestoreData(doc.data()!);
 
   if (
     body.status !== undefined &&
@@ -213,7 +203,7 @@ bookingLinkRoutes.patch('/:linkId', requireAuth, async (c) => {
   await ref.update(update);
 
   const updated = await ref.get();
-  return c.json({ link: toBookingLink(updated.data()!) });
+  return c.json({ link: buildBookingLinkFromFirestoreData(updated.data()!) });
 });
 
 bookingLinkRoutes.delete('/:linkId', requireAuth, async (c) => {

--- a/apps/api/src/routes/booking-links.ts
+++ b/apps/api/src/routes/booking-links.ts
@@ -12,6 +12,7 @@ import {
 } from '@calendar-hub/shared';
 import {
   buildBookingLinkFromFirestoreData,
+  buildBookingLinkPatchUpdate,
   validateBookingLinkInvariant,
 } from '../lib/booking-link-utils.js';
 
@@ -180,25 +181,10 @@ bookingLinkRoutes.patch('/:linkId', requireAuth, async (c) => {
     return c.json({ error: patchInvariant.error }, 400);
   }
 
-  const update: Record<string, unknown> = {
+  const update = {
     updatedAt: FieldValue.serverTimestamp(),
+    ...buildBookingLinkPatchUpdate(body),
   };
-
-  if (body.title !== undefined) update.title = body.title;
-  if (body.description !== undefined) update.description = body.description ?? null;
-  if (body.status !== undefined) update.status = body.status;
-  if (body.availableDays !== undefined) update.availableDays = body.availableDays;
-  if (body.rangeDays !== undefined) update.rangeDays = body.rangeDays;
-  if (body.bufferMinutes !== undefined) update.bufferMinutes = body.bufferMinutes;
-  if (body.freeTimeOptions !== undefined) update.freeTimeOptions = body.freeTimeOptions;
-  if (body.expiresAt !== undefined)
-    update.expiresAt = body.expiresAt ? new Date(body.expiresAt) : null;
-  if (body.autoCreateCalendarEvent !== undefined)
-    update.autoCreateCalendarEvent = body.autoCreateCalendarEvent;
-  if (body.calendarIdsForAvailability !== undefined)
-    update.calendarIdsForAvailability = body.calendarIdsForAvailability;
-  if (body.calendarIdForEvent !== undefined) update.calendarIdForEvent = body.calendarIdForEvent;
-  if (body.accountIdForEvent !== undefined) update.accountIdForEvent = body.accountIdForEvent;
 
   await ref.update(update);
 

--- a/apps/api/src/routes/public-booking.ts
+++ b/apps/api/src/routes/public-booking.ts
@@ -19,6 +19,7 @@ import type {
   PublicBookingLinkInfo,
   CreateBookingInput,
 } from '@calendar-hub/shared';
+import { filterCalendarsByIds, shouldCreateCalendarEvent } from '../lib/booking-link-utils.js';
 
 export const publicBookingRoutes = new Hono();
 
@@ -56,6 +57,10 @@ function toBookingLink(data: FirebaseFirestore.DocumentData): BookingLink {
     createdAt: data.createdAt?.toDate?.() ?? new Date(),
     updatedAt: data.updatedAt?.toDate?.() ?? new Date(),
     expiresAt: data.expiresAt?.toDate?.() ?? null,
+    calendarIdForEvent: data.calendarIdForEvent ?? null,
+    accountIdForEvent: data.accountIdForEvent ?? null,
+    autoCreateCalendarEvent: data.autoCreateCalendarEvent ?? true,
+    calendarIdsForAvailability: data.calendarIdsForAvailability ?? null,
   } as BookingLink;
 }
 
@@ -69,6 +74,7 @@ async function getOwnerDisplayName(ownerUid: string): Promise<string> {
 async function fetchOwnerEvents(
   ownerUid: string,
   accountIds: string[],
+  calendarIdsFilter: string[] | null,
   timeMin: Date,
   timeMax: Date,
 ): Promise<CalendarEvent[]> {
@@ -76,8 +82,9 @@ async function fetchOwnerEvents(
     accountIds.map(async (accountId) => {
       const adapter = await createAdapter(ownerUid, accountId);
       const calendars = await adapter.listCalendars();
+      const targets = filterCalendarsByIds(calendars, calendarIdsFilter);
       const allEvents = await Promise.all(
-        calendars.map((cal) => adapter.listEvents(cal.id, timeMin, timeMax)),
+        targets.map((cal) => adapter.listEvents(cal.id, timeMin, timeMax)),
       );
       return allEvents.flat();
     }),
@@ -171,7 +178,13 @@ publicBookingRoutes.get('/:linkId/slots', async (c) => {
   if (rangeStart < now) rangeStart = now;
 
   const [calendarEvents, bookingEvents] = await Promise.all([
-    fetchOwnerEvents(link.ownerUid, link.accountIds, rangeStart, rangeEnd),
+    fetchOwnerEvents(
+      link.ownerUid,
+      link.accountIds,
+      link.calendarIdsForAvailability,
+      rangeStart,
+      rangeEnd,
+    ),
     getConfirmedBookingEventsForOwner(link.ownerUid, rangeStart, rangeEnd),
   ]);
 
@@ -304,7 +317,16 @@ publicBookingRoutes.post('/:linkId/book', async (c) => {
   const ownerDisplayName = await getOwnerDisplayName(link.ownerUid);
 
   // 非同期処理（失敗してもbookingは確定済み）
-  createCalendarEventAsync(link, bookingId, body.guestName, body.guestMessage, slotStart, slotEnd);
+  if (shouldCreateCalendarEvent(link)) {
+    createCalendarEventAsync(
+      link,
+      bookingId,
+      body.guestName,
+      body.guestMessage,
+      slotStart,
+      slotEnd,
+    );
+  }
   sendBookingNotificationsAsync(
     link,
     bookingId,
@@ -342,6 +364,13 @@ function createCalendarEventAsync(
   slotEnd: Date,
 ) {
   (async () => {
+    // 呼出側 (POST /:linkId/book) で null チェック済だが、型 narrowing のため再確認
+    if (!link.accountIdForEvent || !link.calendarIdForEvent) {
+      console.error(
+        `createCalendarEventAsync called with null IDs for booking ${bookingId} (link ${link.id})`,
+      );
+      return;
+    }
     try {
       const adapter = await createAdapter(link.ownerUid, link.accountIdForEvent);
       const event = await adapter.createEvent(link.calendarIdForEvent, {

--- a/apps/api/src/routes/public-booking.ts
+++ b/apps/api/src/routes/public-booking.ts
@@ -19,7 +19,11 @@ import type {
   PublicBookingLinkInfo,
   CreateBookingInput,
 } from '@calendar-hub/shared';
-import { filterCalendarsByIds, shouldCreateCalendarEvent } from '../lib/booking-link-utils.js';
+import {
+  buildBookingLinkFromFirestoreData,
+  filterCalendarsByIds,
+  shouldCreateCalendarEvent,
+} from '../lib/booking-link-utils.js';
 
 export const publicBookingRoutes = new Hono();
 
@@ -38,7 +42,7 @@ async function getActiveBookingLink(linkId: string): Promise<LinkResult> {
   }
 
   const data = doc.data()!;
-  const link = toBookingLink(data);
+  const link = buildBookingLinkFromFirestoreData(data);
 
   if (link.status !== 'active') {
     return { link: null, error: 'This booking link is currently paused', statusCode: 400 };
@@ -49,19 +53,6 @@ async function getActiveBookingLink(linkId: string): Promise<LinkResult> {
   }
 
   return { link, error: null, statusCode: null };
-}
-
-function toBookingLink(data: FirebaseFirestore.DocumentData): BookingLink {
-  return {
-    ...data,
-    createdAt: data.createdAt?.toDate?.() ?? new Date(),
-    updatedAt: data.updatedAt?.toDate?.() ?? new Date(),
-    expiresAt: data.expiresAt?.toDate?.() ?? null,
-    calendarIdForEvent: data.calendarIdForEvent ?? null,
-    accountIdForEvent: data.accountIdForEvent ?? null,
-    autoCreateCalendarEvent: data.autoCreateCalendarEvent ?? true,
-    calendarIdsForAvailability: data.calendarIdsForAvailability ?? null,
-  } as BookingLink;
 }
 
 async function getOwnerDisplayName(ownerUid: string): Promise<string> {

--- a/apps/web/src/app/booking-links/new/new-link-content.tsx
+++ b/apps/web/src/app/booking-links/new/new-link-content.tsx
@@ -99,6 +99,12 @@ export function NewLinkContent() {
       setError('予約イベント作成先のカレンダーを設定してください');
       return;
     }
+    if (useSpecificAvailabilityCalendars && selectedAvailabilityCalendarIds.length === 0) {
+      setError(
+        '「特定のカレンダーのみで空き時間を判定する」を有効にした場合は、対象カレンダーを 1 つ以上選択してください',
+      );
+      return;
+    }
     setSubmitting(true);
     setError('');
     try {

--- a/apps/web/src/app/booking-links/new/new-link-content.tsx
+++ b/apps/web/src/app/booking-links/new/new-link-content.tsx
@@ -38,6 +38,11 @@ export function NewLinkContent() {
   const [availableDays, setAvailableDays] = useState([1, 2, 3, 4, 5]);
   const [rangeDays, setRangeDays] = useState(14);
   const [bufferMinutes, setBufferMinutes] = useState(0);
+  const [autoCreateCalendarEvent, setAutoCreateCalendarEvent] = useState(true);
+  const [useSpecificAvailabilityCalendars, setUseSpecificAvailabilityCalendars] = useState(false);
+  const [selectedAvailabilityCalendarIds, setSelectedAvailabilityCalendarIds] = useState<string[]>(
+    [],
+  );
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
@@ -86,24 +91,33 @@ export function NewLinkContent() {
   );
 
   const handleSubmit = async () => {
-    if (!title.trim() || !calendarIdForEvent || selectedAccountIds.length === 0) {
-      setError('タイトル、カレンダー、アカウントを設定してください');
+    if (!title.trim() || selectedAccountIds.length === 0) {
+      setError('タイトルとアカウントを設定してください');
+      return;
+    }
+    if (autoCreateCalendarEvent && !calendarIdForEvent) {
+      setError('予約イベント作成先のカレンダーを設定してください');
       return;
     }
     setSubmitting(true);
     setError('');
     try {
+      const calendarIdsForAvailability = useSpecificAvailabilityCalendars
+        ? selectedAvailabilityCalendarIds
+        : null;
       await apiPost('/api/booking-links', {
         title: title.trim(),
         description: description.trim() || undefined,
         durationMinutes,
         accountIds: selectedAccountIds,
-        calendarIdForEvent,
-        accountIdForEvent,
+        calendarIdForEvent: autoCreateCalendarEvent ? calendarIdForEvent : null,
+        accountIdForEvent: autoCreateCalendarEvent ? accountIdForEvent : null,
         freeTimeOptions: { dayStartHour, dayEndHour },
         availableDays,
         rangeDays,
         bufferMinutes,
+        autoCreateCalendarEvent,
+        calendarIdsForAvailability,
       });
       router.push('/booking-links');
     } catch (err) {
@@ -197,18 +211,62 @@ export function NewLinkContent() {
               ))}
             </div>
 
-            <label style={s.label}>予約イベントを作成するカレンダー</label>
-            <select
-              value={calendarIdForEvent}
-              onChange={(e) => handleCalendarSelect(e.target.value)}
-              style={s.select}
-            >
-              {calendars.map((cal) => (
-                <option key={cal.id} value={cal.id}>
-                  {cal.name}
-                </option>
-              ))}
-            </select>
+            <label style={{ ...s.checkboxItem, marginTop: '12px' }}>
+              <input
+                type="checkbox"
+                checked={useSpecificAvailabilityCalendars}
+                onChange={(e) => setUseSpecificAvailabilityCalendars(e.target.checked)}
+              />
+              <span>特定のカレンダーのみで空き時間を判定する</span>
+            </label>
+            {useSpecificAvailabilityCalendars && (
+              <div style={{ ...s.checkboxList, marginTop: '8px', paddingLeft: '24px' }}>
+                {calendars
+                  .filter((cal) => selectedAccountIds.includes(cal.accountId))
+                  .map((cal) => (
+                    <label key={cal.id} style={s.checkboxItem}>
+                      <input
+                        type="checkbox"
+                        checked={selectedAvailabilityCalendarIds.includes(cal.id)}
+                        onChange={() => {
+                          setSelectedAvailabilityCalendarIds((prev) =>
+                            prev.includes(cal.id)
+                              ? prev.filter((id) => id !== cal.id)
+                              : [...prev, cal.id],
+                          );
+                        }}
+                      />
+                      <span>{cal.name}</span>
+                    </label>
+                  ))}
+              </div>
+            )}
+
+            <label style={{ ...s.checkboxItem, marginTop: '16px' }}>
+              <input
+                type="checkbox"
+                checked={autoCreateCalendarEvent}
+                onChange={(e) => setAutoCreateCalendarEvent(e.target.checked)}
+              />
+              <span>予約成立時に Google Calendar へ予定を自動登録する</span>
+            </label>
+
+            {autoCreateCalendarEvent && (
+              <>
+                <label style={s.label}>予約イベントを作成するカレンダー</label>
+                <select
+                  value={calendarIdForEvent}
+                  onChange={(e) => handleCalendarSelect(e.target.value)}
+                  style={s.select}
+                >
+                  {calendars.map((cal) => (
+                    <option key={cal.id} value={cal.id}>
+                      {cal.name}
+                    </option>
+                  ))}
+                </select>
+              </>
+            )}
           </div>
 
           {/* 受付設定 */}

--- a/docs/specs/2026-06-24-booking-mirror-design.md
+++ b/docs/specs/2026-06-24-booking-mirror-design.md
@@ -1,0 +1,280 @@
+# 設計仕様書: Google 予約スケジュール read-only ミラー
+
+- 作成日: 2026-06-24
+- ステータス: Draft (Phase 8 ユーザーレビュー前)
+- 関連 Issue / PR: (未起票)
+- ブランチ: `feature/booking-mirror-design`
+
+---
+
+## 1. 概要
+
+本田康志様 (`yasushi.honda@aozora-cg.com`) が現在顧客向けに利用している Google Appointment Schedule (`https://calendar.app.google/qyKq3kU2sX9e2vid7`) を、Calendar Hub の既存予約機能を活用して **read-only ミラー** として併設する。
+
+Google 側を「主たる予約スケジュール所有者」「予定の真実の源 (source of truth)」として尊重し、Calendar Hub は以下に限定する。
+
+- 空き時間の表示 (本田様の Google Calendar から自前算出)
+- 顧客側予約フォームの提供
+- 予約成立時のメール通知 (`hy.unimail.11@gmail.com` 宛)
+
+**Calendar Hub は Google Calendar に event を自動作成しない**。本田様が通知メールを受け取り、必要に応じて Google Calendar 側で手動で予定を入れる運用とする。
+
+## 2. 動機
+
+ユーザー要望の経緯:
+
+1. 初期要望: 「`calendar.app.google/xxx` の URL を入れたら、その内容を自前 UI で表示して、フォーム経由でメール通知する仕組みが欲しい」
+2. 実機検証 (Phase 1): iframe 埋め込みは `X-Frame-Options: SAMEORIGIN` で不可、Playwright スクレイプは技術的可能だが Bot 検知・規約リスクで運用不向きと判明
+3. 方針確定: 「Calendar Hub は Google 予約 URL の読み取り専用ミラーとして動作」「インタラクティブな相互通信なし、こちら側は読むだけ」「クリック後の入力は Calendar Hub 側のフォームで」
+
+結果として、既存の `bookingLink` 機能と要件がほぼ一致 (違いは「Google Calendar への event 自動作成 OFF」のみ) ことが判明。既存資産を流用しつつ最小変更で実現する。
+
+## 3. 要件
+
+### 3.1 機能要件
+
+| ID   | 要件                                                                                                                     |
+| ---- | ------------------------------------------------------------------------------------------------------------------------ |
+| FR-1 | `yasushi.honda@aozora-cg.com` カレンダー**のみ**の空き時間を 60 分枠で表示する公開予約ページを Calendar Hub 上で提供する |
+| FR-2 | 公開ページを開いた時とリロードした時に最新の空き時間を再取得する (既存実装で対応済)                                      |
+| FR-3 | ゲストが枠を選択 → 氏名 (必須) / メール (任意) / メッセージ (任意) を入力するフォームを表示する (既存実装で対応済)       |
+| FR-4 | 予約成立時に `hy.unimail.11@gmail.com` に通知メールを送信する (既存実装で対応済)                                         |
+| FR-5 | ゲストがメールを入力した場合、確認メールも送信する (既存実装で対応済)                                                    |
+| FR-6 | Google Calendar への event 自動作成は**行わない** (新規ゲート追加)                                                       |
+| FR-7 | 二重予約防止 (Firestore transaction による排他制御は既存実装で対応済)                                                    |
+| FR-8 | 既存の `bookingLink` の挙動 (autoCreateCalendarEvent = true として動作) は壊さない                                       |
+
+### 3.2 非機能要件
+
+| ID    | 要件                                                                                        |
+| ----- | ------------------------------------------------------------------------------------------- |
+| NFR-1 | 既存 Cloud Run service `calendar-hub-web` をそのまま利用 (独自ドメイン設定は今回スコープ外) |
+| NFR-2 | ismap 準拠 (GCP 内で完結。外部スクレイピング等は行わない)                                   |
+| NFR-3 | Google ToS に抵触しない (公式 Calendar API のみを利用)                                      |
+
+## 4. アーキテクチャ
+
+```
+┌──────────────────────────────────────────┐
+│ Google Calendar (yasushi.honda@aozora-cg.com)│
+└──────────────────────────────────────────┘
+           │ events.list / freebusy (公式 API、read-only)
+           ▼
+┌──────────────────────────────────────────┐
+│ Calendar Hub API (Cloud Run / Hono)       │
+│  ├ GET /api/public/booking/:linkId         │
+│  ├ GET /api/public/booking/:linkId/slots   │
+│  │    → fetchOwnerEvents()                │
+│  │       + calendarIdsForAvailability 絞込 │
+│  │    → free-time calculator              │
+│  └ POST /api/public/booking/:linkId/book   │
+│       → Firestore に Booking 保存          │
+│       → メール通知 (Gmail API for hy.unimail.11) │
+│       → ★ Google Calendar に event 作成は SKIP ★│
+└──────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────┐
+│ Next.js 公開ページ (apps/web/src/app/book/[linkId]) │
+│  (既存実装そのまま使用、UI 変更なし)        │
+└──────────────────────────────────────────┘
+```
+
+### 4.1 変更前後の差分
+
+| レイヤー         | 変更前                            | 変更後                                                                  |
+| ---------------- | --------------------------------- | ----------------------------------------------------------------------- |
+| `BookingLink` 型 | 全 link で event 自動作成 ON      | flag (`autoCreateCalendarEvent`) で ON/OFF 切替可                       |
+| 空き時間判定     | `accountIds` の全カレンダーを参照 | `calendarIdsForAvailability` で特定 calendar 絞込可 (null なら従来挙動) |
+| 予約成立後       | 必ず `adapter.createEvent` を呼ぶ | flag が `false` なら skip                                               |
+
+## 5. データモデル
+
+### 5.1 `BookingLink` (`packages/shared/src/booking-types.ts`)
+
+```typescript
+export interface BookingLink {
+  id: string;
+  ownerUid: string;
+  title: string;
+  description?: string;
+  durationMinutes: DurationOption;
+  accountIds: string[];
+
+  // 自動 event 作成関連 (autoCreateCalendarEvent=false なら null 可)
+  calendarIdForEvent: string | null;
+  accountIdForEvent: string | null;
+
+  freeTimeOptions: BookingLinkFreeTimeOptions;
+  availableDays: number[];
+  rangeDays: number;
+  bufferMinutes: number;
+  status: BookingLinkStatus;
+  expiresAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+
+  // ★ 今回追加
+  autoCreateCalendarEvent: boolean;
+  calendarIdsForAvailability: string[] | null;
+}
+```
+
+### 5.2 不変条件
+
+- `autoCreateCalendarEvent === true` のとき: `calendarIdForEvent` と `accountIdForEvent` は **必須 (非 null)**
+- `autoCreateCalendarEvent === false` のとき: `calendarIdForEvent` と `accountIdForEvent` は **null 許容**
+- `calendarIdsForAvailability === null`: 既存挙動 (`accountIds` の全カレンダーを参照)
+- `calendarIdsForAvailability` が配列: その配列に含まれる calendar ID のみ参照
+
+### 5.3 既存 Firestore document の読み出し互換性 (`toBookingLink`)
+
+| フィールド                   | 既存 document に欠如している場合の default |
+| ---------------------------- | ------------------------------------------ |
+| `autoCreateCalendarEvent`    | `true` (既存挙動)                          |
+| `calendarIdsForAvailability` | `null` (既存挙動)                          |
+| `calendarIdForEvent`         | 既存値 / `null`                            |
+| `accountIdForEvent`          | 既存値 / `null`                            |
+
+これにより、本変更のデプロイ時に既存 link を migration する必要はない。
+
+### 5.4 本田様用 `bookingLink` インスタンス
+
+実装フェーズで本田様が管理画面 (`/booking-links/new`) から作成する。推奨値:
+
+| フィールド                     | 値                                                    |
+| ------------------------------ | ----------------------------------------------------- |
+| `title`                        | 「【本田】予約スケジュール」                          |
+| `description`                  | 「ご相談・お打ち合わせのご予約はこちらから（60 分）」 |
+| `durationMinutes`              | `60`                                                  |
+| `accountIds`                   | `[<hy.unimail.11 の connected account ID>]`           |
+| `calendarIdsForAvailability`   | `["yasushi.honda@aozora-cg.com"]`                     |
+| `autoCreateCalendarEvent`      | `false`                                               |
+| `calendarIdForEvent`           | `null`                                                |
+| `accountIdForEvent`            | `null`                                                |
+| `availableDays`                | `[0,1,2,3,4,5,6]`                                     |
+| `freeTimeOptions.dayStartHour` | `8`                                                   |
+| `freeTimeOptions.dayEndHour`   | `23`                                                  |
+| `bufferMinutes`                | `0`                                                   |
+| `rangeDays`                    | `30`                                                  |
+| `expiresAt`                    | `null`                                                |
+| `status`                       | `'active'`                                            |
+
+## 6. インターフェース変更
+
+### 6.1 `apps/api/src/routes/booking-links.ts`
+
+#### POST `/` (新規作成)
+
+`CreateBookingLinkInput` に以下を追加:
+
+```typescript
+autoCreateCalendarEvent?: boolean;        // default true
+calendarIdsForAvailability?: string[];    // default null
+```
+
+バリデーション:
+
+- `autoCreateCalendarEvent !== false` のとき: `calendarIdForEvent` / `accountIdForEvent` は必須
+- `autoCreateCalendarEvent === false` のとき: 両者 null 許容
+- `calendarIdsForAvailability` 指定時: 配列要素は文字列
+
+#### PATCH `/:linkId` (更新)
+
+- 上記 2 フィールドの更新を許可
+- 不変条件チェックを再実行 (false → true 変更時、必須フィールドの存在確認)
+
+#### `toBookingLink` (Firestore data → BookingLink)
+
+§5.3 の default 補完を実装する。
+
+### 6.2 `apps/api/src/routes/public-booking.ts`
+
+#### `fetchOwnerEvents` (signature 変更)
+
+```typescript
+async function fetchOwnerEvents(
+  ownerUid: string,
+  accountIds: string[],
+  calendarIdsFilter: string[] | null, // ★ 引数追加
+  timeMin: Date,
+  timeMax: Date,
+): Promise<CalendarEvent[]>;
+```
+
+実装内で `calendarIdsFilter !== null` の場合、`adapter.listCalendars()` の結果を filter してから `listEvents` を呼ぶ。
+
+#### `GET /:linkId/slots` のハンドラ
+
+`fetchOwnerEvents` の呼出に `link.calendarIdsForAvailability` を渡す。
+
+#### `POST /:linkId/book` のハンドラ
+
+```typescript
+if (link.autoCreateCalendarEvent) {
+  createCalendarEventAsync(link, bookingId, body.guestName, body.guestMessage, slotStart, slotEnd);
+}
+sendBookingNotificationsAsync(...);  // メール通知は flag に関係なく実行
+```
+
+### 6.3 `apps/web/src/app/booking-links/new/new-link-content.tsx`
+
+新規作成 UI に以下を追加:
+
+- チェックボックス「Google Calendar に予定を自動登録する」(default ON、OFF なら autoCreateCalendarEvent=false)
+- カレンダー絞り込み欄: connected account の calendar 一覧から複数選択 (空なら calendarIdsForAvailability=null)
+
+## 7. エラー処理
+
+新規ロジック (calendar 絞込・event skip) は副作用のないシンプルな分岐のため、追加のエラーパスは発生しない。既存実装のエラー処理 (二重予約防止の 409 / event 作成失敗時のログ ([MAIL-FAIL]) / メール送信失敗時のフォールバック) はそのまま維持する。
+
+## 8. テスト戦略
+
+### 8.1 Acceptance Criteria
+
+| AC   | 内容                                                                                                                                | 検証方法                                            |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| AC-1 | `autoCreateCalendarEvent: false` の link で予約成立時、`adapter.createEvent` が呼ばれない                                           | unit test (mock adapter)                            |
+| AC-2 | `calendarIdsForAvailability: ['x']` の link で `/slots` 取得時、events が `x` カレンダーのみから取られる                            | unit test (mock adapter.listCalendars + listEvents) |
+| AC-3 | `autoCreateCalendarEvent` が undefined の既存 link で予約成立時、`createEvent` が呼ばれる (既存挙動の維持)                          | unit test                                           |
+| AC-4 | `calendarIdsForAvailability` が undefined の既存 link で `/slots` 取得時、すべてのカレンダーから events が取られる (既存挙動の維持) | unit test                                           |
+| AC-5 | `autoCreateCalendarEvent: true` で `calendarIdForEvent` を null で作成しようとすると 400 エラー                                     | unit test (POST `/`)                                |
+| AC-6 | 本田様用 link (60 分 / 全曜日 / 8-23 時) で `yasushi.honda@aozora-cg.com` の空き時間が枠として表示される                            | 手動確認 (dev server)                               |
+| AC-7 | 予約成立で `hy.unimail.11@gmail.com` に通知メールが届く                                                                             | 手動確認                                            |
+| AC-8 | 予約成立で `yasushi.honda@aozora-cg.com` の Google Calendar には event が追加されない                                               | 手動確認 (Google Calendar 画面)                     |
+
+### 8.2 既存テストへの影響
+
+| ファイル                                         | 影響                                                             |
+| ------------------------------------------------ | ---------------------------------------------------------------- |
+| `apps/api/src/__tests__/notifications.test.ts`   | 新規 flag を default 補完するため、既存ケースは無変更で通るはず  |
+| `apps/api/src/__tests__/adapter-factory.test.ts` | 影響なし                                                         |
+| `apps/api/src/__tests__/sync.test.ts`            | 影響なし                                                         |
+| 新規 test ファイル                               | `public-booking.test.ts` の追加を検討 (上記 AC-1〜AC-5 をカバー) |
+
+## 9. スコープ外 / 将来課題
+
+| 項目                                               | 理由                                                                                                                                            |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 独自ドメイン (`book.honda.work` 等) のセットアップ | 本田様の判断で「不要」とされた (Phase 5-3)                                                                                                      |
+| フロントエンドのデザイン刷新                       | Phase 5-4 で「既存デザインのまま進める (A スタート)」を決定。実物確認後に必要なら別仕様で実施                                                   |
+| spam 対策 (hCaptcha 等)                            | 本田様の要件にない (現状の Google 側にも明示的な spam 対策なし)                                                                                 |
+| メール通知の宛先カスタマイズ                       | 現状の `hy.unimail.11@gmail.com` 固定で十分 (本田様承認済)                                                                                      |
+| Google Calendar への双方向同期                     | 「インタラクティブな相互通信なし」の方針により対象外                                                                                            |
+| Google 予約スケジュールの完全な挙動再現            | Working Location / Working Hours / 不規則な時間帯ルール等は Calendar API では取得不可。`availableDays` + `dayStartHour`/`dayEndHour` で近似する |
+
+## 10. Open Questions
+
+実装フェーズで検証する前提条件:
+
+- [ ] `hy.unimail.11@gmail.com` が Calendar Hub に既にログイン済か (Firebase Auth に user document が存在するか)
+- [ ] `hy.unimail.11` の connected account から `yasushi.honda@aozora-cg.com` カレンダーが `calendarList.list()` で見えるか
+- [ ] 見えない場合、Google Workspace 側で `yasushi.honda@aozora-cg.com` カレンダーの共有設定が必要
+
+→ これらは dev server を立ち上げてログイン確認後に判明する。本設計の妥当性には影響しないが、本田様用 link の作成に必要な前提条件。
+
+## 11. 参考
+
+- 既存実装: `packages/shared/src/booking-types.ts` / `apps/api/src/routes/booking-links.ts` / `apps/api/src/routes/public-booking.ts` / `apps/web/src/app/book/[linkId]/book-content.tsx`
+- Phase 1 検証ログ: `https://calendar.app.google/qyKq3kU2sX9e2vid7` のリダイレクト先 `calendar.google.com/calendar/appointments/schedules/AcZssZ1...` を Playwright で取得し、X-Frame-Options: SAMEORIGIN と予約枠 DOM 構造を確認
+- 関連 ADR: ADR-002 (calendar-integration) / ADR-004 (auth-multi-account) / ADR-009 (timetree-session-management)

--- a/packages/shared/src/booking-types.ts
+++ b/packages/shared/src/booking-types.ts
@@ -21,8 +21,8 @@ export interface BookingLink {
   description?: string;
   durationMinutes: DurationOption;
   accountIds: string[];
-  calendarIdForEvent: string;
-  accountIdForEvent: string;
+  calendarIdForEvent: string | null;
+  accountIdForEvent: string | null;
   freeTimeOptions: BookingLinkFreeTimeOptions;
   availableDays: number[];
   rangeDays: number;
@@ -31,6 +31,8 @@ export interface BookingLink {
   expiresAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
+  autoCreateCalendarEvent: boolean;
+  calendarIdsForAvailability: string[] | null;
 }
 
 /** Public-safe subset — no ownerUid, accountIds, calendarId */
@@ -81,13 +83,15 @@ export interface CreateBookingLinkInput {
   description?: string;
   durationMinutes: DurationOption;
   accountIds: string[];
-  calendarIdForEvent: string;
-  accountIdForEvent: string;
+  calendarIdForEvent?: string | null;
+  accountIdForEvent?: string | null;
   freeTimeOptions?: Partial<BookingLinkFreeTimeOptions>;
   availableDays?: number[];
   rangeDays?: number;
   bufferMinutes?: number;
   expiresAt?: string | null;
+  autoCreateCalendarEvent?: boolean;
+  calendarIdsForAvailability?: string[] | null;
 }
 
 export interface CreateBookingInput {


### PR DESCRIPTION
## Summary
- Google Appointment Schedule (`calendar.app.google/qyKq3kU2sX9e2vid7`) の **read-only ミラー機能** を Calendar Hub に追加
- `BookingLink` に `autoCreateCalendarEvent` (default `true`) と `calendarIdsForAvailability` (default `null`) を追加
- 本田様用リンクは Google Calendar への event 自動作成を **OFF** + `yasushi.honda@aozora-cg.com` カレンダーのみ参照で動作

## 設計
詳細は `docs/specs/2026-06-24-booking-mirror-design.md` を参照。

## 変更内容
- 型 (`packages/shared/src/booking-types.ts`): 2 フィールド追加 + `calendarIdForEvent` / `accountIdForEvent` を nullable 化
- pure 関数 (`apps/api/src/lib/booking-link-utils.ts` 新規): default 補完 / Firestore→BookingLink 変換 / event 作成ガード / カレンダー絞込 / 不変条件検証 / PATCH update 構築
- API (`booking-links.ts` / `public-booking.ts`): バリデーション拡張・flag ゲート・カレンダー絞込
- UI (`new-link-content.tsx`): 「自動登録」「特定カレンダー絞込」のチェックボックス追加

## Test plan

### 自動テスト (実装時に PASS 確認済)
- [x] TypeScript 型チェック PASS (全 5 パッケージ)
- [x] Vitest 23 ファイル / **349 件 PASS** (新規 29 件追加: AC-1〜AC-5 + Partial Update 9 件)
- [x] Husky pre-commit (Lint + Prettier) PASS
- [x] dev server 起動・新規 endpoint への routing 到達確認

### 手動確認 (デプロイ後に本田様にお願いしたい項目)

#### 本田様用リンク作成
- [ ] `hy.unimail.11@gmail.com` で Calendar Hub にログイン
- [ ] Google connected account から `yasushi.honda@aozora-cg.com` カレンダーが見えることを確認 (見えない場合は Workspace 側で共有設定を確認)
- [ ] `/booking-links/new` で以下の設定でリンクを作成:
  - title: 「【本田】予約スケジュール」
  - description: 「ご相談・お打ち合わせのご予約はこちらから（60 分）」
  - 所要時間: **60 分**
  - 空き時間計算アカウント: Google (hy.unimail.11)
  - 「特定のカレンダーのみで空き時間を判定する」を **ON** → `yasushi.honda@aozora-cg.com` を選択
  - 「予約成立時に Google Calendar へ予定を自動登録する」を **OFF**
  - 受付曜日: 全曜日 / 受付時間: 08:00-23:00 / 公開日数: 30 日 / バッファ: なし

#### 公開ページでの動作確認 (AC-6/7/8)
- [ ] **AC-6**: 公開 URL `/book/<linkId>` を開いて、`yasushi.honda@aozora-cg.com` の空き時間が枠として表示されることを確認
- [ ] **AC-7**: テスト予約を 1 件作成 → `hy.unimail.11@gmail.com` に通知メールが届くことを確認
- [ ] **AC-8**: `yasushi.honda@aozora-cg.com` の Google Calendar に event が **追加されていない** ことを確認

#### 完了後
- [ ] テスト予約を管理画面からキャンセル
- [ ] PR をマージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Booking links can now optionally auto-create Google Calendar events when a reservation is made.
  * You can limit availability calculations to specific calendars when creating or editing a booking link.
  * Public booking pages now respect these calendar settings during slot search and booking.

* **Bug Fixes**
  * Improved handling of booking link settings so missing or empty calendar values no longer break booking flows.
  * Existing booking links continue to work with safe default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->