### PR TITLE
fix(email): nodemailer SMTP → Gmail API 移行で 535 認証エラー解消

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,12 +19,10 @@
     "firebase-admin": "^13.7.0",
     "googleapis": "^171.4.0",
     "hono": "^4.12.18",
-    "nanoid": "^5.1.7",
-    "nodemailer": "^8.0.5"
+    "nanoid": "^5.1.7"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
-    "@types/nodemailer": "^7.0.11",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0"
   }

--- a/apps/api/src/__tests__/email-send.test.ts
+++ b/apps/api/src/__tests__/email-send.test.ts
@@ -1,20 +1,37 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const sendMailMock = vi.fn();
-vi.mock('nodemailer', () => ({
-  default: {
-    createTransport: vi.fn(() => ({ sendMail: sendMailMock })),
-  },
-}));
+const sendMock = vi.fn();
+const setCredentialsMock = vi.fn();
+
+vi.mock('googleapis', () => {
+  class MockOAuth2 {
+    setCredentials(credentials: unknown) {
+      return setCredentialsMock(credentials);
+    }
+  }
+  return {
+    google: {
+      auth: { OAuth2: MockOAuth2 },
+      gmail: () => ({
+        users: {
+          messages: {
+            send: sendMock,
+          },
+        },
+      }),
+    },
+  };
+});
 
 // モック登録後に import する（vi.mock は hoisted だが、明示的に順序を示す）
 const { sendEmail } = await import('../lib/email.js');
 
-describe('sendEmail integration', () => {
+describe('sendEmail integration (Gmail API)', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    sendMailMock.mockReset();
+    sendMock.mockReset();
+    setCredentialsMock.mockReset();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
@@ -22,9 +39,12 @@ describe('sendEmail integration', () => {
     errorSpy.mockRestore();
   });
 
-  it('rethrows errors; with context it also emits [MAIL-FAIL]', async () => {
-    sendMailMock.mockRejectedValueOnce(
-      Object.assign(new Error('Invalid login: 535-5.7.8'), { responseCode: 535 }),
+  it('rethrows AUTH errors; with context it also emits [MAIL-FAIL] kind=AUTH', async () => {
+    // Gmail API の典型的な認証エラー (Gaxios 形状)
+    sendMock.mockRejectedValueOnce(
+      Object.assign(new Error('Request had invalid authentication credentials.'), {
+        response: { status: 401, data: {} },
+      }),
     );
 
     await expect(
@@ -37,7 +57,7 @@ describe('sendEmail integration', () => {
           context: 'owner-notification',
         },
       ),
-    ).rejects.toThrow(/Invalid login/);
+    ).rejects.toThrow(/invalid authentication credentials/);
 
     expect(errorSpy).toHaveBeenCalledTimes(1);
     const line = errorSpy.mock.calls[0][0];
@@ -48,7 +68,7 @@ describe('sendEmail integration', () => {
   });
 
   it('without context, rethrows but does NOT emit [MAIL-FAIL]', async () => {
-    sendMailMock.mockRejectedValueOnce(new Error('network down'));
+    sendMock.mockRejectedValueOnce(new Error('network down'));
 
     await expect(
       sendEmail(
@@ -60,15 +80,26 @@ describe('sendEmail integration', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
-  it('success path does not emit [MAIL-FAIL]', async () => {
-    sendMailMock.mockResolvedValueOnce({ messageId: 'm1' });
+  it('success path does not emit [MAIL-FAIL] and sends base64url-encoded raw message', async () => {
+    sendMock.mockResolvedValueOnce({ data: { id: 'm1' } });
 
     await sendEmail(
       { email: 'owner@example.com', accessToken: 'tok' },
-      { to: 'r@example.com', subject: 's', html: '<p>h</p>', context: 'test-notification' },
+      { to: 'r@example.com', subject: '件名', html: '<p>本文</p>', context: 'test-notification' },
     );
 
     expect(errorSpy).not.toHaveBeenCalled();
-    expect(sendMailMock).toHaveBeenCalledTimes(1);
+    expect(setCredentialsMock).toHaveBeenCalledWith({ access_token: 'tok' });
+    expect(sendMock).toHaveBeenCalledTimes(1);
+
+    const callArg = sendMock.mock.calls[0][0];
+    expect(callArg).toMatchObject({ userId: 'me' });
+    expect(callArg.requestBody.raw).toBeTruthy();
+    // base64url 形式: +/= が含まれない
+    expect(callArg.requestBody.raw).not.toMatch(/[+/=]/);
+    // raw を decode すると From / To が含まれる
+    const decoded = Buffer.from(callArg.requestBody.raw, 'base64url').toString('utf8');
+    expect(decoded).toContain('From: Calendar Hub <owner@example.com>');
+    expect(decoded).toContain('To: r@example.com');
   });
 });

--- a/apps/api/src/__tests__/mail-fail.test.ts
+++ b/apps/api/src/__tests__/mail-fail.test.ts
@@ -140,6 +140,42 @@ describe('logMailFailure', () => {
     expect(reasonPart.length).toBeLessThanOrEqual(203);
   });
 
+  it('classifies Gaxios-style { response: { status: 401 } } as AUTH (Gmail API)', () => {
+    const err = Object.assign(new Error('Request had invalid authentication credentials.'), {
+      response: { status: 401, data: {} },
+    });
+    expect(classifyMailError(err).kind).toBe('AUTH');
+    expect(classifyMailError(err).reason).toBe('http=401');
+  });
+
+  it('classifies Gaxios-style { response: { status: 403 } } as AUTH', () => {
+    const err = Object.assign(new Error('Insufficient permissions'), {
+      response: { status: 403, data: {} },
+    });
+    expect(classifyMailError(err).kind).toBe('AUTH');
+  });
+
+  it('classifies Gaxios-style { response: { status: 429 } } as TRANSIENT', () => {
+    const err = Object.assign(new Error('Rate limit exceeded'), {
+      response: { status: 429, data: {} },
+    });
+    expect(classifyMailError(err).kind).toBe('TRANSIENT');
+    expect(classifyMailError(err).reason).toBe('http=429');
+  });
+
+  it('classifies "invalid authentication credentials" message as AUTH (Gmail API)', () => {
+    const err = new Error(
+      'Request had invalid authentication credentials. Expected OAuth 2 access token.',
+    );
+    expect(classifyMailError(err).kind).toBe('AUTH');
+    expect(classifyMailError(err).reason).toBe('gmail_api_auth_rejected');
+  });
+
+  it('classifies "insufficient scope" message as AUTH (Gmail API)', () => {
+    const err = new Error('Request had insufficient authentication scopes.');
+    expect(classifyMailError(err).kind).toBe('AUTH');
+  });
+
   it('classifies synthetic Errors from booking-auth flow as UNKNOWN with useful reason', () => {
     const err1 = new Error('no_refresh_token_stored');
     logMailFailure({ context: 'booking-auth', recipient: 'o@example.com' }, err1);

--- a/apps/api/src/__tests__/notifications.test.ts
+++ b/apps/api/src/__tests__/notifications.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildSuggestionEmailHtml, buildTestEmailHtml } from '../lib/email.js';
+import { buildSuggestionEmailHtml, buildTestEmailHtml, buildMimeMessage } from '../lib/email.js';
 
 describe('buildSuggestionEmailHtml', () => {
   it('should generate HTML with suggestion details', () => {
@@ -79,5 +79,118 @@ describe('buildTestEmailHtml', () => {
     expect(html).toContain('テスト通知');
     expect(html).toContain('正常に設定されています');
     expect(html).toContain('送信日時');
+  });
+});
+
+describe('buildMimeMessage (Gmail API への RFC 2822 メッセージ構築)', () => {
+  it('Subject を RFC 2047 base64 encoded-word でエンコードする', () => {
+    const msg = buildMimeMessage({
+      from: 'sender@example.com',
+      to: 'recipient@example.com',
+      subject: '日本語件名',
+      html: '<p>hello</p>',
+    });
+    const expected = `=?UTF-8?B?${Buffer.from('日本語件名', 'utf8').toString('base64')}?=`;
+    expect(msg).toContain(`Subject: ${expected}`);
+  });
+
+  it('From ヘッダに "Calendar Hub <email>" 形式が含まれる', () => {
+    const msg = buildMimeMessage({
+      from: 'me@example.com',
+      to: 'you@example.com',
+      subject: 'test',
+      html: '<p>hi</p>',
+    });
+    expect(msg).toContain('From: Calendar Hub <me@example.com>');
+  });
+
+  it('To ヘッダが含まれる', () => {
+    const msg = buildMimeMessage({
+      from: 'a@example.com',
+      to: 'b@example.com',
+      subject: 't',
+      html: '<p></p>',
+    });
+    expect(msg).toContain('To: b@example.com');
+  });
+
+  it('MIME-Version: 1.0 が含まれる', () => {
+    const msg = buildMimeMessage({
+      from: 'a@example.com',
+      to: 'b@example.com',
+      subject: 't',
+      html: '<p></p>',
+    });
+    expect(msg).toContain('MIME-Version: 1.0');
+  });
+
+  it('html のみの場合は text/html charset=UTF-8 + base64 で body が encode される', () => {
+    const html = '<p>こんにちは</p>';
+    const msg = buildMimeMessage({
+      from: 'a@example.com',
+      to: 'b@example.com',
+      subject: 't',
+      html,
+    });
+    expect(msg).toContain('Content-Type: text/html; charset=UTF-8');
+    expect(msg).toContain('Content-Transfer-Encoding: base64');
+    expect(msg).toContain(Buffer.from(html, 'utf8').toString('base64'));
+  });
+
+  it('text + html の場合は multipart/alternative で構築され、両 body が base64 で含まれる', () => {
+    const text = 'プレーンテキスト本文';
+    const html = '<p>HTML 本文</p>';
+    const msg = buildMimeMessage({
+      from: 'a@example.com',
+      to: 'b@example.com',
+      subject: 't',
+      html,
+      text,
+    });
+    expect(msg).toMatch(/Content-Type: multipart\/alternative; boundary="boundary_[A-Za-z0-9]+"/);
+    expect(msg).toContain(Buffer.from(text, 'utf8').toString('base64'));
+    expect(msg).toContain(Buffer.from(html, 'utf8').toString('base64'));
+  });
+
+  it('ヘッダと body は CRLF (\\r\\n) で改行される (RFC 2822 準拠)', () => {
+    const msg = buildMimeMessage({
+      from: 'a@example.com',
+      to: 'b@example.com',
+      subject: 't',
+      html: '<p></p>',
+    });
+    expect(msg).toContain('\r\n');
+    expect(msg).not.toMatch(/[^\r]\n/);
+  });
+
+  it('日本語の件名と本文を正しく扱える', () => {
+    const subject = '【本田】予約スケジュール - 山田 太郎';
+    const html = '<p>こんにちは、世界！🌏</p>';
+    const msg = buildMimeMessage({
+      from: 'a@example.com',
+      to: 'b@example.com',
+      subject,
+      html,
+    });
+    expect(msg).toContain(`=?UTF-8?B?${Buffer.from(subject, 'utf8').toString('base64')}?=`);
+    expect(msg).toContain(Buffer.from(html, 'utf8').toString('base64'));
+  });
+
+  it('multipart の boundary は 1 つのメッセージ内で一意 (closing boundary --<b>-- が出現)', () => {
+    const msg = buildMimeMessage({
+      from: 'a@example.com',
+      to: 'b@example.com',
+      subject: 't',
+      html: '<p>h</p>',
+      text: 't',
+    });
+    const match = msg.match(/boundary="(boundary_[A-Za-z0-9]+)"/);
+    expect(match).not.toBeNull();
+    const boundary = match![1];
+    // 開く側 2 回 (text part / html part), 閉じる側 1 回
+    const openCount = (msg.match(new RegExp(`^--${boundary}$`, 'gm')) ?? []).length;
+    const closeCount = (msg.match(new RegExp(`^--${boundary}--$`, 'gm')) ?? []).length;
+    expect(openCount).toBe(2);
+    expect(closeCount).toBe(1);
   });
 });

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -1,4 +1,4 @@
-import nodemailer from 'nodemailer';
+import { google } from 'googleapis';
 import { logMailFailure } from './mail-fail.js';
 
 interface SendEmailOptions {
@@ -21,30 +21,93 @@ interface GmailAuth {
 }
 
 /**
- * Gmail OAuth2経由でメール送信
- * access_tokenはrefreshAccessToken()で事前に取得しておく
+ * RFC 2822 形式の MIME message を構築する pure 関数。
+ * 件名・本文は日本語を扱うため UTF-8 + base64 で encode する。
+ *
+ * - 件名: RFC 2047 encoded-word (`=?UTF-8?B?<base64>?=`)
+ * - 本文: `Content-Transfer-Encoding: base64`
+ * - text/html 両方ある場合は multipart/alternative
+ */
+export function buildMimeMessage(opts: {
+  from: string;
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}): string {
+  const subjectEncoded = `=?UTF-8?B?${Buffer.from(opts.subject, 'utf8').toString('base64')}?=`;
+  const fromHeader = `Calendar Hub <${opts.from}>`;
+
+  if (opts.text && opts.html) {
+    const boundary = `boundary_${Buffer.from(opts.subject + opts.to)
+      .toString('base64')
+      .replace(/[^A-Za-z0-9]/g, '')
+      .slice(0, 24)}`;
+    return [
+      `From: ${fromHeader}`,
+      `To: ${opts.to}`,
+      `Subject: ${subjectEncoded}`,
+      'MIME-Version: 1.0',
+      `Content-Type: multipart/alternative; boundary="${boundary}"`,
+      '',
+      `--${boundary}`,
+      'Content-Type: text/plain; charset=UTF-8',
+      'Content-Transfer-Encoding: base64',
+      '',
+      Buffer.from(opts.text, 'utf8').toString('base64'),
+      '',
+      `--${boundary}`,
+      'Content-Type: text/html; charset=UTF-8',
+      'Content-Transfer-Encoding: base64',
+      '',
+      Buffer.from(opts.html, 'utf8').toString('base64'),
+      '',
+      `--${boundary}--`,
+    ].join('\r\n');
+  }
+
+  return [
+    `From: ${fromHeader}`,
+    `To: ${opts.to}`,
+    `Subject: ${subjectEncoded}`,
+    'MIME-Version: 1.0',
+    'Content-Type: text/html; charset=UTF-8',
+    'Content-Transfer-Encoding: base64',
+    '',
+    Buffer.from(opts.html, 'utf8').toString('base64'),
+  ].join('\r\n');
+}
+
+/**
+ * Gmail API (users.messages.send) でメール送信。
+ * OAuth scope は `https://www.googleapis.com/auth/gmail.send` のみで動作する。
+ * (旧実装の nodemailer SMTP は `https://mail.google.com/` scope が必要だったため
+ *  535 認証エラーが発生していた。)
  */
 export async function sendEmail(auth: GmailAuth, options: SendEmailOptions): Promise<void> {
   try {
-    // createTransport も try 内に含める: OAuth2 config 検証等で synchronous に
-    // 例外が出るケースも `[MAIL-FAIL]` で捕捉するため。
-    const transporter = nodemailer.createTransport({
-      service: 'gmail',
-      auth: {
-        type: 'OAuth2',
-        user: auth.email,
-        accessToken: auth.accessToken,
-        clientId: process.env.GOOGLE_CLIENT_ID,
-        clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-      },
-    });
+    const oauth2Client = new google.auth.OAuth2();
+    oauth2Client.setCredentials({ access_token: auth.accessToken });
 
-    await transporter.sendMail({
-      from: `Calendar Hub <${auth.email}>`,
+    const gmail = google.gmail({ version: 'v1', auth: oauth2Client });
+
+    const message = buildMimeMessage({
+      from: auth.email,
       to: options.to,
       subject: options.subject,
       html: options.html,
       text: options.text,
+    });
+
+    const encodedMessage = Buffer.from(message, 'utf8')
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+
+    await gmail.users.messages.send({
+      userId: 'me',
+      requestBody: { raw: encodedMessage },
     });
   } catch (err) {
     if (options.context) {

--- a/apps/api/src/lib/mail-fail.ts
+++ b/apps/api/src/lib/mail-fail.ts
@@ -41,6 +41,7 @@ export function classifyMailError(err: unknown): MailFailClassification {
   const message = typeof e.message === 'string' ? e.message : '';
   const code = typeof e.code === 'string' ? e.code : '';
   const responseCode = typeof e.responseCode === 'number' ? e.responseCode : undefined;
+  const responseStatus = readResponseStatus(e);
   const oauthError = readOAuthErrorField(e);
 
   // AUTH 判定
@@ -50,19 +51,35 @@ export function classifyMailError(err: unknown): MailFailClassification {
   if (responseCode === 401 || responseCode === 403) {
     return { kind: 'AUTH', reason: `http=${responseCode}` };
   }
+  if (responseStatus === 401 || responseStatus === 403) {
+    return { kind: 'AUTH', reason: `http=${responseStatus}` };
+  }
   if (/\b535-5\.7\.\d\b|Invalid login|Username and Password not accepted/i.test(message)) {
     return { kind: 'AUTH', reason: 'smtp_auth_rejected' };
+  }
+  // Gmail API: scope 不足 / 認証情報不正の典型メッセージ
+  if (/invalid authentication credentials|insufficient.+scope/i.test(message)) {
+    return { kind: 'AUTH', reason: 'gmail_api_auth_rejected' };
   }
 
   // TRANSIENT 判定
   if (responseCode === 429 || responseCode === 503 || responseCode === 504) {
     return { kind: 'TRANSIENT', reason: `http=${responseCode}` };
   }
+  if (responseStatus === 429 || responseStatus === 503 || responseStatus === 504) {
+    return { kind: 'TRANSIENT', reason: `http=${responseStatus}` };
+  }
   if (code === 'ETIMEDOUT' || code === 'ECONNRESET' || code === 'ECONNREFUSED') {
     return { kind: 'TRANSIENT', reason: `code=${code}` };
   }
 
   return { kind: 'UNKNOWN', reason: message || 'no-message' };
+}
+
+function readResponseStatus(e: Record<string, unknown>): number | undefined {
+  const response = e.response as { status?: unknown } | undefined;
+  if (typeof response?.status === 'number') return response.status;
+  return undefined;
 }
 
 function readOAuthErrorField(e: Record<string, unknown>): string | undefined {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,16 +81,10 @@ importers:
       nanoid:
         specifier: ^5.1.7
         version: 5.1.7
-      nodemailer:
-        specifier: ^8.0.5
-        version: 8.0.5
     devDependencies:
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
-      '@types/nodemailer':
-        specifier: ^7.0.11
-        version: 7.0.11
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -1095,9 +1089,6 @@ packages:
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
-
-  '@types/nodemailer@7.0.11':
-    resolution: {integrity: sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -2152,10 +2143,6 @@ packages:
   node-forge@1.4.0:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
-
-  nodemailer@8.0.5:
-    resolution: {integrity: sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==}
-    engines: {node: '>=6.0.0'}
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -3612,10 +3599,6 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@types/nodemailer@7.0.11':
-    dependencies:
-      '@types/node': 25.5.0
-
   '@types/prop-types@15.7.15': {}
 
   '@types/react-big-calendar@1.16.3':
@@ -4824,8 +4807,6 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-forge@1.4.0: {}
-
-  nodemailer@8.0.5: {}
 
   npm-run-path@5.3.0:
     dependencies:


### PR DESCRIPTION
## Summary
PR #138 マージ後、本番で `[MAIL-FAIL] kind=AUTH reason=smtp_auth_rejected` (535-5.7.8 Username and Password not accepted) が発生し、予約成立時のオーナー通知メールが届かない状態。

**原因**: 実装と OAuth scope の不一致
- 実装: `nodemailer` SMTP via OAuth2 (Gmail SMTP は `https://mail.google.com/` scope が必要)
- 現状の scope: `gmail.send` (Gmail **API** 用、SMTP には不足)

**修正**: 実装を Gmail API (`gmail.users.messages.send`) に切り替え。既存の `gmail.send` scope のまま動作。**再認証不要**。

## 影響範囲
本田様の本日のテスト予約 (PR #138 動作確認時) のオーナー通知も含む、Calendar Hub の **全メール送信機能**:
- 予約成立時のオーナー通知 (`owner-notification`)
- 予約成立時のゲスト確認メール (`guest-confirmation`)
- AI スケジュール提案メール (`ai-suggestion`)
- テスト通知メール (`test-notification`)

すべて本 fix で動作するようになる想定。

## 変更内容
| ファイル | 変更 |
|---|---|
| `apps/api/src/lib/email.ts` | nodemailer → googleapis。RFC 2822 MIME 構築を `buildMimeMessage` (pure 関数) に分離 |
| `apps/api/src/lib/mail-fail.ts` | Gaxios `response.status` と Gmail API 典型メッセージ ("invalid authentication credentials" / "insufficient scope") の AUTH/TRANSIENT 分類追加 |
| `apps/api/src/__tests__/email-send.test.ts` | nodemailer mock → googleapis mock。base64url raw payload と `setCredentials` 呼出を verify |
| `apps/api/src/__tests__/mail-fail.test.ts` | Gaxios エラー形状 / Gmail API メッセージの分類テスト 5 件追加 |
| `apps/api/src/__tests__/notifications.test.ts` | `buildMimeMessage` の単体テスト 9 件追加 (RFC 2047 件名 / multipart boundary / 日本語 / CRLF 等) |
| `apps/api/package.json` / `pnpm-lock.yaml` | 不要になった `nodemailer` / `@types/nodemailer` を削除 |

## 設計判断: なぜ Gmail API を選んだか
| 案 | 評価 |
|---|---|
| **A. Gmail API (本 PR)** ◎ | 既存 `gmail.send` scope のまま。再認証不要。実装変更のみ |
| B. SMTP scope を `https://mail.google.com/` に拡大 | 全ユーザーの再認証必要 + scope 拡大 (全メール読み取り権限を含む) |

## Test plan

### 自動テスト
- [x] TypeScript 型チェック: 全パッケージ PASS
- [x] Vitest: 12 ファイル / 203 件 PASS (新規 14 件)
- [x] Husky pre-commit (Lint + Prettier): PASS

### 手動確認 (デプロイ後)
- [ ] 本田様用予約リンクで再度テスト予約 → `hy.unimail.11@gmail.com` 受信箱に「新しい予約: 【本田】予約スケジュール」メールが届く
- [ ] Cloud Run ログで `[MAIL-FAIL] kind=AUTH` が出ないこと
- [ ] AI 提案メール / テスト通知メール (`/api/notifications/test`) も同様に届くこと
- [ ] テスト予約をキャンセル

## 関連 PR / Issue
- 設計文書: PR #138 (`docs/specs/2026-06-24-booking-mirror-design.md`)
- 本番ログ証拠: `[MAIL-FAIL] context=owner-notification recipient=***@gmail.com kind=AUTH reason=smtp_auth_rejected` (2026-06-24T20:33:04Z, calendar-hub-api revision 00082-sqp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)