### PR TITLE
fix(email): 予約通知メールの日時表記から秒を削除 (12:00:00 → 12:00)

### DIFF
--- a/apps/api/src/__tests__/notifications.test.ts
+++ b/apps/api/src/__tests__/notifications.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { buildSuggestionEmailHtml, buildTestEmailHtml, buildMimeMessage } from '../lib/email.js';
+import {
+  buildSuggestionEmailHtml,
+  buildTestEmailHtml,
+  buildMimeMessage,
+  buildBookingNotificationHtml,
+  buildBookingConfirmationHtml,
+  formatJstDateTime,
+  formatJstTime,
+} from '../lib/email.js';
 
 describe('buildSuggestionEmailHtml', () => {
   it('should generate HTML with suggestion details', () => {
@@ -192,5 +200,100 @@ describe('buildMimeMessage (Gmail API への RFC 2822 メッセージ構築)', (
     const closeCount = (msg.match(new RegExp(`^--${boundary}--$`, 'gm')) ?? []).length;
     expect(openCount).toBe(2);
     expect(closeCount).toBe(1);
+  });
+});
+
+describe('formatJstDateTime', () => {
+  it('JST 12:00 (UTC 03:00) を秒なしで整形する', () => {
+    // 2026-06-28T03:00:00Z = JST 2026-06-28 12:00
+    const d = new Date('2026-06-28T03:00:00Z');
+    expect(formatJstDateTime(d)).toBe('2026/6/28 12:00');
+  });
+
+  it('UTC が日付境界をまたいでも JST に変換される', () => {
+    // UTC 2026-06-27T15:30:00Z = JST 2026-06-28 00:30
+    const d = new Date('2026-06-27T15:30:00Z');
+    expect(formatJstDateTime(d)).toBe('2026/6/28 00:30');
+  });
+
+  it('秒の情報は出力に含まれない (本田様報告 12:00:00 → 12:00 の修正)', () => {
+    const d = new Date('2026-06-28T03:00:42Z');
+    const out = formatJstDateTime(d);
+    expect(out).not.toMatch(/:\d{2}:\d{2}/); // HH:MM:SS パターンが残らない
+    expect(out).toMatch(/\d+:\d{2}$/); // 末尾は HH:MM
+  });
+});
+
+describe('formatJstTime', () => {
+  it('時分のみを返す (時間レンジの終端用)', () => {
+    const d = new Date('2026-06-28T04:00:00Z'); // JST 13:00
+    expect(formatJstTime(d)).toBe('13:00');
+  });
+
+  it('秒は含まれない', () => {
+    const d = new Date('2026-06-28T04:00:55Z');
+    expect(formatJstTime(d)).toBe('13:00');
+  });
+});
+
+describe('buildBookingNotificationHtml (オーナー向け)', () => {
+  it('日時表記が "YYYY/M/D HH:MM 〜 HH:MM" 形式 (秒なし)', () => {
+    const html = buildBookingNotificationHtml({
+      linkTitle: '【本田】予約スケジュール',
+      guestName: '山田 太郎',
+      slotStart: new Date('2026-06-28T03:00:00Z'), // JST 12:00
+      slotEnd: new Date('2026-06-28T04:00:00Z'), // JST 13:00
+    });
+    expect(html).toContain('2026/6/28 12:00 〜 13:00');
+    expect(html).not.toContain('12:00:00'); // 本田様報告のリグレッション防止
+  });
+
+  it('guestEmail があれば mailto リンクが含まれる', () => {
+    const html = buildBookingNotificationHtml({
+      linkTitle: 'タイトル',
+      guestName: 'ゲスト',
+      guestEmail: 'guest@example.com',
+      slotStart: new Date('2026-06-28T03:00:00Z'),
+      slotEnd: new Date('2026-06-28T04:00:00Z'),
+    });
+    expect(html).toContain('mailto:guest@example.com');
+  });
+
+  it('guestMessage を含む', () => {
+    const html = buildBookingNotificationHtml({
+      linkTitle: 't',
+      guestName: 'g',
+      guestMessage: '備考メモ',
+      slotStart: new Date('2026-06-28T03:00:00Z'),
+      slotEnd: new Date('2026-06-28T04:00:00Z'),
+    });
+    expect(html).toContain('備考メモ');
+  });
+});
+
+describe('buildBookingConfirmationHtml (ゲスト向け)', () => {
+  it('日時表記が "YYYY/M/D HH:MM 〜 HH:MM" 形式 (秒なし)', () => {
+    const html = buildBookingConfirmationHtml({
+      linkTitle: 't',
+      ownerDisplayName: '本田',
+      guestName: '山田',
+      slotStart: new Date('2026-06-28T03:00:00Z'),
+      slotEnd: new Date('2026-06-28T04:00:00Z'),
+      durationMinutes: 60,
+    });
+    expect(html).toContain('2026/6/28 12:00 〜 13:00');
+    expect(html).not.toContain('12:00:00');
+  });
+
+  it('所要時間 (分) が含まれる', () => {
+    const html = buildBookingConfirmationHtml({
+      linkTitle: 't',
+      ownerDisplayName: '本田',
+      guestName: '山田',
+      slotStart: new Date('2026-06-28T03:00:00Z'),
+      slotEnd: new Date('2026-06-28T04:00:00Z'),
+      durationMinutes: 60,
+    });
+    expect(html).toContain('60分');
   });
 });

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -118,6 +118,33 @@ export async function sendEmail(auth: GmailAuth, options: SendEmailOptions): Pro
 }
 
 /**
+ * 予約通知メールで使う JST 日時フォーマット (秒なし)。
+ * 例: `2026/6/28 12:00`
+ */
+export function formatJstDateTime(date: Date): string {
+  return date.toLocaleString('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * 同上、時分のみ (時間レンジの終端表記用)。
+ * 例: `13:00`
+ */
+export function formatJstTime(date: Date): string {
+  return date.toLocaleString('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
  * AI提案通知メールのHTML生成
  */
 export function buildSuggestionEmailHtml(
@@ -190,12 +217,8 @@ export function buildBookingNotificationHtml(params: {
   slotEnd: Date;
 }): string {
   const { linkTitle, guestName, guestEmail, guestMessage, slotStart, slotEnd } = params;
-  const startStr = slotStart.toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' });
-  const endStr = slotEnd.toLocaleString('ja-JP', {
-    timeZone: 'Asia/Tokyo',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  const startStr = formatJstDateTime(slotStart);
+  const endStr = formatJstTime(slotEnd);
 
   const guestEmailHtml = guestEmail
     ? `<p style="margin:4px 0;font-size:14px;">メール: <a href="mailto:${escapeHtml(guestEmail)}">${escapeHtml(guestEmail)}</a></p>`
@@ -236,12 +259,8 @@ export function buildBookingConfirmationHtml(params: {
   durationMinutes: number;
 }): string {
   const { linkTitle, ownerDisplayName, guestName, slotStart, slotEnd, durationMinutes } = params;
-  const startStr = slotStart.toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' });
-  const endStr = slotEnd.toLocaleString('ja-JP', {
-    timeZone: 'Asia/Tokyo',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  const startStr = formatJstDateTime(slotStart);
+  const endStr = formatJstTime(slotEnd);
 
   return `
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
PR #139 マージ後の実機確認で、予約通知メールの日時表記が `2026/6/28 12:00:00 〜 13:00` のように開始時刻にだけ秒が含まれていた (本田様報告)。`buildBookingNotificationHtml` / `buildBookingConfirmationHtml` の `startStr` が `toLocaleString` のオプション未指定でデフォルト形式 (秒含む) になっていたのが原因。

`formatJstDateTime` / `formatJstTime` helper を抽出して両 builder で共通利用、表記を `YYYY/M/D HH:MM` に統一しました。

## 変更内容
| ファイル | 変更 |
|---|---|
| `apps/api/src/lib/email.ts` | `formatJstDateTime` / `formatJstTime` を新設、両 booking builder で利用 |
| `apps/api/src/__tests__/notifications.test.ts` | 各 formatter + 両 booking builder のテスト合計 **9 件追加** (リグレッション防止に `12:00:00` が含まれないことを明示的に assert) |

## Test plan
- [x] TypeScript 型チェック: 全パッケージ PASS
- [x] Vitest: 18 ファイル / 305 件 PASS
- [x] Husky pre-commit: PASS
- [ ] デプロイ後、本田様の予約リンクで再度テスト予約 → 通知メールが `12:00 〜 13:00` 形式で届くこと

## 関連
- PR #138 (read-only ミラー機能)
- PR #139 (Gmail API 移行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)