### PR TITLE
feat(booking): 公開予約ページに空き枠ポーリングを追加 (60s)

### DIFF
--- a/apps/web/src/app/book/[linkId]/book-content.tsx
+++ b/apps/web/src/app/book/[linkId]/book-content.tsx
@@ -68,6 +68,55 @@ export function BookContent() {
     })();
   }, [linkId]);
 
+  // 空き枠ポーリング: 選択画面で開きっぱなしの間、最新化する
+  const refreshSlots = useCallback(async () => {
+    if (!linkId) return;
+    try {
+      const slotsRes = await publicGet<SlotsResponse>(`/api/public/booking/${linkId}/slots`);
+      setSlots(slotsRes.slots);
+    } catch {
+      // ポーリングは silent（次回再試行で復旧）
+    }
+  }, [linkId]);
+
+  useEffect(() => {
+    if (step !== 'select' || !linkId) return;
+
+    const POLL_INTERVAL_MS = 60_000;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const start = () => {
+      if (intervalId !== null) return;
+      intervalId = setInterval(refreshSlots, POLL_INTERVAL_MS);
+    };
+    const stop = () => {
+      if (intervalId === null) return;
+      clearInterval(intervalId);
+      intervalId = null;
+    };
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        refreshSlots();
+        start();
+      } else {
+        stop();
+      }
+    };
+    const handleFocus = () => {
+      refreshSlots();
+    };
+
+    if (document.visibilityState === 'visible') start();
+    document.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('focus', handleFocus);
+
+    return () => {
+      stop();
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, [step, linkId, refreshSlots]);
+
   // 日付別グルーピング
   const dateGroups = useMemo(() => {
     const groups: Record<string, BookingSlot[]> = {};


### PR DESCRIPTION
## Summary
- 公開予約ページ `/book/<linkId>` を開きっぱなしの間、最新の空き枠が反映されない問題への対応
- 選択画面（`step='select'`）中のみ **60s 間隔**で `/api/public/booking/<linkId>/slots` を再取得
- `visibilitychange` で **バックグラウンドタブ時は停止**、表示復帰で即時 fetch + ポーリング再開
- `focus` イベントで **タブ復帰時に即時 fetch**（鮮度を担保）
- フォーム入力中 (`step='form'`) ・予約完了後 (`step='confirmed'`) はポーリング停止（入力中に選択枠が消えるのを防止）

## 設計判断
| パラメータ | 値 | 理由 |
|---|---|---|
| 間隔 | 60s | 予約者の通常滞在は数分〜10分。表示と実態のズレを 1 分以内に収め、Google API quota も 1 セッション 10 回程度で軽い |
| 可視性 | 非表示で停止 | Cloud Run min-instance 0 を起こし続けないため |
| フォーカス | 即時 fetch | タブ戻り直後の鮮度を最優先 |

## 二重予約の最終防御
ポーリングはあくまで UX 改善で、二重予約の最終防御は POST 時の Firestore transaction（`public-booking.ts:270-300`）。表示中に枠が取られた場合は POST が 409 で弾かれる従来の挙動が維持される。

## 変更内容
- `apps/web/src/app/book/[linkId]/book-content.tsx` (+49 行 / -0 行)
  - `refreshSlots` を `useCallback` で切り出し（サイレント失敗、次回 fetch で復旧）
  - `step`/`linkId`/`refreshSlots` を依存配列に持つポーリング用 `useEffect` を追加

## Test plan

### 自動テスト（実装時 PASS 確認済）
- [x] TypeScript 型チェック PASS（`pnpm --filter @calendar-hub/web type-check`）
- [x] ESLint PASS（`pnpm --filter @calendar-hub/web lint`）
- [x] Vitest 18 ファイル / 305 件 PASS
- [x] Husky pre-commit (ESLint + Prettier) PASS

### 手動確認（デプロイ後）
- [ ] `/book/<linkId>` を開いて 60s 後にネットワークタブで `/slots` への 2 回目リクエストが飛ぶことを確認
- [ ] タブを別タブに切り替え → 戻すと即座に `/slots` リクエストが飛ぶことを確認
- [ ] フォーム入力画面 (`step='form'`) に進んだら新しい `/slots` リクエストが飛ばないことを確認
- [ ] バックグラウンドタブにしている間、`/slots` リクエストが飛ばないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)