### PR TITLE
chore: registry を registry.npmjs.org に明示 (Dependabot proxy ノイズ回避)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary
- root に \`.npmrc\` を追加し registry を \`https://registry.npmjs.org/\` に明示
- Dependabot proxy の \`automatic-github-packages-auth\` experiment による \`npm.pkg.github.com\` 自動 credential 注入を回避し、PR #137/#134 マージ前に発生していた 6 件の Dependabot Updates failure (form-data / tar / js-yaml / ws / hono / turbo) の再発を予防

## 背景
PR #137/#134 マージ前、main で Dependabot Updates が 6 件連続 failure。エラー内容:

\`\`\`
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @types/react@^19.0.0
while fetching it from https://npm.pkg.github.com/
The latest release of @types/react is "17.0.39".
\`\`\`

真因: Dependabot job が \`automatic-github-packages-auth: true\` experiment で \`npm.pkg.github.com\` を npm registry credential に自動追加 → pnpm がそこから React 19 系 type を取り (Internal GitHub Packages mirror は React 17 までしか公開していない) → recreate / rebase に失敗。

## 公式仕様による制約
- \`.github/dependabot.yml\` の \`registries:\` block で npm 用に \`type: npm-registry\` を明示する案 (オプション 2) は **公式仕様で token 必須**、public registry に token を渡せない設計のため不可 (dependabot/dependabot-core#10258 が open のまま)
- 代わりに \`.npmrc\` で registry を明示する方法を採用 (dependabot/dependabot-core#8242 の PR #8330 以降 \`.npmrc\` が respect される設計)

## 副作用
- 既存挙動: pnpm/npm はデフォルトで \`registry.npmjs.org\` を見ているため、local/CI の挙動変化なし
- \`pnpm install\` 実行確認: lockfile 変更なし

## Test plan
- [x] \`pnpm install\` が lockfile を変更せずに完了
- [ ] マージ後、Dependabot Updates の次回 run で 6 件 failure が再発しないこと
- [ ] (検証手段) Dependabot tab で \"Last checked\" 更新を確認、または GH UI で recreate 手動 trigger

## 参考
- dependabot/dependabot-core#10258 (npm-registry type で token 必須の制約)
- dependabot/dependabot-core#8242 (pnpm が registry config を respect しない問題、PR #8330 で fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Set the package manager to use the official npm registry by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->