### PR TITLE
feat(monitoring): Issue #79 TimeTree session expired alert (Future Work 実装)

### DIFF
--- a/docs/adr/009-timetree-session-management.md
+++ b/docs/adr/009-timetree-session-management.md
@@ -68,12 +68,19 @@ session 切れが検出された場合のユーザー対応フロー:
 - 自動再ログインは依然不可能（password 永続化しない設計の延長）
 - ユーザーには 14 日ごとの再連携が暗黙的に必要
 
+## 実装済み (本 ADR の後続作業)
+
+- ✅ ログベースメトリクス `calendar_hub_tt_session_expired` 作成 (PR #150、`infra/setup-monitoring.sh`)
+- ✅ アラートポリシー `[Calendar Hub] TimeTree session expired (24h ≥ 3)` (`infra/alert-policies/tt-session-expired.yaml`)
+  - **スコープ調整**: プロジェクト全体で 24h 内 3 件以上で発報。ADR 当初案の「単一ユーザー」識別は現状ログ (`timetree.ts:91/103`) に userId/accountId が含まれないため将来課題 (下記 Future Work)
+
 ## Future Work
 
-- ログベースメトリクス（`logging.googleapis.com/user/timetree_session_expired`）作成
-- アラートポリシー: 単一ユーザーで 24h 以内に `[TT-SESSION-EXPIRED]` 連続発生 → 通知
-- Web UI の連携アカウント設定画面で **session 残日数バッジ**表示（`expiresAt` を Firestore に保存して算出）
-- session 切れ通知メール（任意機能）
+- 単一ユーザー (accountId) 単位の `[TT-SESSION-EXPIRED]` グループ化 alert
+  - 前提: ログに `accountId=...` を追加 (`TimeTreeAdapter` constructor で accountId を受け取り、ログ出力に含める)
+  - 別 Issue 化候補 (本 ADR スコープ外、ログ schema 変更が必要)
+- Web UI の連携アカウント設定画面で **session 残日数バッジ**表示 (`expiresAt` を Firestore に保存して算出)
+- session 切れ通知メール (任意機能)
 
 ### 既存ロジックの強化候補（本 ADR スコープ外、将来検討）
 

--- a/infra/alert-policies/tt-session-expired.yaml
+++ b/infra/alert-policies/tt-session-expired.yaml
@@ -1,0 +1,28 @@
+displayName: '[Calendar Hub] TimeTree session expired (24h ≥ 3)'
+documentation:
+  content: |
+    TimeTree session (cookie) 切れが 24 時間以内に 3 件以上発生した。
+
+    対応:
+    1. Cloud Logging で `textPayload:"[TT-SESSION-EXPIRED]"` を検索し、reason (expiresAt/httpStatus) と URL を確認
+    2. ユーザーが Web アプリ「連携アカウント設定」画面で TimeTree を再連携する必要あり (ADR-009 §2 参照)
+    3. 連続発生がプロジェクト全体で複数アカウント横断なら、TimeTree 側 API 仕様変更の可能性も視野
+
+    補足: 個別ユーザー識別は現状ログに含まれていないため、本 alert はプロジェクト全体集計。
+    ユーザー単位の identification は ADR-009 Future Work の「session 残日数バッジ」実装と合わせて将来検討。
+  mimeType: text/markdown
+combiner: OR
+conditions:
+  - displayName: 'tt_session_expired >= 3 in 24h'
+    conditionThreshold:
+      filter: 'metric.type="logging.googleapis.com/user/calendar_hub_tt_session_expired" AND resource.type="cloud_run_revision"'
+      comparison: COMPARISON_GT
+      thresholdValue: 2
+      duration: 0s
+      aggregations:
+        - alignmentPeriod: 86400s
+          perSeriesAligner: ALIGN_SUM
+          crossSeriesReducer: REDUCE_SUM
+alertStrategy:
+  autoClose: 86400s
+enabled: true

--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -64,6 +64,11 @@ create_or_update_metric \
   "Count of [MAIL-FAIL] occurrences (Gmail OAuth2 send failure, #74)" \
   "${BASE_FILTER} AND textPayload:\"[MAIL-FAIL]\""
 
+create_or_update_metric \
+  "calendar_hub_tt_session_expired" \
+  "Count of [TT-SESSION-EXPIRED] occurrences (TimeTree cookie expired, #79)" \
+  "${BASE_FILTER} AND textPayload:\"[TT-SESSION-EXPIRED]\""
+
 # --- 2. Notification channel (email) ---
 
 # 既存のチャネルを検索。権限失敗を NOT_FOUND と取り違えて重複作成しないよう、
@@ -193,6 +198,7 @@ apply_policy "${SCRIPT_DIR}/alert-policies/mail-fail.yaml"
 apply_policy "${SCRIPT_DIR}/alert-policies/api-5xx-rate.yaml"
 apply_policy "${SCRIPT_DIR}/alert-policies/api-4xx-spike.yaml"
 apply_policy "${SCRIPT_DIR}/alert-policies/api-latency-p99.yaml"
+apply_policy "${SCRIPT_DIR}/alert-policies/tt-session-expired.yaml"
 
 echo ""
 echo "=== Monitoring setup complete ==="


### PR DESCRIPTION
## Summary

ADR-009 (2026-05-03 Accepted) の Future Work セクションで残作業として記載されていた「ログベースメトリクス + alert policy」を実装。本 PR で Issue #79 完了条件を全充足。

| Issue 完了条件 | 状態 |
|--------------|------|
| 期限切れ検知ログ + alert | ✅ 検知ログ既存 (`timetree.ts:91/103`) + 本 PR で alert 追加 |
| 再ログイン運用手順の ADR 化 | ✅ ADR-009 で既達成 (本 PR で実装済みマーク追加) |

## 変更内容

### 新規ファイル
- `infra/alert-policies/tt-session-expired.yaml`:
  - displayName: `[Calendar Hub] TimeTree session expired (24h ≥ 3)`
  - metric: `logging.googleapis.com/user/calendar_hub_tt_session_expired`
  - 閾値: 24h で 3 件以上発生時に発報 (1-2 件単発は通常運用範囲)
  - autoClose: 86400s

### 更新ファイル
- `infra/setup-monitoring.sh`: ログベースメトリクス + alert apply (既存パターン完全踏襲)
- `docs/adr/009-timetree-session-management.md`: Future Work を「実装済み」と「残作業」に分離

## スコープ調整 (重要)

ADR-009 Future Work の「**単一ユーザー**で 24h 以内に連続発生」は理想形だが、現状ログに `accountId` / `userId` が含まれない (`timetree.ts:91/103` 参照) ため、本 PR では**プロジェクト全体集計**で実装。

ユーザー単位グループ化はログ schema 変更 (TimeTreeAdapter constructor で accountId を受け取り、ログ出力に含める) が必要なため、ADR-009 Future Work 残課題として明示。別 Issue 化候補。

## 本番適用 (decision-maker 認可必須、本 PR スコープ外)

PR マージ後、以下を本田様が実行:

\`\`\`bash
bash infra/setup-monitoring.sh
\`\`\`

冪等、既存 metric/policy は update。通知先 email (`hy.unimail.11@gmail.com`) は既存チャネル流用、追加 verification 不要。

## Test plan

- [x] `bash -n infra/setup-monitoring.sh` で構文 OK
- [x] 新規 yaml が既存 `rrule-skip.yaml` と構造一致 (displayName / combiner / conditions / aggregations / alertStrategy)
- [x] ADR-009 Future Work セクションが「実装済み」「Future Work (残課題)」に正しく分離
- [ ] (PR マージ後) decision-maker が `bash infra/setup-monitoring.sh` 実行、`gcloud alpha monitoring policies list --project=calendar-hub-prod --filter='displayName:TimeTree session'` で新 policy 確認
- [ ] (将来) 実際に `[TT-SESSION-EXPIRED]` が 3 件発生した際に alert 発報を確認 (受動検証)

## Refs

- Closes #79
- ADR-009 (TimeTree session management) Future Work セクション

🤖 Generated with [Claude Code](https://claude.com/claude-code)