### PR TITLE
feat: ADR-009 Future Work — per-account TimeTree session expired alert

### DIFF
--- a/apps/api/src/lib/adapter-factory.ts
+++ b/apps/api/src/lib/adapter-factory.ts
@@ -40,7 +40,7 @@ export async function createAdapter(userId: string, accountId: string): Promise<
     if (!session.sessionId || !session.csrfToken) {
       throw new Error(`Incomplete TimeTree session for account: ${accountId}`);
     }
-    return new TimeTreeAdapter(session);
+    return new TimeTreeAdapter(session, { accountId });
   }
 
   throw new Error(`Unknown provider: ${provider}`);

--- a/docs/adr/009-timetree-session-management.md
+++ b/docs/adr/009-timetree-session-management.md
@@ -71,16 +71,22 @@ session 切れが検出された場合のユーザー対応フロー:
 ## 実装済み (本 ADR の後続作業)
 
 - ✅ ログベースメトリクス `calendar_hub_tt_session_expired` 作成 (PR #150、`infra/setup-monitoring.sh`)
-- ✅ アラートポリシー `[Calendar Hub] TimeTree session expired (24h ≥ 3)` (`infra/alert-policies/tt-session-expired.yaml`)
-  - **スコープ調整**: プロジェクト全体で 24h 内 3 件以上で発報。ADR 当初案の「単一ユーザー」識別は現状ログ (`timetree.ts:91/103`) に userId/accountId が含まれないため将来課題 (下記 Future Work)
+- ✅ アラートポリシー (`infra/alert-policies/tt-session-expired.yaml`)
+  - 初期実装 (PR #150): プロジェクト全体集計、24h 内 3 件以上で発報、displayName `(24h ≥ 3)`
+  - **per-account 化 (本 ADR Future Work 実装、後続 PR)**: ログに `accountId=...` を追加し、`metric.label.accountId` で groupBy。閾値を 1+/24h、displayName `(per account, 24h)` に変更
+- ✅ `TimeTreeAdapter` constructor の options object 化 (`{ accountId: string; reLoginFn?: TimeTreeReLoginFn }`)
+  - 設計判断: required `accountId` を後付けする際、第3引数に required を置くと TypeScript で `(s, reLoginFn?, accountId)` が型として破綻するため options object を採用。将来 `userId` / `logger` 追加時の拡張性も確保 (Codex review 指摘)
+- ✅ log-based metric への label extractor 後付け
+  - `labelExtractors.accountId: REGEXP_EXTRACT(textPayload, "accountId=([^ ]+)")` で抽出
+  - GCP 仕様: 既存ラベルは追加可能・削除/変更不可。本実装は新規ラベル追加のみで非破壊更新
+  - `setup-monitoring.sh` の `create_or_update_metric` を 4 引数化 (第4引数 `labels_yaml` で labelExtractors + metricDescriptor.labels を `--config-from-file` 経由で適用)
+- ✅ 旧 alert policy の冪等 cleanup
+  - displayName 変更を伴うため、`setup-monitoring.sh` に `cleanup_legacy_policy` 関数を追加。1 回目で旧 displayName `(24h ≥ 3)` を削除、2 回目以降は no-op
 
 ## Future Work
 
-- 単一ユーザー (accountId) 単位の `[TT-SESSION-EXPIRED]` グループ化 alert
-  - 前提: ログに `accountId=...` を追加 (`TimeTreeAdapter` constructor で accountId を受け取り、ログ出力に含める)
-  - 別 Issue 化候補 (本 ADR スコープ外、ログ schema 変更が必要)
 - Web UI の連携アカウント設定画面で **session 残日数バッジ**表示 (`expiresAt` を Firestore に保存して算出)
-- session 切れ通知メール (任意機能)
+- session 切れ通知メール (任意機能、admin 宛 alert からエンドユーザー直接通知への展開)
 
 ### 既存ロジックの強化候補（本 ADR スコープ外、将来検討）
 

--- a/infra/alert-policies/tt-session-expired.yaml
+++ b/infra/alert-policies/tt-session-expired.yaml
@@ -14,7 +14,7 @@ documentation:
     - 短時間に 3 件以上の accountId で本 alert が発火 → API 仕様変更チェック
     - 単一 accountId 単発なら通常の cookie 失効 (14 日経過)
 
-    補足: 本 alert は ADR-009 Future Work の per-account grouping 実装 (PR #79 後続)。
+    補足: 本 alert は ADR-009 Future Work の per-account grouping 実装 (Issue #79、PR #150 後続)。
     旧「プロジェクト全体集計 alert」は本 alert で置換済み。
   mimeType: text/markdown
 combiner: OR

--- a/infra/alert-policies/tt-session-expired.yaml
+++ b/infra/alert-policies/tt-session-expired.yaml
@@ -1,28 +1,36 @@
-displayName: '[Calendar Hub] TimeTree session expired (24h ≥ 3)'
+displayName: '[Calendar Hub] TimeTree session expired (per account, 24h)'
 documentation:
   content: |
-    TimeTree session (cookie) 切れが 24 時間以内に 3 件以上発生した。
+    特定の TimeTree 連携アカウントで session (cookie) 切れが 24 時間以内に 1 件以上発生した。
 
     対応:
-    1. Cloud Logging で `textPayload:"[TT-SESSION-EXPIRED]"` を検索し、reason (expiresAt/httpStatus) と URL を確認
-    2. ユーザーが Web アプリ「連携アカウント設定」画面で TimeTree を再連携する必要あり (ADR-009 §2 参照)
-    3. 連続発生がプロジェクト全体で複数アカウント横断なら、TimeTree 側 API 仕様変更の可能性も視野
+    1. アラート本文の `metric.label.accountId` (= `timetree_<id>`) で対象アカウントを特定
+    2. Cloud Logging で
+       `textPayload:"[TT-SESSION-EXPIRED]" AND textPayload:"accountId=<id>"`
+       を検索し、reason (expiresAt/httpStatus) と URL を確認
+    3. 当該ユーザーが Web アプリ「連携アカウント設定」画面で TimeTree を再連携する必要あり (ADR-009 §2 参照)
 
-    補足: 個別ユーザー識別は現状ログに含まれていないため、本 alert はプロジェクト全体集計。
-    ユーザー単位の identification は ADR-009 Future Work の「session 残日数バッジ」実装と合わせて将来検討。
+    複数 accountId で同時発火した場合は TimeTree 側 API 仕様変更を疑う:
+    - 短時間に 3 件以上の accountId で本 alert が発火 → API 仕様変更チェック
+    - 単一 accountId 単発なら通常の cookie 失効 (14 日経過)
+
+    補足: 本 alert は ADR-009 Future Work の per-account grouping 実装 (PR #79 後続)。
+    旧「プロジェクト全体集計 alert」は本 alert で置換済み。
   mimeType: text/markdown
 combiner: OR
 conditions:
-  - displayName: 'tt_session_expired >= 3 in 24h'
+  - displayName: 'tt_session_expired per account >= 1 in 24h'
     conditionThreshold:
       filter: 'metric.type="logging.googleapis.com/user/calendar_hub_tt_session_expired" AND resource.type="cloud_run_revision"'
       comparison: COMPARISON_GT
-      thresholdValue: 2
+      thresholdValue: 0
       duration: 0s
       aggregations:
         - alignmentPeriod: 86400s
           perSeriesAligner: ALIGN_SUM
           crossSeriesReducer: REDUCE_SUM
+          groupByFields:
+            - metric.label.accountId
 alertStrategy:
   autoClose: 86400s
 enabled: true

--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -54,10 +54,14 @@ create_or_update_metric() {
   local tmpfile
   tmpfile=$(mktemp)
   trap "rm -f '$tmpfile'" RETURN
+  # description は literal block scalar (|-) で記述し、YAML plain scalar の
+  # コメント解釈 (`,  #79` → comment) や flow indicator 誤解釈を回避。
+  # 既存ラベルは追加可・削除不可 (GCP 仕様、#79 Future Work 実装時に確認済み)。
   cat > "$tmpfile" <<EOF
 name: ${name}
-description: ${description}
-filter: |
+description: |-
+  ${description}
+filter: |-
   ${filter}
 ${labels_yaml}
 EOF

--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -26,19 +26,52 @@ create_or_update_metric() {
   local name="$1"
   local description="$2"
   local filter="$3"
+  # 第4引数: ユーザー定義ラベル YAML 断片 (任意)。
+  # 指定時は --config-from-file 経由で labelExtractors + metricDescriptor.labels を反映。
+  # 例: see calendar_hub_tt_session_expired below.
+  local labels_yaml="${4:-}"
+
+  if [ -z "$labels_yaml" ]; then
+    # Simple counter mode (既存 4 metrics)
+    if gcloud logging metrics describe "$name" --project="$PROJECT_ID" >/dev/null 2>&1; then
+      echo "Updating log metric: $name"
+      gcloud logging metrics update "$name" \
+        --project="$PROJECT_ID" \
+        --description="$description" \
+        --log-filter="$filter" --quiet
+    else
+      echo "Creating log metric: $name"
+      gcloud logging metrics create "$name" \
+        --project="$PROJECT_ID" \
+        --description="$description" \
+        --log-filter="$filter"
+    fi
+    return
+  fi
+
+  # Advanced mode: labelExtractors + custom labels via config file.
+  # GCP 仕様: 既存ラベルは削除/変更不可だが、追加は可能 (#79 Future Work 実装時に確認済み)。
+  local tmpfile
+  tmpfile=$(mktemp)
+  trap "rm -f '$tmpfile'" RETURN
+  cat > "$tmpfile" <<EOF
+name: ${name}
+description: ${description}
+filter: |
+  ${filter}
+${labels_yaml}
+EOF
 
   if gcloud logging metrics describe "$name" --project="$PROJECT_ID" >/dev/null 2>&1; then
-    echo "Updating log metric: $name"
+    echo "Updating log metric (with labels): $name"
     gcloud logging metrics update "$name" \
       --project="$PROJECT_ID" \
-      --description="$description" \
-      --log-filter="$filter" --quiet
+      --config-from-file="$tmpfile" --quiet
   else
-    echo "Creating log metric: $name"
+    echo "Creating log metric (with labels): $name"
     gcloud logging metrics create "$name" \
       --project="$PROJECT_ID" \
-      --description="$description" \
-      --log-filter="$filter"
+      --config-from-file="$tmpfile"
   fi
 }
 
@@ -66,8 +99,17 @@ create_or_update_metric \
 
 create_or_update_metric \
   "calendar_hub_tt_session_expired" \
-  "Count of [TT-SESSION-EXPIRED] occurrences (TimeTree cookie expired, #79)" \
-  "${BASE_FILTER} AND textPayload:\"[TT-SESSION-EXPIRED]\""
+  "Count of [TT-SESSION-EXPIRED] occurrences (TimeTree cookie expired, #79). accountId label enables per-account alert grouping (ADR-009 Future Work)." \
+  "${BASE_FILTER} AND textPayload:\"[TT-SESSION-EXPIRED]\"" \
+  'labelExtractors:
+  accountId: REGEXP_EXTRACT(textPayload, "accountId=([^ ]+)")
+metricDescriptor:
+  labels:
+  - key: accountId
+    valueType: STRING
+    description: TimeTree connected account identifier (timetree_<id>)
+  metricKind: DELTA
+  valueType: INT64'
 
 # --- 2. Notification channel (email) ---
 
@@ -190,6 +232,29 @@ apply_policy() {
       --policy-from-file="$tmpfile"
   fi
 }
+
+# 旧 displayName で残っているポリシーがあれば削除 (ADR-009 Future Work の rename 移行用、冪等)。
+# 1 回目の実行で旧ポリシーを掃除、2 回目以降は no-op (旧 displayName 不在で skip)。
+cleanup_legacy_policy() {
+  local legacy_name="$1"
+  local policies_out
+  if ! policies_out=$(gcloud alpha monitoring policies list \
+    --project="$PROJECT_ID" \
+    --format="csv[no-heading](name,displayName)" 2>&1); then
+    echo "WARN: failed to list policies for legacy cleanup; skipping: $legacy_name" >&2
+    return 0
+  fi
+  local legacy_id
+  legacy_id=$(echo "$policies_out" \
+    | awk -F, -v name="$legacy_name" '$2 == name {print $1; exit}')
+  if [ -n "$legacy_id" ]; then
+    echo "Deleting legacy policy: $legacy_name"
+    gcloud alpha monitoring policies delete "$legacy_id" \
+      --project="$PROJECT_ID" --quiet
+  fi
+}
+
+cleanup_legacy_policy "[Calendar Hub] TimeTree session expired (24h ≥ 3)"
 
 apply_policy "${SCRIPT_DIR}/alert-policies/rrule-skip.yaml"
 apply_policy "${SCRIPT_DIR}/alert-policies/sync-failed.yaml"

--- a/infra/setup-monitoring.sh
+++ b/infra/setup-monitoring.sh
@@ -50,13 +50,12 @@ create_or_update_metric() {
   fi
 
   # Advanced mode: labelExtractors + custom labels via config file.
-  # GCP 仕様: 既存ラベルは削除/変更不可だが、追加は可能 (#79 Future Work 実装時に確認済み)。
-  local tmpfile
+  # description / filter は literal block scalar (|-) で記述し、YAML plain scalar の
+  # コメント解釈 (`, #79` → comment) や flow indicator 誤解釈を回避。
+  # GCP 仕様: 既存ラベルは削除/変更不可だが、追加は可能 (Issue #79 Future Work 実装時に確認済み)。
+  local tmpfile rc
   tmpfile=$(mktemp)
-  trap "rm -f '$tmpfile'" RETURN
-  # description は literal block scalar (|-) で記述し、YAML plain scalar の
-  # コメント解釈 (`,  #79` → comment) や flow indicator 誤解釈を回避。
-  # 既存ラベルは追加可・削除不可 (GCP 仕様、#79 Future Work 実装時に確認済み)。
+  # trap RETURN は global 状態で他関数の return にも fire するため使わず、明示 cleanup する。
   cat > "$tmpfile" <<EOF
 name: ${name}
 description: |-
@@ -71,12 +70,16 @@ EOF
     gcloud logging metrics update "$name" \
       --project="$PROJECT_ID" \
       --config-from-file="$tmpfile" --quiet
+    rc=$?
   else
     echo "Creating log metric (with labels): $name"
     gcloud logging metrics create "$name" \
       --project="$PROJECT_ID" \
       --config-from-file="$tmpfile"
+    rc=$?
   fi
+  rm -f "$tmpfile"
+  return $rc
 }
 
 BASE_FILTER="resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${SERVICE_NAME}\""
@@ -239,14 +242,18 @@ apply_policy() {
 
 # 旧 displayName で残っているポリシーがあれば削除 (ADR-009 Future Work の rename 移行用、冪等)。
 # 1 回目の実行で旧ポリシーを掃除、2 回目以降は no-op (旧 displayName 不在で skip)。
+# list 失敗時は fail-hard: silent skip すると旧 policy + 新 policy が並存して
+# session 切れ 1 件で「全体集計 alert (3+ 旧)」と「per-account alert (1+ 新)」が
+# 二重発火するため。
 cleanup_legacy_policy() {
   local legacy_name="$1"
   local policies_out
   if ! policies_out=$(gcloud alpha monitoring policies list \
     --project="$PROJECT_ID" \
     --format="csv[no-heading](name,displayName)" 2>&1); then
-    echo "WARN: failed to list policies for legacy cleanup; skipping: $legacy_name" >&2
-    return 0
+    echo "ERROR: failed to list policies for legacy cleanup ($legacy_name):" >&2
+    echo "$policies_out" >&2
+    exit 1
   fi
   local legacy_id
   legacy_id=$(echo "$policies_out" \

--- a/packages/calendar-sdk/src/__tests__/timetree-adapter.test.ts
+++ b/packages/calendar-sdk/src/__tests__/timetree-adapter.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TimeTreeAdapter, normalizeAllDayEnd, type TimeTreeSession } from '../adapters/timetree.js';
 
+const TEST_ACCOUNT_ID = 'timetree_test_acc_001';
+
 // TimeTree内部APIのレスポンス型・パース検証（外部APIモック不要の単体テスト）
 
 describe('TimeTree response parsing', () => {
@@ -218,13 +220,14 @@ describe('TimeTreeAdapter session expiry observability', () => {
       fetchSpy = mockFetchSequence([{ status }]);
       vi.stubGlobal('fetch', fetchSpy);
 
-      const adapter = new TimeTreeAdapter(validSession);
+      const adapter = new TimeTreeAdapter(validSession, { accountId: TEST_ACCOUNT_ID });
       await expect(adapter.listCalendars()).rejects.toThrow(
         new RegExp(`TimeTree listCalendars failed: ${status}`),
       );
 
       const warned = warnSpy.mock.calls.flat().join(' ');
       expect(warned).toContain('[TT-SESSION-EXPIRED]');
+      expect(warned).toContain(`accountId=${TEST_ACCOUNT_ID}`);
       expect(warned).toContain('reason=httpStatus');
       expect(warned).toContain(`status=${status}`);
       expect(warned).toContain('reLoginAvailable=false');
@@ -235,11 +238,12 @@ describe('TimeTreeAdapter session expiry observability', () => {
     fetchSpy = mockFetchOk({ calendars: [] });
     vi.stubGlobal('fetch', fetchSpy);
 
-    const adapter = new TimeTreeAdapter(expiredSession);
+    const adapter = new TimeTreeAdapter(expiredSession, { accountId: TEST_ACCOUNT_ID });
     await adapter.listCalendars();
 
     const warned = warnSpy.mock.calls.flat().join(' ');
     expect(warned).toContain('[TT-SESSION-EXPIRED]');
+    expect(warned).toContain(`accountId=${TEST_ACCOUNT_ID}`);
     expect(warned).toContain('reason=expiresAt');
     expect(warned).toContain('reLoginAvailable=false');
   });
@@ -254,7 +258,7 @@ describe('TimeTreeAdapter session expiry observability', () => {
       expiresAt: Date.now() + 60 * 60 * 1000,
     });
 
-    const adapter = new TimeTreeAdapter(validSession, reLoginFn);
+    const adapter = new TimeTreeAdapter(validSession, { accountId: TEST_ACCOUNT_ID, reLoginFn });
     await adapter.listCalendars();
 
     const warned = warnSpy.mock.calls.flat().join(' ');
@@ -277,7 +281,7 @@ describe('TimeTreeAdapter session expiry observability', () => {
       expiresAt: Date.now() + 60 * 60 * 1000,
     });
 
-    const adapter = new TimeTreeAdapter(expiredSession, reLoginFn);
+    const adapter = new TimeTreeAdapter(expiredSession, { accountId: TEST_ACCOUNT_ID, reLoginFn });
     await adapter.listCalendars();
 
     const warned = warnSpy.mock.calls.flat().join(' ');
@@ -297,7 +301,7 @@ describe('TimeTreeAdapter session expiry observability', () => {
 
     const reLoginFn = vi.fn().mockRejectedValue(new Error('login server down'));
 
-    const adapter = new TimeTreeAdapter(validSession, reLoginFn);
+    const adapter = new TimeTreeAdapter(validSession, { accountId: TEST_ACCOUNT_ID, reLoginFn });
     await expect(adapter.listCalendars()).rejects.toThrow(/login server down/);
 
     const errored = errorSpy.mock.calls.flat().join(' ');
@@ -419,7 +423,7 @@ describe('TimeTreeAdapter.listEvents - 複数日終日の end 正規化', () => 
     } as Response);
     vi.stubGlobal('fetch', fetchSpy);
 
-    const adapter = new TimeTreeAdapter(validSession);
+    const adapter = new TimeTreeAdapter(validSession, { accountId: TEST_ACCOUNT_ID });
     const tMin = new Date('2026-04-01T00:00:00Z');
     const tMax = new Date('2026-06-01T00:00:00Z');
     const events = await adapter.listEvents('cal-1', tMin, tMax);
@@ -464,7 +468,7 @@ describe('TimeTreeAdapter.listEvents - 複数日終日の end 正規化', () => 
     } as Response);
     vi.stubGlobal('fetch', fetchSpy);
 
-    const adapter = new TimeTreeAdapter(validSession);
+    const adapter = new TimeTreeAdapter(validSession, { accountId: TEST_ACCOUNT_ID });
     const tMin = new Date('2026-04-01T00:00:00Z');
     const tMax = new Date('2026-06-01T00:00:00Z');
     const events = await adapter.listEvents('cal-1', tMin, tMax);
@@ -505,7 +509,7 @@ describe('TimeTreeAdapter.listEvents - 複数日終日の end 正規化', () => 
     } as Response);
     vi.stubGlobal('fetch', fetchSpy);
 
-    const adapter = new TimeTreeAdapter(validSession);
+    const adapter = new TimeTreeAdapter(validSession, { accountId: TEST_ACCOUNT_ID });
     const tMin = new Date('2026-04-01T00:00:00Z');
     const tMax = new Date('2026-06-01T00:00:00Z');
     const events = await adapter.listEvents('cal-1', tMin, tMax);
@@ -549,7 +553,7 @@ describe('TimeTreeAdapter.listEvents - 複数日終日の end 正規化', () => 
     } as Response);
     vi.stubGlobal('fetch', fetchSpy);
 
-    const adapter = new TimeTreeAdapter(validSession);
+    const adapter = new TimeTreeAdapter(validSession, { accountId: TEST_ACCOUNT_ID });
     // 修正前は raw end (= may3JstMs) > timeMin (= may3JstMs) が false で欠落していたケース
     const tMin = new Date(may3JstMs);
     const tMax = new Date('2026-06-01T00:00:00Z');
@@ -592,7 +596,7 @@ describe('TimeTreeAdapter.listEvents - 複数日終日の end 正規化', () => 
     } as Response);
     vi.stubGlobal('fetch', fetchSpy);
 
-    const adapter = new TimeTreeAdapter(validSession);
+    const adapter = new TimeTreeAdapter(validSession, { accountId: TEST_ACCOUNT_ID });
     const tMin = new Date('2026-04-01T00:00:00Z');
     const tMax = new Date('2026-06-01T00:00:00Z');
     const events = await adapter.listEvents('cal-1', tMin, tMax);

--- a/packages/calendar-sdk/src/__tests__/timetree-adapter.test.ts
+++ b/packages/calendar-sdk/src/__tests__/timetree-adapter.test.ts
@@ -167,6 +167,17 @@ describe('TimeTree login body format', () => {
   });
 });
 
+describe('TimeTreeAdapter constructor guard', () => {
+  it('should throw when options.accountId is empty string', () => {
+    const session: TimeTreeSession = {
+      sessionId: 'sid',
+      csrfToken: 'csrf',
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    };
+    expect(() => new TimeTreeAdapter(session, { accountId: '' })).toThrow(/accountId is required/);
+  });
+});
+
 describe('TimeTreeAdapter session expiry observability', () => {
   const validSession: TimeTreeSession = {
     sessionId: 'sid',
@@ -264,6 +275,7 @@ describe('TimeTreeAdapter session expiry observability', () => {
     const warned = warnSpy.mock.calls.flat().join(' ');
     const informed = infoSpy.mock.calls.flat().join(' ');
     expect(warned).toContain('[TT-SESSION-EXPIRED]');
+    expect(warned).toContain(`accountId=${TEST_ACCOUNT_ID}`);
     expect(warned).toContain('reLoginAvailable=true');
     expect(informed).toContain('[TT-SESSION-RELOGIN-ATTEMPT]');
     expect(informed).toContain('[TT-SESSION-RELOGIN-OK]');
@@ -287,6 +299,7 @@ describe('TimeTreeAdapter session expiry observability', () => {
     const warned = warnSpy.mock.calls.flat().join(' ');
     const informed = infoSpy.mock.calls.flat().join(' ');
     expect(warned).toContain('[TT-SESSION-EXPIRED]');
+    expect(warned).toContain(`accountId=${TEST_ACCOUNT_ID}`);
     expect(warned).toContain('reason=expiresAt');
     expect(warned).toContain('reLoginAvailable=true');
     expect(informed).toContain('[TT-SESSION-RELOGIN-ATTEMPT]');

--- a/packages/calendar-sdk/src/adapters/timetree.ts
+++ b/packages/calendar-sdk/src/adapters/timetree.ts
@@ -16,6 +16,14 @@ export interface TimeTreeSession {
 /** Session期限切れ時に再ログインするためのコールバック */
 export type TimeTreeReLoginFn = () => Promise<TimeTreeSession>;
 
+/** TimeTreeAdapter constructor options */
+export interface TimeTreeAdapterOptions {
+  /** 連携アカウントID (例: timetree_xxx)。session expired ログ出力時のグルーピングキー */
+  accountId: string;
+  /** Session期限切れ時に再ログインするためのコールバック */
+  reLoginFn?: TimeTreeReLoginFn;
+}
+
 interface TimeTreeRawEvent {
   id: string;
   title: string;
@@ -61,12 +69,14 @@ export class TimeTreeAdapter implements CalendarAdapter {
   private expiresAt: number;
   private headers: Record<string, string>;
   private reLoginFn?: TimeTreeReLoginFn;
+  private accountId: string;
 
-  constructor(session: TimeTreeSession, reLoginFn?: TimeTreeReLoginFn) {
+  constructor(session: TimeTreeSession, options: TimeTreeAdapterOptions) {
     this.sessionId = session.sessionId;
     this.csrfToken = session.csrfToken;
     this.expiresAt = session.expiresAt ?? Date.now() + 14 * 24 * 60 * 60 * 1000; // default 14 days
-    this.reLoginFn = reLoginFn;
+    this.reLoginFn = options.reLoginFn;
+    this.accountId = options.accountId;
     this.headers = this.buildHeaders(session);
   }
 
@@ -88,7 +98,7 @@ export class TimeTreeAdapter implements CalendarAdapter {
     // session期限切れチェック
     if (Date.now() > this.expiresAt) {
       console.warn(
-        `[TT-SESSION-EXPIRED] reason=expiresAt url=${url} expiresAt=${new Date(this.expiresAt).toISOString()} reLoginAvailable=${Boolean(this.reLoginFn)}`,
+        `[TT-SESSION-EXPIRED] accountId=${this.accountId} reason=expiresAt url=${url} expiresAt=${new Date(this.expiresAt).toISOString()} reLoginAvailable=${Boolean(this.reLoginFn)}`,
       );
       if (this.reLoginFn) {
         await this.refreshSession();
@@ -100,7 +110,7 @@ export class TimeTreeAdapter implements CalendarAdapter {
     // 401/403で再ログイン試行（1回のみ）
     if (res.status === 400 || res.status === 401 || res.status === 403) {
       console.warn(
-        `[TT-SESSION-EXPIRED] reason=httpStatus url=${url} status=${res.status} reLoginAvailable=${Boolean(this.reLoginFn)}`,
+        `[TT-SESSION-EXPIRED] accountId=${this.accountId} reason=httpStatus url=${url} status=${res.status} reLoginAvailable=${Boolean(this.reLoginFn)}`,
       );
       if (this.reLoginFn) {
         await this.refreshSession();

--- a/packages/calendar-sdk/src/adapters/timetree.ts
+++ b/packages/calendar-sdk/src/adapters/timetree.ts
@@ -72,6 +72,11 @@ export class TimeTreeAdapter implements CalendarAdapter {
   private accountId: string;
 
   constructor(session: TimeTreeSession, options: TimeTreeAdapterOptions) {
+    // 空文字 accountId は alert grouping を破壊するため early reject。
+    // 型は `string` で required だが、TS は空文字を弾けないため runtime guard が必要。
+    if (!options.accountId) {
+      throw new Error('TimeTreeAdapter: options.accountId is required (cannot be empty)');
+    }
     this.sessionId = session.sessionId;
     this.csrfToken = session.csrfToken;
     this.expiresAt = session.expiresAt ?? Date.now() + 14 * 24 * 60 * 60 * 1000; // default 14 days
@@ -216,7 +221,7 @@ export class TimeTreeAdapter implements CalendarAdapter {
         name: cal.name,
         description: cal.purpose || undefined,
         provider: 'timetree' as const,
-        accountId: '',
+        accountId: this.accountId,
       }));
   }
 


### PR DESCRIPTION
## Summary

ADR-009 Future Work の per-account alert grouping を実装。`[TT-SESSION-EXPIRED]` ログに `accountId` を埋め込み、log-based metric の label extractor で抽出、alert policy で `metric.label.accountId` 単位の groupBy + threshold 1+/24h に変更。

## 主な変更

### コード変更 (commit 1)
- `TimeTreeAdapter` constructor を options object に: `(session, { accountId, reLoginFn? })`
  - 設計判断: required `accountId` を後付け時、第3引数に required を置くと TS 的に破綻 (Codex review 指摘)
- `[TT-SESSION-EXPIRED]` ログ 2 箇所に `accountId=${this.accountId}` 挿入
- `adapter-factory.ts` 更新、unit test 10 件 + accountId assertion 2 件追加

### IaC 変更 (commit 2)
- `setup-monitoring.sh` の `create_or_update_metric` を 4 引数化 (labels_yaml 対応)
- `calendar_hub_tt_session_expired` に `labelExtractors.accountId = REGEXP_EXTRACT(textPayload, "accountId=([^ ]+)")` 後付け
- `cleanup_legacy_policy` 関数追加 (旧 displayName 削除の冪等 cleanup)
- alert policy: per-account 集計 + threshold 0 + documentation 拡充

### ADR 更新 (commit 3)
- ADR-009 Future Work → 実装済み移動、設計判断 audit trail 記録

## Acceptance Criteria

全 8 件 PASS (evaluator agent 独立確認):
- AC1: options object 採用、`new TimeTreeAdapter(s, { accountId })` 動作
- AC2: ログ両ケース (expiresAt / httpStatus) で `accountId=` 含有
- AC3: log-based metric に label extractor 適用
- AC4: alert policy `groupByFields: [metric.label.accountId]`
- AC5: 既存テスト全 PASS (57 → 213 件中、関連テスト含む)
- AC6: accountId 未指定で TS compile error
- AC7: label extractor 後付け可否は GCP 仕様で確認済み (ラベル追加可、削除/変更不可)
- AC8: documentation に multi-account 同時発火時の API 仕様変更チェック手順記載

## Quality Gate

- ✅ pnpm turbo type-check (8 packages)
- ✅ pnpm lint (8 packages)
- ✅ pnpm vitest run (57 tests, calendar-sdk)
- ✅ bash -n infra/setup-monitoring.sh (syntax OK)
- ✅ /safe-refactor (findings: 0)
- ✅ /code-review low (findings: 0)
- ✅ /codex plan セカンドオピニオン (3 件採用済み: options object, label extractor 後付け検証, 4 引数化)
- ✅ evaluator agent 独立 AC 検証 (全 8 PASS、APPROVE)

## Test plan

- [x] Unit tests (calendar-sdk): 57 PASS
- [x] Type-check: 8 packages successful
- [x] Lint: 8 packages successful
- [x] Shell syntax: setup-monitoring.sh OK
- [ ] 本番適用 (`bash infra/setup-monitoring.sh`): decision-maker 手動実行 (cleanup_legacy_policy で旧 policy 削除 → 新 policy 作成 → metric に accountId label 追加)
- [ ] 本番動作確認: 次回 TimeTree session 切れ発生時 (14 日サイクル) に accountId 付きログ + per-account alert 発火を確認

## リスク・トレードオフ

- **displayName 変更**: 旧 `(24h ≥ 3)` → 新 `(per account, 24h)`。`cleanup_legacy_policy` で旧削除を冪等処理
- **既存 metric への label 後付け**: GCP 公式仕様で「ラベル追加は可能、削除/変更は不可」のため安全
- **threshold 0 (= 1+ per account in 24h)**: 個人プロジェクト規模で再連携を促すには即時発火が適切。autoClose: 86400s で同一アカウントの過剰通知防止

## Refs

- Closes ADR-009 Future Work 「per-account grouping alert」
- Refs #79 (PR #150 後続実装)

🤖 Generated with [Claude Code](https://claude.com/claude-code)