### PR TITLE
feat(infra): log retention buckets + sinks (Issue #81 a)

### DIFF
--- a/infra/setup-log-retention.sh
+++ b/infra/setup-log-retention.sh
@@ -16,6 +16,12 @@ set -euo pipefail
 PROJECT_ID="${GCP_PROJECT_ID:-calendar-hub-prod}"
 SERVICE_NAME="${SERVICE_NAME:-calendar-hub-api}"
 
+# gcloud CLI 不在で describe 戻り値 127 を「リソース不在」と誤判定するのを防ぐ。
+command -v gcloud >/dev/null 2>&1 || {
+  echo "ERROR: gcloud CLI not found in PATH" >&2
+  exit 1
+}
+
 echo "=== Setting up Calendar Hub log retention ==="
 echo "Project: $PROJECT_ID | Service: $SERVICE_NAME"
 
@@ -47,12 +53,12 @@ create_or_update_bucket() {
 create_or_update_bucket \
   "sync-logs" \
   "90" \
-  "Sync-related logs ([SYNC-GAP] / [RRULE-SKIP] / Sync failed for). 90 days for incident analysis (ADR-010)."
+  "Sync-related logs ([SYNC-GAP] / [RRULE-SKIP] / Sync failed for). 90 days for incident analysis (ADR-010 §4)."
 
 create_or_update_bucket \
   "auth-logs" \
   "180" \
-  "Auth-related logs (/api/auth/*, TimeTree session). 180 days for security audit (ADR-010)."
+  "Auth-related logs (/api/auth/*, TimeTree session). 180 days for security audit (ADR-010 §4)."
 
 # --- 2. Log routing sinks ---
 
@@ -61,7 +67,8 @@ create_or_update_bucket \
 SYNC_FILTER="resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${SERVICE_NAME}\" AND (textPayload:\"[SYNC-GAP]\" OR textPayload:\"[RRULE-SKIP]\" OR textPayload:\"Sync failed for\")"
 
 # auth-logs sink: /api/auth/* HTTP request + TimeTree session 構造化ログ。
-# /api/auth/* は httpRequest.requestUrl で広く拾い、TT 系は textPayload プレフィックスで拾う。
+# /api/auth/* は httpRequest.requestUrl で広く拾い、TimeTree session 系は
+# textPayload プレフィックス `[TT-SESSION-*` で拾う ([TT-SESSION-EXPIRED]/RELOGIN-* 共通)。
 AUTH_FILTER="resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${SERVICE_NAME}\" AND (httpRequest.requestUrl:\"/api/auth/\" OR textPayload:\"[TT-SESSION-\")"
 
 create_or_update_sink() {
@@ -105,9 +112,17 @@ create_or_update_sink \
 echo ""
 echo "=== Log retention setup complete ==="
 echo ""
-echo "Verify:"
+echo "Verify resources:"
 echo "  gcloud logging buckets list --project=$PROJECT_ID --filter='name:sync-logs OR name:auth-logs'"
 echo "  gcloud logging sinks list --project=$PROJECT_ID --filter='name:sync-logs-sink OR name:auth-logs-sink'"
+echo ""
+echo "Verify sink writer identity (same-project log bucket destinations は GCP 自動付与、"
+echo "  org policy iam.allowedPolicyMemberDomains 制約下では失敗の可能性あり):"
+echo "  gcloud logging sinks describe sync-logs-sink --project=$PROJECT_ID --format='value(writerIdentity)'"
+echo "  gcloud logging sinks describe auth-logs-sink --project=$PROJECT_ID --format='value(writerIdentity)'"
+echo ""
+echo "Verify log flow (適用 30 分後以降に実行、対象パターンが流れていれば 1 件以上 hit):"
+echo "  gcloud logging read 'logName=\"projects/$PROJECT_ID/logs/run.googleapis.com%2Fstdout\" AND textPayload:\"[TT-SESSION-\"' --bucket=auth-logs --location=global --limit=1"
 echo ""
 echo "Note: 新規 sink は _Default を抑止しません。対象ログは _Default (30d) と"
 echo "      専用バケット (90d/180d) 双方に保存されます (storage コスト延長分のみ加算)。"

--- a/infra/setup-log-retention.sh
+++ b/infra/setup-log-retention.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+set -euo pipefail
+
+# Calendar Hub log retention buckets and routing sinks (Issue #81, ADR-010)
+#
+# 冪等: 既存リソースは update、存在しなければ create。
+# 前提: gcloud 認証済み + logging.googleapis.com 有効化済み (setup-monitoring.sh と共通)。
+#
+# 設計根拠 (docs/adr/010-slo-and-log-retention.md §4):
+# - sync-logs (90d): 障害解析・データ整合性事後検証
+# - auth-logs (180d): 不正利用調査・規制対応
+# - _Default (30d) と並行運用: 新 sink は _Default を抑止せず、対象ログは
+#   _Default + 専用バケット双方に保存される (Cloud Logging ingestion は重複課金なし、
+#   storage コストのみ延長分を負担)。
+
+PROJECT_ID="${GCP_PROJECT_ID:-calendar-hub-prod}"
+SERVICE_NAME="${SERVICE_NAME:-calendar-hub-api}"
+
+echo "=== Setting up Calendar Hub log retention ==="
+echo "Project: $PROJECT_ID | Service: $SERVICE_NAME"
+
+# --- 1. Log buckets ---
+
+create_or_update_bucket() {
+  local name="$1"
+  local retention_days="$2"
+  local description="$3"
+
+  if gcloud logging buckets describe "$name" \
+    --location=global --project="$PROJECT_ID" >/dev/null 2>&1; then
+    echo "Updating log bucket: $name (retention=${retention_days}d)"
+    gcloud logging buckets update "$name" \
+      --location=global \
+      --project="$PROJECT_ID" \
+      --retention-days="$retention_days" \
+      --description="$description" --quiet
+  else
+    echo "Creating log bucket: $name (retention=${retention_days}d)"
+    gcloud logging buckets create "$name" \
+      --location=global \
+      --project="$PROJECT_ID" \
+      --retention-days="$retention_days" \
+      --description="$description"
+  fi
+}
+
+create_or_update_bucket \
+  "sync-logs" \
+  "90" \
+  "Sync-related logs ([SYNC-GAP] / [RRULE-SKIP] / Sync failed for). 90 days for incident analysis (ADR-010)."
+
+create_or_update_bucket \
+  "auth-logs" \
+  "180" \
+  "Auth-related logs (/api/auth/*, TimeTree session). 180 days for security audit (ADR-010)."
+
+# --- 2. Log routing sinks ---
+
+# sync-logs sink: textPayload プレフィックスベース (構造化ログ既存パターンを踏襲)。
+# 既存 sync 系メトリクスと同じ patterns を採用 (setup-monitoring.sh: calendar_hub_sync_*)。
+SYNC_FILTER="resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${SERVICE_NAME}\" AND (textPayload:\"[SYNC-GAP]\" OR textPayload:\"[RRULE-SKIP]\" OR textPayload:\"Sync failed for\")"
+
+# auth-logs sink: /api/auth/* HTTP request + TimeTree session 構造化ログ。
+# /api/auth/* は httpRequest.requestUrl で広く拾い、TT 系は textPayload プレフィックスで拾う。
+AUTH_FILTER="resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${SERVICE_NAME}\" AND (httpRequest.requestUrl:\"/api/auth/\" OR textPayload:\"[TT-SESSION-\")"
+
+create_or_update_sink() {
+  local name="$1"
+  local bucket="$2"
+  local filter="$3"
+  local description="$4"
+
+  local destination
+  destination="logging.googleapis.com/projects/${PROJECT_ID}/locations/global/buckets/${bucket}"
+
+  if gcloud logging sinks describe "$name" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    echo "Updating log sink: $name → $bucket"
+    gcloud logging sinks update "$name" \
+      "$destination" \
+      --project="$PROJECT_ID" \
+      --log-filter="$filter" \
+      --description="$description" --quiet
+  else
+    echo "Creating log sink: $name → $bucket"
+    gcloud logging sinks create "$name" \
+      "$destination" \
+      --project="$PROJECT_ID" \
+      --log-filter="$filter" \
+      --description="$description"
+  fi
+}
+
+create_or_update_sink \
+  "sync-logs-sink" \
+  "sync-logs" \
+  "$SYNC_FILTER" \
+  "Routes sync-related logs to sync-logs bucket (ADR-010)."
+
+create_or_update_sink \
+  "auth-logs-sink" \
+  "auth-logs" \
+  "$AUTH_FILTER" \
+  "Routes auth-related logs to auth-logs bucket (ADR-010)."
+
+echo ""
+echo "=== Log retention setup complete ==="
+echo ""
+echo "Verify:"
+echo "  gcloud logging buckets list --project=$PROJECT_ID --filter='name:sync-logs OR name:auth-logs'"
+echo "  gcloud logging sinks list --project=$PROJECT_ID --filter='name:sync-logs-sink OR name:auth-logs-sink'"
+echo ""
+echo "Note: 新規 sink は _Default を抑止しません。対象ログは _Default (30d) と"
+echo "      専用バケット (90d/180d) 双方に保存されます (storage コスト延長分のみ加算)。"


### PR DESCRIPTION
## Summary

Issue #81 実装フェーズ (a): ADR-010 §4 「ログ保持ポリシー」を実装。3 PR sequence の 1/3。

## 変更内容

### 新規ファイル

- `infra/setup-log-retention.sh` (113 行、idempotent bash)
  - sync-logs bucket (90 日) + sync-logs-sink
  - auth-logs bucket (180 日) + auth-logs-sink

### Filter 設計

| sink | filter | 用途 |
|------|--------|------|
| sync-logs-sink | `textPayload:"[SYNC-GAP]" OR textPayload:"[RRULE-SKIP]" OR textPayload:"Sync failed for"` | 障害解析・データ整合性事後検証 |
| auth-logs-sink | `httpRequest.requestUrl:"/api/auth/" OR textPayload:"[TT-SESSION-"` | 不正利用調査・規制対応 |

両 sink とも `resource.type="cloud_run_revision" AND resource.labels.service_name="calendar-hub-api"` 前提。

## 設計判断

- **_Default sink (30 日) と並行運用**: 新 sink は _Default を抑止せず、対象ログは _Default + 専用バケット双方に保存
  - Cloud Logging ingestion は重複課金なし、storage コストのみ延長分を負担 (ADR-010 §コスト影響)
- **既存 setup-monitoring.sh パターン踏襲**: 冪等設計 (describe → update or create)
- **terraform 不採用**: 個人プロジェクト規模、既存 bash 統一

## Acceptance Criteria

| # | 基準 | 検証 |
|---|------|------|
| AC1 | `gcloud logging buckets list` で sync-logs (90d) / auth-logs (180d) 表示 | gcloud (本番適用後) |
| AC2 | `gcloud logging sinks list` で 2 sink + 適切な filter 表示 | gcloud (本番適用後) |
| AC3 | スクリプト 2 回実行で no-op (冪等性) | 本番適用後に再実行 |
| AC4 | sync-logs sink filter が [SYNC-GAP] / [RRULE-SKIP] / Sync failed for をカバー | YAML 内容確認 ✅ |

## Quality Gate

- ✅ `bash -n infra/setup-log-retention.sh` (syntax OK)
- ✅ gcloud flag 整合性確認 (logging buckets/sinks create|update --help)
- ✅ /code-review low (findings: 0)
- ⏭️ unit test 対象外 (IaC のみ)

## Test plan

- [x] Shell syntax check (`bash -n`)
- [x] gcloud command flag 整合性確認
- [ ] 本番適用 (`bash infra/setup-log-retention.sh`): decision-maker 手動実行
- [ ] 本番動作確認: `gcloud logging buckets list` / `gcloud logging sinks list` で AC1/AC2 確認
- [ ] テストログ注入: `[SYNC-GAP]` または `[TT-SESSION-EXPIRED]` を Cloud Run logger 経由で書き込み、対応 bucket に反映されることを確認 (任意)

## Risks

- 既存 _Default sink 動作への影響なし (新 sink は ADDITIVE)
- Storage コスト増は ADR-010 で「数 USD/月、現状規模では微小」と試算済み
- Sink writer identity の権限: 同一プロジェクト内 log bucket への routing は GCP が自動付与

## Refs

- Issue #81 (a) ログ保持期間の見直しと bucket 設定
- ADR-010 §4 ログ保持ポリシー
- 次 PR: (b) SLI/SLO Cloud Monitoring 設定
- 後続 PR: (c) ダッシュボード作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated log retention setup for the service, creating separate storage for sync and authentication logs with different retention periods.
  * Improved log routing so sync-related and auth-related entries are organized into the appropriate logging buckets for easier review and troubleshooting.
  * Added clearer progress output and verification guidance when setting up log retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->