### PR TITLE
fix(infra): GOOGLE_REDIRECT_URI を本番 deploy 時に設定

### DIFF
--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -9,8 +9,11 @@ REPO_NAME="calendar-hub"
 # Web URLを取得（CORS設定に必要）
 WEB_URL="${WEB_URL:-$(gcloud run services describe calendar-hub-web --project="$PROJECT_ID" --region="$REGION" --format="value(status.url)" 2>/dev/null || echo "http://localhost:3000")}"
 
+# API URL を取得（Google OAuth callback redirect_uri に必要）
+API_URL="${API_URL:-$(gcloud run services describe "$SERVICE_NAME" --project="$PROJECT_ID" --region="$REGION" --format="value(status.url)" 2>/dev/null || echo "http://localhost:8080")}"
+
 echo "=== Deploying Calendar Hub API to Cloud Run ==="
-echo "Project: $PROJECT_ID | Region: $REGION | Web: $WEB_URL"
+echo "Project: $PROJECT_ID | Region: $REGION | Web: $WEB_URL | Api: $API_URL"
 
 # Artifact Registry リポジトリ作成（初回のみ）
 gcloud artifacts repositories describe "$REPO_NAME" \
@@ -43,7 +46,7 @@ gcloud run deploy "$SERVICE_NAME" \
   --cpu=1 \
   --min-instances=0 \
   --max-instances=3 \
-  --set-env-vars="GCP_PROJECT_ID=$PROJECT_ID,FRONTEND_URL=$WEB_URL" \
+  --set-env-vars="GCP_PROJECT_ID=$PROJECT_ID,FRONTEND_URL=$WEB_URL,GOOGLE_REDIRECT_URI=$API_URL/api/auth/callback/google" \
   --set-secrets="GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,TOKEN_ENCRYPTION_KEY=token-encryption-key:latest,SYNC_SCHEDULER_TOKEN=sync-scheduler-token:latest"
 
 # Cloud Run の traffic ピン留め回避 (Issue #119) — 詳細は infra/promote-traffic.sh


### PR DESCRIPTION
## Summary

本番 Cloud Run api への deploy で \`GOOGLE_REDIRECT_URI\` env が未設定だったため、本番 api が Google OAuth に送る redirect_uri が \`apps/api/src/lib/google-oauth.ts:7\` のデフォルト値 \`http://localhost:8080/api/auth/callback/google\` になっていた。結果、本番 UI から新規 OAuth flow を開始すると \`redirect_uri_mismatch\` (エラー 400) で Access blocked となる。

\`infra/deploy-api.sh\` で \`API_URL\` を describe で取得し、redirect_uri を \`\$API_URL/api/auth/callback/google\` で組み立てて \`--set-env-vars\` に追加する。

## 関連エラー

```
Access blocked: This app's request is invalid
エラー 400: redirect_uri_mismatch
```

新規アカウント (\`yasushi.honda@aozora-cg.com\`) を CalendarHub に OAuth 連携しようとした際に発生。

## 既存連携が動いている経緯（推測）

既存連携 \`hy.unimail.11@gmail.com\` は本番 UI からは新規 OAuth flow を開始していないため動作していた。おそらくローカル dev (\`pnpm dev\`、port 8080) で OAuth 完了 → Firestore に \`refresh_token\` 保存 → 本番 api はその \`refresh_token\` でアクセストークン更新できる、という構造。

## 本番反映に必要な前提作業

merge 前または並行で、Google Cloud Console 側の **OAuth 2.0 クライアント ID → 承認済みのリダイレクト URI** に以下を追加する必要がある:

\`\`\`
https://calendar-hub-api-cu7tz7flqq-an.a.run.app/api/auth/callback/google
\`\`\`

既存の \`http://localhost:8080/api/auth/callback/google\` は dev 用にそのまま残す。

## Test plan

- [x] \`bash -n infra/deploy-api.sh\` (syntax OK)
- [ ] PR merge → Deploy workflow で env が \`gcloud run services describe\` に表示されること
- [ ] 本番 UI から新規 Google アカウント連携を試み、\`redirect_uri_mismatch\` が出ないこと（Console 側設定完了後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment now automatically includes the API’s callback URL in environment settings.
  * The deployment log now shows the resolved API URL, with a local fallback when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->