### PR TITLE
fix(ci): deploy.yml で GOOGLE_REDIRECT_URI を Cloud Run api に設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,31 @@ jobs:
           fi
           echo "url=${WEB_URL}" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve API URL for OAuth redirect_uri
+        id: apiurl
+        run: |
+          # 既存APIサービス未存在（初回ブートストラップ）のみ空を許容。
+          # 空のとき GOOGLE_REDIRECT_URI は env から省略 → google-oauth.ts の localhost default が使われる
+          # (初回 deploy 後の 2 回目以降で本番 URL が解決され、env が設定される)
+          set +e
+          API_URL=$(gcloud run services describe calendar-hub-api \
+            --project="$GCP_PROJECT_ID" \
+            --region="$GCP_REGION" \
+            --format="value(status.url)" 2>describe_api_err.log)
+          DESCRIBE_EXIT=$?
+          set -e
+          if [ "$DESCRIBE_EXIT" -ne 0 ]; then
+            if grep -q "NOT_FOUND\|Cannot find service" describe_api_err.log; then
+              echo "::warning::calendar-hub-api not yet deployed; GOOGLE_REDIRECT_URI will use localhost default on first bootstrap"
+              API_URL=""
+            else
+              echo "::error::failed to describe calendar-hub-api"
+              cat describe_api_err.log
+              exit 1
+            fi
+          fi
+          echo "url=${API_URL}" >> "$GITHUB_OUTPUT"
+
       - name: Cloud Build submit (API image)
         env:
           COMMIT_SHA: ${{ github.sha }}
@@ -100,7 +125,14 @@ jobs:
         id: deploy
         env:
           WEB_URL: ${{ steps.weburl.outputs.url }}
+          API_URL: ${{ steps.apiurl.outputs.url }}
         run: |
+          # API_URL が空 (初回 bootstrap) のときは GOOGLE_REDIRECT_URI を省略
+          # → google-oauth.ts の localhost default → 次回 deploy で本番 URL 解決後に env 設定
+          REDIRECT_URI_ENV=""
+          if [ -n "$API_URL" ]; then
+            REDIRECT_URI_ENV=",GOOGLE_REDIRECT_URI=${API_URL}/api/auth/callback/google"
+          fi
           gcloud run deploy calendar-hub-api \
             --project="$GCP_PROJECT_ID" \
             --region="$GCP_REGION" \
@@ -112,7 +144,7 @@ jobs:
             --cpu=1 \
             --min-instances=0 \
             --max-instances=3 \
-            --set-env-vars="GCP_PROJECT_ID=${GCP_PROJECT_ID},FRONTEND_URL=${WEB_URL}" \
+            --set-env-vars="GCP_PROJECT_ID=${GCP_PROJECT_ID},FRONTEND_URL=${WEB_URL}${REDIRECT_URI_ENV}" \
             --set-secrets="GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,TOKEN_ENCRYPTION_KEY=token-encryption-key:latest,SYNC_SCHEDULER_TOKEN=sync-scheduler-token:latest"
           # Cloud Run の traffic ピン留め回避 (Issue #119) — 詳細は infra/promote-traffic.sh
           PROJECT_ID="$GCP_PROJECT_ID" REGION="$GCP_REGION" \


### PR DESCRIPTION
## Summary

PR #159 で \`infra/deploy-api.sh\` は修正したが、**CI/CD は \`.github/workflows/deploy.yml\` が直接 \`gcloud run deploy\` を叩いており \`deploy-api.sh\` を経由しない** ため env が反映されない構造だった。

\`Resolve Web URL\` と同じパターンで \`Resolve API URL\` ステップを追加し、deploy step の \`--set-env-vars\` に \`GOOGLE_REDIRECT_URI=\${API_URL}/api/auth/callback/google\` を追加する。

## 実証症状

\`yasushi.honda@aozora-cg.com\` の新規 OAuth 連携を本番から試みると:

\`\`\`
Access blocked: This app's request is invalid
エラー 400: redirect_uri_mismatch
\`\`\`

PR #159 merge → Deploy workflow success 後も再現。\`gcloud run services describe\` で \`GOOGLE_REDIRECT_URI\` が env に存在しないことを確認、本 file が原因。

## ブートストラップ対応

\`API_URL\` が空 (初回 deploy、サービス未存在) の場合は env を省略 → \`apps/api/src/lib/google-oauth.ts:7\` の localhost default を踏襲。2 回目以降の deploy で URL 解決後に env が設定される。Web 側 \`FRONTEND_URL\` と同じ pattern。

## Test plan

- [x] \`git diff --stat\` で 1 file / +33/-1
- [x] content grep で \`Resolve API URL\` step と \`REDIRECT_URI_ENV\` 分岐の存在確認
- [ ] PR merge → Deploy workflow 完走 → \`gcloud run services describe calendar-hub-api --format=json\` で \`GOOGLE_REDIRECT_URI\` が env に表示されること
- [ ] 本番 UI から新規 Google アカウント連携が成立すること (redirect_uri_mismatch が出ないこと)

## 関連

- PR #159: \`infra/deploy-api.sh\` 修正 (CI を介さない手動 deploy 用)
- 本 PR は CI/CD path の同等修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)