### PR TITLE
fix(api): アカウント解除を hard delete に変更

### DIFF
--- a/apps/api/src/lib/token-store.ts
+++ b/apps/api/src/lib/token-store.ts
@@ -116,12 +116,7 @@ export async function listConnectedAccounts(userId: string): Promise<ConnectedAc
   });
 }
 
-export async function deactivateAccount(userId: string, accountId: string): Promise<void> {
+export async function deleteConnectedAccount(userId: string, accountId: string): Promise<void> {
   const db = getDb();
-  await db
-    .collection('users')
-    .doc(userId)
-    .collection('connectedAccounts')
-    .doc(accountId)
-    .update({ isActive: false });
+  await db.collection('users').doc(userId).collection('connectedAccounts').doc(accountId).delete();
 }

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -7,7 +7,7 @@ import { generateAuthUrl, exchangeCode, getGoogleUserInfo } from '../lib/google-
 import {
   saveConnectedAccount,
   listConnectedAccounts,
-  deactivateAccount,
+  deleteConnectedAccount,
 } from '../lib/token-store.js';
 import { getDb } from '../lib/firebase-admin.js';
 
@@ -181,7 +181,7 @@ authRoutes.post('/connect/timetree', requireAuth, async (c) => {
 authRoutes.delete('/accounts/:accountId', requireAuth, async (c) => {
   const user = c.get('user');
   const accountId = c.req.param('accountId');
-  await deactivateAccount(user.uid, accountId);
+  await deleteConnectedAccount(user.uid, accountId);
   return c.json({ success: true });
 });
 


### PR DESCRIPTION
## Summary

\`deactivateAccount\` は \`isActive: false\` に更新するだけの soft delete で、settings UI 上では「無効」バッジ付きで表示が残り続け、本田様の「削除したい」直観に反していた（個人アプリで履歴保持の業務要件なし）。

\`deleteConnectedAccount\` に rename し、Firestore document を完全削除する hard delete に変更。

## 変更点

- \`apps/api/src/lib/token-store.ts\`: \`deactivateAccount\` → \`deleteConnectedAccount\`、内部実装を \`.update({ isActive: false })\` → \`.delete()\`
- \`apps/api/src/routes/auth.ts\`: import 名と呼び出し名を更新

## 既存挙動への影響

\`listConnectedAccounts\` は元から \`isActive\` を読んで filter していたため、document が削除されれば自然に UI から消える（追加の表示ロジック修正不要）。

## 既存の「無効」状態の document について

PR merge 後、本田様が settings 画面で再度「解除」ボタンを押すことで、Firestore に残っている \`yasushi.honda@aozora-cg.com\`（現状 \`isActive: false\`）の document が完全削除される。

## Test plan

- [x] \`pnpm --filter @calendar-hub/api type-check\` ✅
- [x] \`pnpm --filter @calendar-hub/api lint\` ✅
- [x] \`pnpm --filter @calendar-hub/shared test\` ✅ (35 pass)
- [ ] PR merge + Deploy → settings 画面で「解除」ボタンを押すと account 一覧から完全に消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disconnecting an external account now fully removes it instead of leaving it marked inactive.
  * Account unlink requests continue to return success as before, with the same user-facing behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->