### PR TITLE
feat(booking-mirror): Google 予約スケジュール完全反映ミラー機能 v2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,7 +145,7 @@ jobs:
             --min-instances=0 \
             --max-instances=3 \
             --set-env-vars="GCP_PROJECT_ID=${GCP_PROJECT_ID},FRONTEND_URL=${WEB_URL}${REDIRECT_URI_ENV}" \
-            --set-secrets="GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,TOKEN_ENCRYPTION_KEY=token-encryption-key:latest,SYNC_SCHEDULER_TOKEN=sync-scheduler-token:latest"
+            --set-secrets="GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,TOKEN_ENCRYPTION_KEY=token-encryption-key:latest,SYNC_SCHEDULER_TOKEN=sync-scheduler-token:latest,GOOGLE_BOOKING_MIRROR_API_KEY=google-booking-mirror-api-key:latest"
           # Cloud Run の traffic ピン留め回避 (Issue #119) — 詳細は infra/promote-traffic.sh
           PROJECT_ID="$GCP_PROJECT_ID" REGION="$GCP_REGION" \
             bash infra/promote-traffic.sh calendar-hub-api

--- a/apps/api/src/__tests__/google-booking-mirror.test.ts
+++ b/apps/api/src/__tests__/google-booking-mirror.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseSlotResponse,
+  resolveScheduleId,
+  BookingMirrorError,
+} from '../lib/google-booking-mirror.js';
+
+describe('parseSlotResponse', () => {
+  it('PoC で取得した実 fixture から slot 配列を抽出する', () => {
+    // 2026-06-26 PoC で実際に取得した gRPC-web response の縮約版
+    // [[[[["1782466200"],60]],[[["1782469800"],60]],[[["1782514800"],60]]]]
+    const fixture = [[[[['1782466200'], 60]], [[['1782469800'], 60]], [[['1782514800'], 60]]]];
+    const result = parseSlotResponse(fixture);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ startUnix: 1782466200, durationMinutes: 60 });
+    expect(result[1]).toEqual({ startUnix: 1782469800, durationMinutes: 60 });
+    expect(result[2]).toEqual({ startUnix: 1782514800, durationMinutes: 60 });
+  });
+
+  it('data[0] が null のとき空配列を返す (営業時間外 / 全予定埋まり)', () => {
+    const result = parseSlotResponse([null]);
+    expect(result).toEqual([]);
+  });
+
+  it('top-level が array でないとき invalid_shape エラーを投げる', () => {
+    expect(() => parseSlotResponse({ foo: 'bar' } as unknown)).toThrowError(BookingMirrorError);
+    try {
+      parseSlotResponse('not array' as unknown);
+    } catch (err) {
+      expect(err).toBeInstanceOf(BookingMirrorError);
+      expect((err as BookingMirrorError).kind).toBe('parse');
+      expect((err as BookingMirrorError).subKind).toBe('invalid_shape');
+    }
+  });
+
+  it('Google エラーペイロード形式 ({error: {...}}) を検出する', () => {
+    const errorPayload = { error: { code: 403, message: 'PERMISSION_DENIED' } };
+    try {
+      parseSlotResponse(errorPayload);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(BookingMirrorError);
+      expect((err as BookingMirrorError).subKind).toBe('google_error_payload');
+    }
+  });
+
+  it('不完全な slot 要素は skip される (defensive)', () => {
+    const fixture = [
+      [
+        [[['1782466200'], 60]], // OK
+        [[['not-a-number'], 60]], // OK (parseInt → NaN → skip)
+        [[['1782469800']]], // duration なし → skip
+        [[[1782514800], 60]], // ts not string → skip
+        [[['1782514800'], 60]], // OK
+      ],
+    ];
+    const result = parseSlotResponse(fixture);
+    // 'not-a-number' は parseInt で NaN になり skip される
+    expect(result).toEqual([
+      { startUnix: 1782466200, durationMinutes: 60 },
+      { startUnix: 1782514800, durationMinutes: 60 },
+    ]);
+  });
+});
+
+describe('resolveScheduleId (完全 URL のみ、短縮 URL は network)', () => {
+  it('完全 URL から schedule ID を抽出する', async () => {
+    const id = await resolveScheduleId(
+      'https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ1eaFrYGKa4y8yOXMORxwrEGNl3cTSsOyTf38BAxmiukcpKjxE2apxUVBayl6IXHEIVJ47tculQ',
+    );
+    expect(id).toBe(
+      'AcZssZ1eaFrYGKa4y8yOXMORxwrEGNl3cTSsOyTf38BAxmiukcpKjxE2apxUVBayl6IXHEIVJ47tculQ',
+    );
+  });
+
+  it('空文字を渡すと invalid_input エラー', async () => {
+    await expect(resolveScheduleId('')).rejects.toThrowError(BookingMirrorError);
+    await expect(resolveScheduleId('   ')).rejects.toThrowError(BookingMirrorError);
+  });
+
+  it('URL でない文字列は not_url エラー', async () => {
+    try {
+      await resolveScheduleId('not-a-url');
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(BookingMirrorError);
+      expect((err as BookingMirrorError).subKind).toBe('not_url');
+    }
+  });
+
+  it('サポート対象外ホストの URL は unsupported_host エラー', async () => {
+    try {
+      await resolveScheduleId('https://example.com/foo');
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(BookingMirrorError);
+      expect((err as BookingMirrorError).subKind).toBe('unsupported_host');
+    }
+  });
+
+  it('完全 URL に schedule ID が含まれていない場合 no_id_in_path エラー', async () => {
+    try {
+      await resolveScheduleId('https://calendar.google.com/calendar/u/0/appointments/schedules/');
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(BookingMirrorError);
+      expect((err as BookingMirrorError).subKind).toBe('no_id_in_path');
+    }
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,7 +7,9 @@ import { profileRoutes } from './routes/profile.js';
 import { aiRoutes } from './routes/ai.js';
 import { notificationRoutes } from './routes/notifications.js';
 import { bookingLinkRoutes } from './routes/booking-links.js';
+import { bookingMirrorLinkRoutes } from './routes/booking-mirror-links.js';
 import { publicBookingRoutes } from './routes/public-booking.js';
+import { publicBookingMirrorRoutes } from './routes/public-booking-mirror.js';
 import { syncRoutes } from './routes/sync.js';
 import { rateLimit } from './middleware/rate-limit.js';
 import type { AppEnv } from './types.js';
@@ -41,6 +43,8 @@ if (isE2EMode && process.env.NODE_ENV === 'production') {
 if (!isE2EMode) {
   app.use('/api/public/booking/*/slots', rateLimit({ windowMs: 60_000, max: 30 }));
   app.use('/api/public/booking/*/book', rateLimit({ windowMs: 60_000, max: 5 }));
+  app.use('/api/public/booking-mirror/*/slots', rateLimit({ windowMs: 60_000, max: 30 }));
+  app.use('/api/public/booking-mirror/*/book', rateLimit({ windowMs: 60_000, max: 5 }));
 }
 
 app.get('/health', (c) => c.json({ status: 'ok' }));
@@ -51,5 +55,7 @@ app.route('/api/profile', profileRoutes);
 app.route('/api/ai', aiRoutes);
 app.route('/api/notifications', notificationRoutes);
 app.route('/api/booking-links', bookingLinkRoutes);
+app.route('/api/booking-mirror-links', bookingMirrorLinkRoutes);
 app.route('/api/public/booking', publicBookingRoutes);
+app.route('/api/public/booking-mirror', publicBookingMirrorRoutes);
 app.route('/api/sync', syncRoutes);

--- a/apps/api/src/lib/google-booking-mirror.ts
+++ b/apps/api/src/lib/google-booking-mirror.ts
@@ -1,0 +1,218 @@
+/**
+ * Google 予約スケジュール公開ページが内部で叩く gRPC-web API を直接叩く。
+ *
+ * 経緯: docs/specs/2026-06-26-booking-mirror-v2-grpc-design.md
+ *
+ * セキュリティ: API Key は env `GOOGLE_BOOKING_MIRROR_API_KEY` から取得。
+ *   ログ出力時は値をマスクすること。
+ */
+
+const GRPC_ENDPOINT_BASE = 'https://calendar-pa.clients6.google.com/$rpc';
+const APPT_SERVICE = 'google.internal.calendar.v1.AppointmentBookingService';
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+const SHORT_URL_HOST = 'calendar.app.google';
+const FULL_URL_HOST = 'calendar.google.com';
+
+export interface GoogleSlot {
+  startUnix: number; // 秒
+  durationMinutes: number;
+}
+
+export type ParseErrorKind = 'invalid_shape' | 'empty_slots' | 'google_error_payload' | 'non_json';
+
+export class BookingMirrorError extends Error {
+  constructor(
+    public readonly kind: 'parse' | 'http' | 'timeout' | 'resolve' | 'invalid_input',
+    public readonly subKind: ParseErrorKind | string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'BookingMirrorError';
+  }
+}
+
+function getApiKey(): string {
+  const key = process.env.GOOGLE_BOOKING_MIRROR_API_KEY;
+  if (!key) {
+    throw new BookingMirrorError(
+      'invalid_input',
+      'missing_api_key',
+      'GOOGLE_BOOKING_MIRROR_API_KEY is not configured',
+    );
+  }
+  return key;
+}
+
+/**
+ * 短縮 URL or 完全 URL から schedule ID を抽出する。
+ *
+ * - 完全 URL: `https://calendar.google.com/calendar/u/0/appointments/schedules/<id>` から ID を抽出
+ * - 短縮 URL: `https://calendar.app.google/<short>` を HEAD/GET fetch してリダイレクト先 URL から抽出
+ */
+export async function resolveScheduleId(input: string): Promise<string> {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new BookingMirrorError('invalid_input', 'empty', 'shortUrl is empty');
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new BookingMirrorError('invalid_input', 'not_url', `not a valid URL: ${trimmed}`);
+  }
+
+  if (url.host === FULL_URL_HOST && url.pathname.includes('/appointments/schedules/')) {
+    const idx = url.pathname.indexOf('/appointments/schedules/');
+    const tail = url.pathname.slice(idx + '/appointments/schedules/'.length);
+    const id = tail.split('/')[0];
+    if (!id) {
+      throw new BookingMirrorError(
+        'resolve',
+        'no_id_in_path',
+        `no schedule id in path: ${url.pathname}`,
+      );
+    }
+    return id;
+  }
+
+  if (url.host !== SHORT_URL_HOST) {
+    throw new BookingMirrorError(
+      'invalid_input',
+      'unsupported_host',
+      `unsupported host: ${url.host}. expect ${SHORT_URL_HOST} or ${FULL_URL_HOST}`,
+    );
+  }
+
+  const res = await fetchWithTimeout(trimmed, { method: 'GET', redirect: 'follow' });
+  const finalUrl = new URL(res.url);
+  if (finalUrl.host !== FULL_URL_HOST || !finalUrl.pathname.includes('/appointments/schedules/')) {
+    throw new BookingMirrorError(
+      'resolve',
+      'unexpected_redirect',
+      `short URL did not redirect to expected schedule URL: ${res.url}`,
+    );
+  }
+  const idx = finalUrl.pathname.indexOf('/appointments/schedules/');
+  const tail = finalUrl.pathname.slice(idx + '/appointments/schedules/'.length);
+  const id = tail.split('/')[0];
+  if (!id) {
+    throw new BookingMirrorError(
+      'resolve',
+      'no_id_after_redirect',
+      `no schedule id after redirect: ${res.url}`,
+    );
+  }
+  return id;
+}
+
+/**
+ * gRPC-web 経由で空き枠を取得する。
+ *
+ * @param scheduleId 完全 schedule ID
+ * @param startUnix 取得範囲開始 (Unix 秒)
+ * @param endUnix 取得範囲終了 (Unix 秒)
+ */
+export async function fetchAvailableSlots(
+  scheduleId: string,
+  startUnix: number,
+  endUnix: number,
+): Promise<GoogleSlot[]> {
+  const key = getApiKey();
+  const url = `${GRPC_ENDPOINT_BASE}/${APPT_SERVICE}/ListAvailableSlots?key=${encodeURIComponent(key)}`;
+  const body = JSON.stringify([null, null, scheduleId, null, [[startUnix], [endUnix]]]);
+
+  const res = await fetchWithTimeout(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json+protobuf',
+      'X-User-Agent': 'grpc-web-javascript/0.1',
+      'X-Goog-AuthUser': '0',
+      Origin: 'https://calendar.google.com',
+      Referer: 'https://calendar.google.com/',
+    },
+    body,
+  });
+
+  if (!res.ok) {
+    let payload: unknown = null;
+    try {
+      payload = await res.json();
+    } catch {
+      // non-JSON error body は無視
+    }
+    throw new BookingMirrorError(
+      'http',
+      `status_${res.status}`,
+      `gRPC-web ListAvailableSlots failed: ${res.status} ${JSON.stringify(payload)}`,
+    );
+  }
+
+  let data: unknown;
+  try {
+    data = await res.json();
+  } catch {
+    throw new BookingMirrorError('parse', 'non_json', 'response is not JSON');
+  }
+
+  return parseSlotResponse(data);
+}
+
+/**
+ * gRPC-web レスポンス body を GoogleSlot[] に変換する。
+ *
+ * 期待形式: `[[ [[<unix-string>], <duration-min>], ... ]]`
+ */
+export function parseSlotResponse(data: unknown): GoogleSlot[] {
+  // エラーペイロード形式の検出
+  if (
+    data &&
+    typeof data === 'object' &&
+    !Array.isArray(data) &&
+    'error' in (data as Record<string, unknown>)
+  ) {
+    throw new BookingMirrorError('parse', 'google_error_payload', JSON.stringify(data));
+  }
+  if (!Array.isArray(data)) {
+    throw new BookingMirrorError('parse', 'invalid_shape', `top-level is not array`);
+  }
+  const outer = data[0];
+  if (outer === null || outer === undefined) {
+    // 空の予約枠 (営業時間外、全予定埋まり) は valid な空配列扱い
+    return [];
+  }
+  if (!Array.isArray(outer)) {
+    throw new BookingMirrorError('parse', 'invalid_shape', `data[0] is not array`);
+  }
+
+  const slots: GoogleSlot[] = [];
+  for (const slotWrap of outer) {
+    if (!Array.isArray(slotWrap) || slotWrap.length === 0) continue;
+    const inner = slotWrap[0];
+    if (!Array.isArray(inner) || inner.length < 2) continue;
+    const tsWrap = inner[0];
+    const duration = inner[1];
+    if (!Array.isArray(tsWrap) || tsWrap.length === 0) continue;
+    const tsStr = tsWrap[0];
+    if (typeof tsStr !== 'string') continue;
+    if (typeof duration !== 'number') continue;
+    const startUnix = parseInt(tsStr, 10);
+    if (!Number.isFinite(startUnix)) continue;
+    slots.push({ startUnix, durationMinutes: duration });
+  }
+  return slots;
+}
+
+async function fetchWithTimeout(input: string, init: RequestInit = {}): Promise<Response> {
+  // Node.js 18+ / undici は AbortSignal.timeout をサポート
+  const signal = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === 'TimeoutError') {
+      throw new BookingMirrorError('timeout', 'fetch_timeout', `request timed out: ${input}`);
+    }
+    throw err;
+  }
+}

--- a/apps/api/src/routes/booking-mirror-links.ts
+++ b/apps/api/src/routes/booking-mirror-links.ts
@@ -1,0 +1,218 @@
+import { Hono } from 'hono';
+import { nanoid } from 'nanoid';
+import { FieldValue } from 'firebase-admin/firestore';
+import type { AppEnv } from '../types.js';
+import { requireAuth } from '../middleware/auth.js';
+import { getDb } from '../lib/firebase-admin.js';
+import type {
+  BookingMirrorLink,
+  BookingMirrorLinkStatus,
+  CreateBookingMirrorLinkInput,
+  UpdateBookingMirrorLinkInput,
+} from '@calendar-hub/shared';
+import { resolveScheduleId, BookingMirrorError } from '../lib/google-booking-mirror.js';
+
+export const bookingMirrorLinkRoutes = new Hono<AppEnv>();
+
+const MAX_RANGE_DAYS = 60;
+const DEFAULT_RANGE_DAYS = 30;
+const DEFAULT_NOTIFICATION_EMAIL =
+  process.env.DEFAULT_NOTIFICATION_EMAIL ?? 'hy.unimail.11@gmail.com';
+
+// --- ヘルパー ---
+
+function fromFirestoreData(data: FirebaseFirestore.DocumentData): BookingMirrorLink {
+  return {
+    id: data.id,
+    ownerUid: data.ownerUid,
+    title: data.title,
+    description: data.description ?? undefined,
+    sourceUrl: data.sourceUrl,
+    scheduleId: data.scheduleId,
+    notificationEmail: data.notificationEmail,
+    rangeDays: data.rangeDays,
+    status: data.status,
+    expiresAt: data.expiresAt?.toDate?.() ?? null,
+    createdAt: data.createdAt?.toDate?.() ?? new Date(),
+    updatedAt: data.updatedAt?.toDate?.() ?? new Date(),
+  };
+}
+
+function buildPatchUpdate(body: UpdateBookingMirrorLinkInput): Record<string, unknown> {
+  const update: Record<string, unknown> = {};
+  if (body.title !== undefined) update.title = body.title;
+  if (body.description !== undefined) update.description = body.description ?? null;
+  if (body.notificationEmail !== undefined) update.notificationEmail = body.notificationEmail;
+  if (body.rangeDays !== undefined) update.rangeDays = body.rangeDays;
+  if (body.status !== undefined) update.status = body.status;
+  if (body.expiresAt !== undefined) {
+    update.expiresAt = body.expiresAt ? new Date(body.expiresAt) : null;
+  }
+  return update;
+}
+
+function validateStatus(value: unknown): value is BookingMirrorLinkStatus {
+  return value === 'active' || value === 'paused';
+}
+
+function validateEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+// --- ルート ---
+
+// 一覧
+bookingMirrorLinkRoutes.get('/', requireAuth, async (c) => {
+  const user = c.get('user');
+  const db = getDb();
+  const snap = await db
+    .collection('bookingMirrorLinks')
+    .where('ownerUid', '==', user.uid)
+    .orderBy('createdAt', 'desc')
+    .get();
+  const links = snap.docs.map((d) => fromFirestoreData(d.data()));
+  return c.json({ links });
+});
+
+// 新規作成
+bookingMirrorLinkRoutes.post('/', requireAuth, async (c) => {
+  const user = c.get('user');
+  let body: CreateBookingMirrorLinkInput;
+  try {
+    body = (await c.req.json()) as CreateBookingMirrorLinkInput;
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  if (!body.sourceUrl || typeof body.sourceUrl !== 'string') {
+    return c.json({ error: 'sourceUrl is required' }, 400);
+  }
+  if (body.notificationEmail !== undefined && !validateEmail(body.notificationEmail)) {
+    return c.json({ error: 'Invalid notificationEmail format' }, 400);
+  }
+  const rangeDays = body.rangeDays ?? DEFAULT_RANGE_DAYS;
+  if (!Number.isInteger(rangeDays) || rangeDays < 1 || rangeDays > MAX_RANGE_DAYS) {
+    return c.json({ error: `rangeDays must be 1-${MAX_RANGE_DAYS}` }, 400);
+  }
+
+  // schedule ID を解決（失敗時は 400）
+  let scheduleId: string;
+  try {
+    scheduleId = await resolveScheduleId(body.sourceUrl);
+  } catch (err) {
+    if (err instanceof BookingMirrorError) {
+      return c.json(
+        { error: `failed to resolve schedule id: ${err.subKind}`, detail: err.message },
+        400,
+      );
+    }
+    throw err;
+  }
+
+  const id = nanoid(12);
+  const now = new Date();
+  const link: BookingMirrorLink = {
+    id,
+    ownerUid: user.uid,
+    title: body.title?.trim() || '【ミラー】予約スケジュール',
+    description: body.description?.trim() || undefined,
+    sourceUrl: body.sourceUrl.trim(),
+    scheduleId,
+    notificationEmail: body.notificationEmail?.trim() || DEFAULT_NOTIFICATION_EMAIL,
+    rangeDays,
+    status: 'active',
+    expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const db = getDb();
+  await db
+    .collection('bookingMirrorLinks')
+    .doc(id)
+    .set({
+      ...link,
+      description: link.description ?? null,
+      expiresAt: link.expiresAt ?? null,
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+  return c.json({ link }, 201);
+});
+
+// 取得
+bookingMirrorLinkRoutes.get('/:linkId', requireAuth, async (c) => {
+  const user = c.get('user');
+  const linkId = c.req.param('linkId');
+  const db = getDb();
+  const doc = await db.collection('bookingMirrorLinks').doc(linkId).get();
+  if (!doc.exists) {
+    return c.json({ error: 'Not found' }, 404);
+  }
+  const data = doc.data()!;
+  if (data.ownerUid !== user.uid) {
+    return c.json({ error: 'Forbidden' }, 403);
+  }
+  return c.json({ link: fromFirestoreData(data) });
+});
+
+// 更新
+bookingMirrorLinkRoutes.patch('/:linkId', requireAuth, async (c) => {
+  const user = c.get('user');
+  const linkId = c.req.param('linkId');
+
+  let body: UpdateBookingMirrorLinkInput;
+  try {
+    body = (await c.req.json()) as UpdateBookingMirrorLinkInput;
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  const db = getDb();
+  const ref = db.collection('bookingMirrorLinks').doc(linkId);
+  const doc = await ref.get();
+  if (!doc.exists) {
+    return c.json({ error: 'Not found' }, 404);
+  }
+  if (doc.data()!.ownerUid !== user.uid) {
+    return c.json({ error: 'Forbidden' }, 403);
+  }
+
+  if (body.status !== undefined && !validateStatus(body.status)) {
+    return c.json({ error: 'status must be active or paused' }, 400);
+  }
+  if (body.notificationEmail !== undefined && !validateEmail(body.notificationEmail)) {
+    return c.json({ error: 'Invalid notificationEmail format' }, 400);
+  }
+  if (
+    body.rangeDays !== undefined &&
+    (!Number.isInteger(body.rangeDays) || body.rangeDays < 1 || body.rangeDays > MAX_RANGE_DAYS)
+  ) {
+    return c.json({ error: `rangeDays must be 1-${MAX_RANGE_DAYS}` }, 400);
+  }
+
+  const update = buildPatchUpdate(body);
+  update.updatedAt = FieldValue.serverTimestamp();
+  await ref.update(update);
+
+  const updated = await ref.get();
+  return c.json({ link: fromFirestoreData(updated.data()!) });
+});
+
+// 削除
+bookingMirrorLinkRoutes.delete('/:linkId', requireAuth, async (c) => {
+  const user = c.get('user');
+  const linkId = c.req.param('linkId');
+  const db = getDb();
+  const ref = db.collection('bookingMirrorLinks').doc(linkId);
+  const doc = await ref.get();
+  if (!doc.exists) {
+    return c.json({ error: 'Not found' }, 404);
+  }
+  if (doc.data()!.ownerUid !== user.uid) {
+    return c.json({ error: 'Forbidden' }, 403);
+  }
+  await ref.delete();
+  return c.json({ success: true });
+});

--- a/apps/api/src/routes/public-booking-mirror.ts
+++ b/apps/api/src/routes/public-booking-mirror.ts
@@ -1,0 +1,387 @@
+import { Hono } from 'hono';
+import { nanoid } from 'nanoid';
+import { FieldValue } from 'firebase-admin/firestore';
+import { getDb } from '../lib/firebase-admin.js';
+import { listConnectedAccounts, getRefreshToken } from '../lib/token-store.js';
+import { refreshAccessToken } from '../lib/google-oauth.js';
+import {
+  sendEmail,
+  buildBookingNotificationHtml,
+  buildBookingConfirmationHtml,
+} from '../lib/email.js';
+import { logMailFailure } from '../lib/mail-fail.js';
+import {
+  resolveScheduleId,
+  fetchAvailableSlots,
+  BookingMirrorError,
+  type GoogleSlot,
+} from '../lib/google-booking-mirror.js';
+import { assertE2EMockSafe } from '../lib/e2e-guard.js';
+import type {
+  BookingMirrorLink,
+  BookingMirrorSlot,
+  CreateBookingMirrorInput,
+  PublicBookingMirrorLinkInfo,
+} from '@calendar-hub/shared';
+
+export const publicBookingMirrorRoutes = new Hono();
+
+type LinkResult =
+  | { link: BookingMirrorLink; error: null; statusCode: null }
+  | { link: null; error: string; statusCode: 400 | 404 };
+
+async function getActiveLink(linkId: string): Promise<LinkResult> {
+  const db = getDb();
+  const doc = await db.collection('bookingMirrorLinks').doc(linkId).get();
+  if (!doc.exists) {
+    return { link: null, error: 'Booking mirror link not found', statusCode: 404 };
+  }
+  const data = doc.data()!;
+  const link: BookingMirrorLink = {
+    id: data.id,
+    ownerUid: data.ownerUid,
+    title: data.title,
+    description: data.description ?? undefined,
+    sourceUrl: data.sourceUrl,
+    scheduleId: data.scheduleId,
+    notificationEmail: data.notificationEmail,
+    rangeDays: data.rangeDays,
+    status: data.status,
+    expiresAt: data.expiresAt?.toDate?.() ?? null,
+    createdAt: data.createdAt?.toDate?.() ?? new Date(),
+    updatedAt: data.updatedAt?.toDate?.() ?? new Date(),
+  };
+  if (link.status !== 'active') {
+    return { link: null, error: 'This booking link is currently paused', statusCode: 400 };
+  }
+  if (link.expiresAt && link.expiresAt < new Date()) {
+    return { link: null, error: 'This booking link has expired', statusCode: 400 };
+  }
+  return { link, error: null, statusCode: null };
+}
+
+async function getOwnerDisplayName(ownerUid: string): Promise<string> {
+  const db = getDb();
+  const doc = await db.collection('users').doc(ownerUid).get();
+  const data = doc.data();
+  return data?.displayName ?? data?.email ?? 'User';
+}
+
+/** GoogleSlot[] を CalendarHub の BookingMirrorSlot[] に変換 */
+function toMirrorSlots(slots: GoogleSlot[]): BookingMirrorSlot[] {
+  return slots.map((s) => {
+    const startDate = new Date(s.startUnix * 1000);
+    const endDate = new Date((s.startUnix + s.durationMinutes * 60) * 1000);
+    return {
+      start: startDate.toISOString(),
+      end: endDate.toISOString(),
+      durationMinutes: s.durationMinutes,
+    };
+  });
+}
+
+/** scheduleId が空の場合は sourceUrl から再解決して Firestore に保存し直す */
+async function ensureScheduleId(link: BookingMirrorLink): Promise<string> {
+  if (link.scheduleId) return link.scheduleId;
+  const resolved = await resolveScheduleId(link.sourceUrl);
+  const db = getDb();
+  await db
+    .collection('bookingMirrorLinks')
+    .doc(link.id)
+    .update({ scheduleId: resolved, updatedAt: FieldValue.serverTimestamp() });
+  return resolved;
+}
+
+// --- ルート ---
+
+publicBookingMirrorRoutes.get('/:linkId', async (c) => {
+  const res = await getActiveLink(c.req.param('linkId'));
+  if (!res.link) return c.json({ error: res.error }, res.statusCode as 400 | 404);
+  const link = res.link;
+  const ownerDisplayName = await getOwnerDisplayName(link.ownerUid);
+  const info: PublicBookingMirrorLinkInfo = {
+    id: link.id,
+    title: link.title,
+    description: link.description,
+    ownerDisplayName,
+    status: link.status,
+  };
+  return c.json({ link: info });
+});
+
+publicBookingMirrorRoutes.get('/:linkId/slots', async (c) => {
+  const res = await getActiveLink(c.req.param('linkId'));
+  if (!res.link) return c.json({ error: res.error }, res.statusCode as 400 | 404);
+  const link = res.link;
+
+  const now = new Date();
+  const endDate = new Date(now);
+  endDate.setDate(endDate.getDate() + link.rangeDays);
+  const startUnix = Math.floor(now.getTime() / 1000);
+  const endUnix = Math.floor(endDate.getTime() / 1000);
+
+  let scheduleId: string;
+  try {
+    scheduleId = await ensureScheduleId(link);
+  } catch (err) {
+    console.error(`[booking-mirror] resolveScheduleId failed for link ${link.id}:`, err);
+    return c.json({ error: 'Failed to resolve schedule id', slots: [] }, 502);
+  }
+
+  let googleSlots: GoogleSlot[];
+  try {
+    googleSlots = await fetchAvailableSlots(scheduleId, startUnix, endUnix);
+  } catch (err) {
+    if (err instanceof BookingMirrorError) {
+      console.error(
+        `[booking-mirror] fetchAvailableSlots ${err.kind}/${err.subKind} for link ${link.id}: ${err.message}`,
+      );
+      if (err.kind === 'timeout') {
+        return c.json({ error: 'Upstream timeout', slots: [] }, 504);
+      }
+      return c.json({ error: 'Upstream unavailable', slots: [] }, 502);
+    }
+    throw err;
+  }
+
+  const slots = toMirrorSlots(googleSlots);
+  return c.json({ slots, title: link.title });
+});
+
+publicBookingMirrorRoutes.post('/:linkId/book', async (c) => {
+  const linkId = c.req.param('linkId');
+  const res = await getActiveLink(linkId);
+  if (!res.link) return c.json({ error: res.error }, res.statusCode as 400 | 404);
+  const link = res.link;
+
+  let body: CreateBookingMirrorInput;
+  try {
+    body = (await c.req.json()) as CreateBookingMirrorInput;
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  if (
+    typeof body.guestName !== 'string' ||
+    body.guestName.trim().length === 0 ||
+    body.guestName.length > 100
+  ) {
+    return c.json({ error: 'guestName is required (max 100 chars)' }, 400);
+  }
+  if (!body.slotStart || typeof body.slotStart !== 'string') {
+    return c.json({ error: 'slotStart is required' }, 400);
+  }
+  if (!body.slotEnd || typeof body.slotEnd !== 'string') {
+    return c.json({ error: 'slotEnd is required' }, 400);
+  }
+  const slotStart = new Date(body.slotStart);
+  const slotEnd = new Date(body.slotEnd);
+  if (isNaN(slotStart.getTime()) || isNaN(slotEnd.getTime())) {
+    return c.json({ error: 'Invalid date format' }, 400);
+  }
+  if (slotEnd <= slotStart) {
+    return c.json({ error: 'slotEnd must be after slotStart' }, 400);
+  }
+  if (slotStart < new Date()) {
+    return c.json({ error: 'Cannot book a slot in the past' }, 400);
+  }
+  if (body.guestEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(body.guestEmail)) {
+    return c.json({ error: 'Invalid email format' }, 400);
+  }
+  if (body.guestMessage && body.guestMessage.length > 1000) {
+    return c.json({ error: 'Message too long (max 1000 chars)' }, 400);
+  }
+
+  // 予約直前に gRPC slots を再取得して、指定 slot が依然 available か検証 (Codex review High)
+  let scheduleId: string;
+  try {
+    scheduleId = await ensureScheduleId(link);
+  } catch {
+    return c.json({ error: 'Failed to resolve schedule id' }, 502);
+  }
+  const startUnix = Math.floor(slotStart.getTime() / 1000);
+  const endUnix = Math.floor(slotEnd.getTime() / 1000) + 60; // 終了直後まで取って境界に含める
+
+  let fresh: GoogleSlot[];
+  try {
+    fresh = await fetchAvailableSlots(scheduleId, startUnix, endUnix);
+  } catch (err) {
+    if (err instanceof BookingMirrorError) {
+      console.error(`[booking-mirror] book revalidate ${err.kind}/${err.subKind}: ${err.message}`);
+      return c.json({ error: 'Upstream unavailable' }, 502);
+    }
+    throw err;
+  }
+  const matched = fresh.find(
+    (s) =>
+      s.startUnix === Math.floor(slotStart.getTime() / 1000) &&
+      s.durationMinutes === (slotEnd.getTime() - slotStart.getTime()) / 60000,
+  );
+  if (!matched) {
+    return c.json({ error: 'This time slot is no longer available' }, 409);
+  }
+
+  const db = getDb();
+  const bookingId = nanoid(12);
+
+  try {
+    const overlapQuery = db
+      .collection('bookings')
+      .where('ownerUid', '==', link.ownerUid)
+      .where('status', '==', 'confirmed')
+      .where('slotStart', '<', slotEnd);
+
+    await db.runTransaction(async (tx) => {
+      const existing = await tx.get(overlapQuery);
+      const hasOverlap = existing.docs.some((doc) => {
+        const eEnd = doc.data().slotEnd.toDate();
+        return eEnd > slotStart;
+      });
+      if (hasOverlap) throw new Error('SLOT_TAKEN');
+
+      tx.set(db.collection('bookings').doc(bookingId), {
+        id: bookingId,
+        linkId,
+        linkType: 'bookingMirrorLink',
+        ownerUid: link.ownerUid,
+        guestName: body.guestName,
+        guestEmail: body.guestEmail ?? null,
+        guestMessage: body.guestMessage ?? null,
+        slotStart,
+        slotEnd,
+        status: 'confirmed',
+        calendarEventId: null,
+        notificationSentToOwner: false,
+        notificationSentToGuest: false,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+    });
+  } catch (err) {
+    if (err instanceof Error && err.message === 'SLOT_TAKEN') {
+      return c.json({ error: 'This time slot is no longer available' }, 409);
+    }
+    throw err;
+  }
+
+  const ownerDisplayName = await getOwnerDisplayName(link.ownerUid);
+  sendBookingNotificationsAsync(
+    link,
+    bookingId,
+    body.guestName,
+    body.guestEmail,
+    body.guestMessage,
+    slotStart,
+    slotEnd,
+    ownerDisplayName,
+  );
+
+  return c.json(
+    {
+      booking: {
+        id: bookingId,
+        slotStart: slotStart.toISOString(),
+        slotEnd: slotEnd.toISOString(),
+        guestName: body.guestName,
+        linkTitle: link.title,
+        ownerDisplayName,
+      },
+    },
+    201,
+  );
+});
+
+// --- 非同期処理 ---
+
+function sendBookingNotificationsAsync(
+  link: BookingMirrorLink,
+  bookingId: string,
+  guestName: string,
+  guestEmail: string | undefined,
+  guestMessage: string | undefined,
+  slotStart: Date,
+  slotEnd: Date,
+  ownerDisplayName: string,
+) {
+  (async () => {
+    const db = getDb();
+    const accounts = await listConnectedAccounts(link.ownerUid);
+    const googleAccount = accounts.find((a) => a.provider === 'google' && a.isActive);
+
+    if (!googleAccount) {
+      console.error(`No Google account for booking notification: ${bookingId}`);
+      return;
+    }
+
+    let auth: { email: string; accessToken: string };
+    if (process.env.E2E_MAIL_MOCK === '1') {
+      assertE2EMockSafe('E2E_MAIL_MOCK');
+      auth = { email: googleAccount.email, accessToken: 'e2e-mock-token' };
+    } else {
+      try {
+        const refreshToken = await getRefreshToken(link.ownerUid, googleAccount.id);
+        if (!refreshToken) {
+          logMailFailure(
+            { context: 'booking-mirror-auth', recipient: link.notificationEmail },
+            new Error('no_refresh_token_stored'),
+          );
+          return;
+        }
+        const tokens = await refreshAccessToken(refreshToken);
+        if (!tokens.access_token) {
+          logMailFailure(
+            { context: 'booking-mirror-auth', recipient: link.notificationEmail },
+            new Error('empty_access_token'),
+          );
+          return;
+        }
+        auth = { email: googleAccount.email, accessToken: tokens.access_token };
+      } catch (err) {
+        logMailFailure({ context: 'booking-mirror-auth', recipient: link.notificationEmail }, err);
+        return;
+      }
+    }
+
+    // オーナー (= notificationEmail 宛) へ通知
+    try {
+      await sendEmail(auth, {
+        to: link.notificationEmail,
+        subject: `新しい予約: ${link.title} - ${guestName}`,
+        html: buildBookingNotificationHtml({
+          linkTitle: link.title,
+          guestName,
+          guestEmail,
+          guestMessage,
+          slotStart,
+          slotEnd,
+        }),
+        context: 'owner-notification',
+      });
+      await db.collection('bookings').doc(bookingId).update({ notificationSentToOwner: true });
+    } catch {
+      // sendEmail 内で [MAIL-FAIL] 出力済
+    }
+
+    // ゲストへ確認メール
+    if (guestEmail) {
+      try {
+        const durationMinutes = Math.round((slotEnd.getTime() - slotStart.getTime()) / 60000);
+        await sendEmail(auth, {
+          to: guestEmail,
+          subject: `予約確認: ${link.title}`,
+          html: buildBookingConfirmationHtml({
+            linkTitle: link.title,
+            ownerDisplayName,
+            guestName,
+            slotStart,
+            slotEnd,
+            durationMinutes,
+          }),
+          context: 'guest-confirmation',
+        });
+        await db.collection('bookings').doc(bookingId).update({ notificationSentToGuest: true });
+      } catch {
+        // sendEmail 内で [MAIL-FAIL] 出力済
+      }
+    }
+  })();
+}

--- a/apps/web/src/app/book-mirror/[linkId]/book-mirror-content.tsx
+++ b/apps/web/src/app/book-mirror/[linkId]/book-mirror-content.tsx
@@ -1,0 +1,973 @@
+'use client';
+
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import { publicGet, publicPost } from '../../../lib/public-api';
+import type {
+  PublicBookingMirrorLinkInfo,
+  BookingMirrorSlot,
+  PublicBookingConfirmation,
+} from '@calendar-hub/shared';
+
+type Step = 'select' | 'form' | 'confirmed';
+
+interface SlotsResponse {
+  slots: BookingMirrorSlot[];
+  title: string;
+}
+
+export function BookMirrorContent() {
+  const params = useParams();
+  const linkId = params.linkId as string;
+
+  const [linkInfo, setLinkInfo] = useState<PublicBookingMirrorLinkInfo | null>(null);
+  const [slots, setSlots] = useState<BookingMirrorSlot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [slotsLoading, setSlotsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [selectedSlot, setSelectedSlot] = useState<BookingMirrorSlot | null>(null);
+  const [step, setStep] = useState<Step>('select');
+
+  // Form state
+  const [guestName, setGuestName] = useState('');
+  const [guestEmail, setGuestEmail] = useState('');
+  const [guestMessage, setGuestMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [confirmation, setConfirmation] = useState<PublicBookingConfirmation | null>(null);
+
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // リンク情報 + スロットを並列取得
+  useEffect(() => {
+    if (!linkId) return;
+    (async () => {
+      setSlotsLoading(true);
+      try {
+        const [linkRes, slotsRes] = await Promise.all([
+          publicGet<{ link: PublicBookingMirrorLinkInfo }>(`/api/public/booking-mirror/${linkId}`),
+          publicGet<SlotsResponse>(`/api/public/booking-mirror/${linkId}/slots`),
+        ]);
+        setLinkInfo(linkRes.link);
+        setSlots(slotsRes.slots);
+        if (slotsRes.slots.length > 0) {
+          setSelectedDate(jstDateKey(slotsRes.slots[0].start));
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load');
+      } finally {
+        setLoading(false);
+        setSlotsLoading(false);
+      }
+    })();
+  }, [linkId]);
+
+  // 空き枠ポーリング: 選択画面で開きっぱなしの間、最新化する
+  const refreshSlots = useCallback(async () => {
+    if (!linkId) return;
+    try {
+      const slotsRes = await publicGet<SlotsResponse>(`/api/public/booking-mirror/${linkId}/slots`);
+      setSlots(slotsRes.slots);
+    } catch {
+      // ポーリングは silent（次回再試行で復旧）
+    }
+  }, [linkId]);
+
+  useEffect(() => {
+    if (step !== 'select' || !linkId) return;
+
+    const POLL_INTERVAL_MS = 60_000;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const start = () => {
+      if (intervalId !== null) return;
+      intervalId = setInterval(refreshSlots, POLL_INTERVAL_MS);
+    };
+    const stop = () => {
+      if (intervalId === null) return;
+      clearInterval(intervalId);
+      intervalId = null;
+    };
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        refreshSlots();
+        start();
+      } else {
+        stop();
+      }
+    };
+    const handleFocus = () => {
+      refreshSlots();
+    };
+
+    if (document.visibilityState === 'visible') start();
+    document.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('focus', handleFocus);
+
+    return () => {
+      stop();
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, [step, linkId, refreshSlots]);
+
+  // 日付別グルーピング（JST 基準。slot.start は UTC ISO 文字列なので、UTC 日付で
+  // split するとタイムゾーン境界で翌日朝の枠が当日に紛れ込む grouping bug が起きる）
+  const dateGroups = useMemo(() => {
+    const groups: Record<string, BookingMirrorSlot[]> = {};
+    for (const slot of slots) {
+      const date = jstDateKey(slot.start);
+      if (!groups[date]) groups[date] = [];
+      groups[date].push(slot);
+    }
+    return groups;
+  }, [slots]);
+
+  const availableDates = useMemo(() => Object.keys(dateGroups).sort(), [dateGroups]);
+
+  const slotsForSelectedDate = useMemo(
+    () => (selectedDate ? (dateGroups[selectedDate] ?? []) : []),
+    [selectedDate, dateGroups],
+  );
+
+  // 時間帯セクション分け（朝 / 昼 / 午後 / 夕方 / 夜）
+  const slotsByTimeBand = useMemo(() => {
+    return TIME_BANDS.map((band) => ({
+      band,
+      slots: slotsForSelectedDate.filter((s) => {
+        const h = jstHour(s.start);
+        return h >= band.startHour && h < band.endHour;
+      }),
+    })).filter((g) => g.slots.length > 0);
+  }, [slotsForSelectedDate]);
+
+  const handleSelectSlot = useCallback((slot: BookingMirrorSlot) => {
+    setSelectedSlot(slot);
+    setStep('form');
+  }, []);
+
+  const handleBack = useCallback(() => {
+    setSelectedSlot(null);
+    setStep('select');
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    if (!selectedSlot || !guestName.trim()) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      const res = await publicPost<{ booking: PublicBookingConfirmation }>(
+        `/api/public/booking-mirror/${linkId}/book`,
+        {
+          slotStart: selectedSlot.start,
+          slotEnd: selectedSlot.end,
+          guestName: guestName.trim(),
+          guestEmail: guestEmail.trim() || undefined,
+          guestMessage: guestMessage.trim() || undefined,
+        },
+      );
+      setConfirmation(res.booking);
+      setStep('confirmed');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Booking failed');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [selectedSlot, guestName, guestEmail, guestMessage, linkId]);
+
+  if (loading) {
+    return (
+      <div style={s.page}>
+        <div style={s.meshBg}>
+          <div style={{ ...s.meshOrb, ...s.orb1 }} />
+        </div>
+        <div style={s.grain} />
+        <div style={s.loadingCenter}>
+          <div style={s.spinner} />
+        </div>
+        <style>{keyframes}</style>
+      </div>
+    );
+  }
+
+  if (error && !linkInfo) {
+    return (
+      <div style={s.page}>
+        <div style={s.meshBg}>
+          <div style={{ ...s.meshOrb, ...s.orb1 }} />
+        </div>
+        <div style={s.grain} />
+        <div style={s.errorCenter}>
+          <h2 style={s.errorTitle}>Link not available</h2>
+          <p style={s.errorMsg}>{error}</p>
+        </div>
+        <style>{keyframes}</style>
+      </div>
+    );
+  }
+
+  if (!linkInfo) return null;
+
+  return (
+    <div style={s.page}>
+      {/* Background */}
+      <div style={s.meshBg}>
+        <div style={{ ...s.meshOrb, ...s.orb1 }} />
+      </div>
+      <div style={s.grain} />
+
+      {/* Main layout */}
+      <div
+        style={{
+          ...s.layout,
+          opacity: mounted ? 1 : 0,
+          transform: mounted ? 'translateY(0)' : 'translateY(16px)',
+        }}
+      >
+        {/* Left: Info panel */}
+        <aside style={s.infoPanel}>
+          <a href="/" style={s.logo}>
+            Calendar<span style={s.logoAccent}>Hub</span>
+          </a>
+
+          <div style={s.ownerName}>{linkInfo.ownerDisplayName}</div>
+          <h1 style={s.meetingTitle}>{linkInfo.title}</h1>
+
+          {slots.length > 0 && (
+            <div style={s.durationBadge}>
+              <span style={s.durationIcon}>◷</span>
+              {slots[0].durationMinutes}分
+            </div>
+          )}
+
+          {linkInfo.description && <p style={s.description}>{linkInfo.description}</p>}
+
+          <div style={s.divider} />
+
+          <div style={s.steps}>
+            <div
+              style={{
+                ...s.stepItem,
+                color: step === 'select' ? 'var(--color-accent)' : 'var(--color-text-muted)',
+              }}
+            >
+              <span style={s.stepNum}>1</span> 日時を選択
+            </div>
+            <div
+              style={{
+                ...s.stepItem,
+                color: step === 'form' ? 'var(--color-accent)' : 'var(--color-text-muted)',
+              }}
+            >
+              <span style={s.stepNum}>2</span> 情報を入力
+            </div>
+            <div
+              style={{
+                ...s.stepItem,
+                color: step === 'confirmed' ? 'var(--color-accent)' : 'var(--color-text-muted)',
+              }}
+            >
+              <span style={s.stepNum}>3</span> 確認
+            </div>
+          </div>
+        </aside>
+
+        {/* Right: Content area */}
+        <main style={s.contentPanel}>
+          {error && <div style={s.errorBanner}>{error}</div>}
+
+          {step === 'select' && (
+            <>
+              {/* Date cards */}
+              <div style={s.sectionLabel}>日付を選択</div>
+              {slotsLoading ? (
+                <div style={s.slotsLoading}>読み込み中...</div>
+              ) : availableDates.length === 0 ? (
+                <div style={s.noSlots}>利用可能な日程がありません</div>
+              ) : (
+                <>
+                  <div style={s.dateCardsWrap}>
+                    <div style={s.dateCards}>
+                      {availableDates.map((date) => (
+                        <button
+                          key={date}
+                          data-testid={`date-card-${date}`}
+                          onClick={() => {
+                            setSelectedDate(date);
+                            setSelectedSlot(null);
+                          }}
+                          className="date-card"
+                          style={{
+                            ...s.dateCard,
+                            borderColor:
+                              selectedDate === date ? 'var(--color-accent)' : 'var(--color-border)',
+                            background:
+                              selectedDate === date
+                                ? 'var(--color-accent-glow)'
+                                : 'var(--color-surface)',
+                          }}
+                        >
+                          <span style={s.dateWeekday}>{formatWeekday(date)}</span>
+                          <span
+                            style={{
+                              ...s.dateNum,
+                              color:
+                                selectedDate === date ? 'var(--color-accent)' : 'var(--color-text)',
+                            }}
+                          >
+                            {formatDateNum(date)}
+                          </span>
+                          <span style={s.dateSlotCount}>{dateGroups[date].length}枠</span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Time slots — 時間帯セクション化 */}
+                  {selectedDate && (
+                    <>
+                      <div style={s.sectionLabel}>{formatDate(selectedDate)} の空き時間</div>
+                      {slotsByTimeBand.length === 0 ? (
+                        <div style={s.noSlots}>この日の空き時間はありません</div>
+                      ) : (
+                        slotsByTimeBand.map(({ band, slots: bandSlots }) => (
+                          <div key={band.key} style={s.timeBandWrap}>
+                            <div style={s.timeBandLabel}>【{band.label}】</div>
+                            <div style={s.slotsGrid}>
+                              {bandSlots.map((slot) => (
+                                <button
+                                  key={slot.start}
+                                  data-testid={`slot-btn-${slot.start}`}
+                                  onClick={() => handleSelectSlot(slot)}
+                                  className="slot-btn"
+                                  style={s.slotBtn}
+                                >
+                                  {formatTime(slot.start)}
+                                </button>
+                              ))}
+                            </div>
+                          </div>
+                        ))
+                      )}
+                    </>
+                  )}
+                </>
+              )}
+            </>
+          )}
+
+          {step === 'form' && selectedSlot && (
+            <div style={s.formWrap}>
+              <button onClick={handleBack} style={s.backBtn}>
+                ← 日時選択に戻る
+              </button>
+
+              <div style={s.selectedTime}>
+                <span style={s.selectedTimeLabel}>選択した日時</span>
+                <span style={s.selectedTimeValue}>
+                  {formatDate(jstDateKey(selectedSlot.start))} {formatTime(selectedSlot.start)} -{' '}
+                  {formatTime(selectedSlot.end)}
+                </span>
+              </div>
+
+              <div style={s.formFields}>
+                <label style={s.label}>
+                  お名前 <span style={s.required}>*</span>
+                </label>
+                <input
+                  type="text"
+                  value={guestName}
+                  onChange={(e) => setGuestName(e.target.value)}
+                  placeholder="山田 太郎"
+                  style={s.input}
+                  autoFocus
+                />
+
+                <label style={s.label}>メールアドレス</label>
+                <input
+                  type="email"
+                  value={guestEmail}
+                  onChange={(e) => setGuestEmail(e.target.value)}
+                  placeholder="email@example.com"
+                  style={s.input}
+                />
+                <span style={s.hint}>入力すると確認メールをお送りします</span>
+
+                <label style={s.label}>メッセージ</label>
+                <textarea
+                  value={guestMessage}
+                  onChange={(e) => setGuestMessage(e.target.value)}
+                  placeholder="ご要望など"
+                  rows={3}
+                  style={{ ...s.input, resize: 'vertical' as const }}
+                />
+              </div>
+
+              <button
+                onClick={handleSubmit}
+                disabled={!guestName.trim() || submitting}
+                data-testid="submit-btn"
+                className="submit-btn"
+                style={{
+                  ...s.submitBtn,
+                  opacity: !guestName.trim() || submitting ? 0.5 : 1,
+                }}
+              >
+                {submitting ? '予約中...' : '予約を確定する'}
+              </button>
+            </div>
+          )}
+
+          {step === 'confirmed' && confirmation && (
+            <div style={s.confirmedWrap}>
+              <div style={s.checkCircle}>
+                <svg width="48" height="48" viewBox="0 0 48 48" fill="none">
+                  <circle cx="24" cy="24" r="22" stroke="var(--color-accent)" strokeWidth="2" />
+                  <path
+                    d="M14 24L21 31L34 18"
+                    stroke="var(--color-accent)"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+              <h2 style={s.confirmedTitle}>予約が確定しました</h2>
+              <div style={s.confirmedCard}>
+                <p style={s.confirmedItem}>
+                  <strong>{confirmation.linkTitle}</strong>
+                </p>
+                <p style={s.confirmedItem}>
+                  {formatDate(jstDateKey(confirmation.slotStart))}{' '}
+                  {formatTime(confirmation.slotStart)} - {formatTime(confirmation.slotEnd)}
+                </p>
+                <p style={s.confirmedItem}>主催: {confirmation.ownerDisplayName}</p>
+              </div>
+              {guestEmail && (
+                <p style={s.confirmedHint}>確認メールを {guestEmail} に送信しました</p>
+              )}
+            </div>
+          )}
+        </main>
+      </div>
+
+      {/* Footer */}
+      <div style={s.footer}>
+        <span style={s.footerText}>
+          Calendar<span style={s.logoAccent}>Hub</span>
+        </span>
+      </div>
+
+      <style>{keyframes}</style>
+    </div>
+  );
+}
+
+// --- ユーティリティ（モジュールスコープ） ---
+
+const TIME_BANDS = [
+  { key: 'morning', label: '朝', startHour: 0, endHour: 12 },
+  { key: 'noon', label: '昼', startHour: 12, endHour: 14 },
+  { key: 'afternoon', label: '午後', startHour: 14, endHour: 17 },
+  { key: 'evening', label: '夕方', startHour: 17, endHour: 19 },
+  { key: 'night', label: '夜', startHour: 19, endHour: 24 },
+] as const;
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+function jstDateKey(isoStr: string): string {
+  const t = new Date(isoStr).getTime();
+  const jst = new Date(t + JST_OFFSET_MS);
+  const y = jst.getUTCFullYear();
+  const m = String(jst.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(jst.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function jstHour(isoStr: string): number {
+  const t = new Date(isoStr).getTime();
+  return new Date(t + JST_OFFSET_MS).getUTCHours();
+}
+
+function toLocalDate(dateStr: string): Date {
+  return new Date(dateStr + 'T00:00:00');
+}
+
+function formatDate(dateStr: string): string {
+  return toLocalDate(dateStr).toLocaleDateString('ja-JP', {
+    month: 'short',
+    day: 'numeric',
+    weekday: 'short',
+  });
+}
+
+function formatTime(isoStr: string): string {
+  return new Date(isoStr).toLocaleTimeString('ja-JP', {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Asia/Tokyo',
+  });
+}
+
+function formatDateNum(dateStr: string): string {
+  return toLocalDate(dateStr).getDate().toString();
+}
+
+function formatWeekday(dateStr: string): string {
+  return toLocalDate(dateStr).toLocaleDateString('ja-JP', { weekday: 'short' });
+}
+
+const keyframes = `
+  @keyframes float1 {
+    0%, 100% { transform: translate(0, 0) scale(1); }
+    33% { transform: translate(30px, -50px) scale(1.1); }
+    66% { transform: translate(-20px, 20px) scale(0.9); }
+  }
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+  @keyframes scaleIn {
+    from { transform: scale(0); opacity: 0; }
+    to { transform: scale(1); opacity: 1; }
+  }
+  .date-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--color-accent) !important;
+  }
+  .slot-btn:hover {
+    background: var(--color-accent-glow) !important;
+    border-color: var(--color-accent) !important;
+    color: var(--color-accent) !important;
+  }
+  .submit-btn:hover:not(:disabled) {
+    background: #c86840 !important;
+  }
+  @media (max-width: 768px) {
+    .book-layout {
+      flex-direction: column !important;
+    }
+    .book-info-panel {
+      border-right: none !important;
+      border-bottom: 1px solid var(--color-border) !important;
+      max-width: 100% !important;
+      padding: 24px !important;
+    }
+  }
+`;
+
+const s: Record<string, React.CSSProperties> = {
+  page: {
+    position: 'relative',
+    minHeight: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  meshBg: {
+    position: 'fixed',
+    inset: 0,
+    overflow: 'hidden',
+    zIndex: 0,
+    pointerEvents: 'none',
+  },
+  meshOrb: {
+    position: 'absolute',
+    borderRadius: '50%',
+    filter: 'blur(120px)',
+  },
+  orb1: {
+    width: '600px',
+    height: '600px',
+    background: 'radial-gradient(circle, rgba(224, 120, 80, 0.12) 0%, transparent 70%)',
+    top: '-15%',
+    right: '-10%',
+    animation: 'float1 20s ease-in-out infinite',
+  },
+  grain: {
+    position: 'fixed',
+    inset: 0,
+    background: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E")`,
+    zIndex: 1,
+    pointerEvents: 'none',
+  },
+  layout: {
+    position: 'relative',
+    zIndex: 10,
+    display: 'flex',
+    width: '100%',
+    maxWidth: '960px',
+    minHeight: '580px',
+    margin: '40px 20px',
+    background: 'rgba(255, 255, 255, 0.02)',
+    border: '1px solid var(--color-border)',
+    borderRadius: '20px',
+    overflow: 'hidden',
+    backdropFilter: 'blur(8px)',
+    transition: 'opacity 0.6s ease, transform 0.6s ease',
+  },
+
+  // Info panel (left)
+  infoPanel: {
+    width: '38.2%',
+    minWidth: '240px',
+    padding: '36px 28px',
+    borderRight: '1px solid var(--color-border)',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  logo: {
+    fontFamily: 'var(--font-display)',
+    fontSize: '16px',
+    fontWeight: 700,
+    color: 'var(--color-text)',
+    textDecoration: 'none',
+    letterSpacing: '-0.5px',
+    marginBottom: '32px',
+  },
+  logoAccent: { color: 'var(--color-accent)' },
+  ownerName: {
+    fontSize: '13px',
+    color: 'var(--color-text-muted)',
+    marginBottom: '6px',
+    letterSpacing: '0.3px',
+  },
+  meetingTitle: {
+    fontFamily: 'var(--font-display)',
+    fontSize: '22px',
+    fontWeight: 600,
+    letterSpacing: '-0.3px',
+    marginBottom: '14px',
+    lineHeight: 1.3,
+  },
+  durationBadge: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '6px',
+    padding: '6px 14px',
+    background: 'var(--color-accent-glow)',
+    border: '1px solid rgba(224, 120, 80, 0.2)',
+    borderRadius: '20px',
+    fontSize: '13px',
+    fontWeight: 500,
+    color: 'var(--color-accent)',
+    marginBottom: '16px',
+    width: 'fit-content',
+  },
+  durationIcon: { fontSize: '14px' },
+  description: {
+    fontSize: '13px',
+    lineHeight: 1.7,
+    color: 'var(--color-text-muted)',
+    marginBottom: '16px',
+  },
+  divider: {
+    height: '1px',
+    background: 'var(--color-border)',
+    margin: '8px 0 20px',
+  },
+  steps: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+    marginTop: 'auto',
+  },
+  stepItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px',
+    fontSize: '13px',
+    fontWeight: 500,
+    transition: 'color 0.2s ease',
+  },
+  stepNum: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '22px',
+    height: '22px',
+    borderRadius: '50%',
+    border: '1px solid currentColor',
+    fontSize: '11px',
+    fontWeight: 600,
+  },
+
+  // Content panel (right)
+  contentPanel: {
+    flex: 1,
+    padding: '32px',
+    overflowY: 'auto',
+    maxHeight: '80vh',
+  },
+  sectionLabel: {
+    fontSize: '13px',
+    fontWeight: 600,
+    color: 'var(--color-text-muted)',
+    marginBottom: '14px',
+    letterSpacing: '0.5px',
+    textTransform: 'uppercase' as const,
+  },
+  errorBanner: {
+    padding: '10px 14px',
+    background: 'rgba(229,57,53,0.1)',
+    border: '1px solid rgba(229,57,53,0.2)',
+    borderRadius: '8px',
+    marginBottom: '16px',
+    fontSize: '13px',
+    color: '#ef9a9a',
+  },
+
+  // Date cards
+  dateCardsWrap: {
+    overflowX: 'auto',
+    marginBottom: '24px',
+    paddingBottom: '4px',
+  },
+  dateCards: {
+    display: 'flex',
+    gap: '8px',
+  },
+  dateCard: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '4px',
+    padding: '12px 16px',
+    border: '1px solid var(--color-border)',
+    borderRadius: '12px',
+    background: 'var(--color-surface)',
+    cursor: 'pointer',
+    transition: 'all 0.2s ease',
+    minWidth: '64px',
+    fontFamily: 'inherit',
+    color: 'inherit',
+  },
+  dateWeekday: {
+    fontSize: '11px',
+    color: 'var(--color-text-muted)',
+    fontWeight: 500,
+  },
+  dateNum: {
+    fontSize: '20px',
+    fontWeight: 600,
+    fontFamily: 'var(--font-display)',
+  },
+  dateSlotCount: {
+    fontSize: '10px',
+    color: 'var(--color-text-muted)',
+  },
+
+  // Time slots
+  timeBandWrap: {
+    marginBottom: '20px',
+  },
+  timeBandLabel: {
+    fontSize: '12px',
+    fontWeight: 600,
+    color: 'var(--color-text-muted)',
+    marginBottom: '8px',
+    letterSpacing: '0.3px',
+  },
+  slotsGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(90px, 1fr))',
+    gap: '8px',
+    marginBottom: '8px',
+  },
+  slotBtn: {
+    padding: '10px 8px',
+    border: '1px solid var(--color-border)',
+    borderRadius: '8px',
+    background: 'var(--color-surface)',
+    color: 'var(--color-text)',
+    fontSize: '14px',
+    fontWeight: 500,
+    fontFamily: 'var(--font-display)',
+    cursor: 'pointer',
+    transition: 'all 0.2s ease',
+    letterSpacing: '0.5px',
+  },
+  slotsLoading: {
+    textAlign: 'center',
+    padding: '40px',
+    color: 'var(--color-text-muted)',
+    fontSize: '13px',
+  },
+  noSlots: {
+    textAlign: 'center',
+    padding: '40px',
+    color: 'var(--color-text-muted)',
+    fontSize: '14px',
+  },
+
+  // Form
+  formWrap: {
+    animation: 'scaleIn 0.3s ease',
+  },
+  backBtn: {
+    background: 'none',
+    border: 'none',
+    color: 'var(--color-text-muted)',
+    cursor: 'pointer',
+    fontSize: '13px',
+    padding: '0',
+    marginBottom: '20px',
+    fontFamily: 'inherit',
+  },
+  selectedTime: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+    padding: '16px',
+    background: 'var(--color-accent-glow)',
+    border: '1px solid rgba(224, 120, 80, 0.2)',
+    borderRadius: '12px',
+    marginBottom: '24px',
+  },
+  selectedTimeLabel: {
+    fontSize: '11px',
+    color: 'var(--color-accent)',
+    fontWeight: 600,
+    letterSpacing: '0.5px',
+    textTransform: 'uppercase' as const,
+  },
+  selectedTimeValue: {
+    fontSize: '16px',
+    fontWeight: 500,
+    fontFamily: 'var(--font-display)',
+  },
+  formFields: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    marginBottom: '24px',
+  },
+  label: {
+    fontSize: '13px',
+    fontWeight: 500,
+    color: 'var(--color-text-muted)',
+    marginTop: '8px',
+  },
+  required: { color: 'var(--color-accent)' },
+  input: {
+    padding: '12px 14px',
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-border)',
+    borderRadius: '10px',
+    color: 'var(--color-text)',
+    fontSize: '14px',
+    fontFamily: 'inherit',
+    outline: 'none',
+    transition: 'border-color 0.2s ease',
+  },
+  hint: {
+    fontSize: '11px',
+    color: 'var(--color-text-muted)',
+    marginTop: '-4px',
+  },
+  submitBtn: {
+    width: '100%',
+    padding: '14px',
+    background: 'var(--color-accent)',
+    color: '#fff',
+    border: 'none',
+    borderRadius: '12px',
+    fontSize: '15px',
+    fontWeight: 600,
+    fontFamily: 'inherit',
+    cursor: 'pointer',
+    transition: 'all 0.2s ease',
+    letterSpacing: '0.3px',
+  },
+
+  // Confirmed
+  confirmedWrap: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    textAlign: 'center',
+    padding: '40px 20px',
+  },
+  checkCircle: {
+    marginBottom: '20px',
+    animation: 'scaleIn 0.4s ease',
+  },
+  confirmedTitle: {
+    fontFamily: 'var(--font-display)',
+    fontSize: '22px',
+    fontWeight: 600,
+    marginBottom: '20px',
+  },
+  confirmedCard: {
+    padding: '20px',
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-border)',
+    borderRadius: '12px',
+    width: '100%',
+    maxWidth: '320px',
+  },
+  confirmedItem: {
+    fontSize: '14px',
+    margin: '6px 0',
+    color: 'var(--color-text-muted)',
+  },
+  confirmedHint: {
+    fontSize: '12px',
+    color: 'var(--color-text-muted)',
+    marginTop: '16px',
+  },
+
+  // Footer
+  footer: {
+    position: 'relative',
+    zIndex: 10,
+    padding: '20px',
+    textAlign: 'center',
+  },
+  footerText: {
+    fontFamily: 'var(--font-display)',
+    fontSize: '12px',
+    color: 'var(--color-text-muted)',
+    opacity: 0.5,
+    letterSpacing: '-0.3px',
+  },
+
+  // Loading / Error states
+  loadingCenter: {
+    position: 'relative',
+    zIndex: 10,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '200px',
+  },
+  spinner: {
+    width: '32px',
+    height: '32px',
+    border: '2px solid var(--color-border)',
+    borderTopColor: 'var(--color-accent)',
+    borderRadius: '50%',
+    animation: 'spin 0.8s linear infinite',
+  },
+  errorCenter: {
+    position: 'relative',
+    zIndex: 10,
+    textAlign: 'center',
+    padding: '60px 20px',
+  },
+  errorTitle: {
+    fontFamily: 'var(--font-display)',
+    fontSize: '20px',
+    fontWeight: 600,
+    marginBottom: '8px',
+  },
+  errorMsg: {
+    fontSize: '14px',
+    color: 'var(--color-text-muted)',
+  },
+};

--- a/apps/web/src/app/book-mirror/[linkId]/layout.tsx
+++ b/apps/web/src/app/book-mirror/[linkId]/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Schedule a Meeting - Calendar Hub',
+  description: 'Pick a time that works for you',
+};
+
+export default function BookMirrorLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/apps/web/src/app/book-mirror/[linkId]/page.tsx
+++ b/apps/web/src/app/book-mirror/[linkId]/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+
+const BookMirrorContent = dynamic(
+  () => import('./book-mirror-content').then((m) => m.BookMirrorContent),
+  { ssr: false },
+);
+
+export default function BookMirrorPage() {
+  return (
+    <Suspense fallback={<div style={{ minHeight: '100vh' }} />}>
+      <BookMirrorContent />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/booking-mirror-links/booking-mirror-links-content.tsx
+++ b/apps/web/src/app/booking-mirror-links/booking-mirror-links-content.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useRequireAuth } from '../../hooks/useRequireAuth';
+import { apiGet, apiDelete, apiPatch } from '../../lib/api';
+import { PageShell, PageLoading } from '../../components/PageShell';
+import type { BookingMirrorLink } from '@calendar-hub/shared';
+
+export function BookingMirrorLinksContent() {
+  const { user, loading: authLoading } = useRequireAuth();
+  const router = useRouter();
+  const [links, setLinks] = useState<BookingMirrorLink[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState('');
+
+  const loadLinks = useCallback(async () => {
+    try {
+      const res = await apiGet<{ links: BookingMirrorLink[] }>('/api/booking-mirror-links');
+      setLinks(res.links);
+    } catch (err) {
+      console.error('Failed to load mirror links:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (user) loadLinks();
+  }, [user, loadLinks]);
+
+  const handleToggleStatus = async (link: BookingMirrorLink) => {
+    const newStatus = link.status === 'active' ? 'paused' : 'active';
+    try {
+      const res = await apiPatch<{ link: BookingMirrorLink }>(
+        `/api/booking-mirror-links/${link.id}`,
+        { status: newStatus },
+      );
+      setLinks((prev) => prev.map((l) => (l.id === link.id ? res.link : l)));
+      setMessage(newStatus === 'active' ? 'リンクを有効にしました' : 'リンクを一時停止しました');
+    } catch {
+      setMessage('更新に失敗しました');
+    }
+  };
+
+  const handleDelete = async (linkId: string) => {
+    if (!confirm('このミラーリンクを削除しますか？')) return;
+    try {
+      await apiDelete(`/api/booking-mirror-links/${linkId}`);
+      setLinks((prev) => prev.filter((l) => l.id !== linkId));
+      setMessage('リンクを削除しました');
+    } catch {
+      setMessage('削除に失敗しました');
+    }
+  };
+
+  const handleCopyLink = (linkId: string) => {
+    const url = `${window.location.origin}/book-mirror/${linkId}`;
+    navigator.clipboard.writeText(url);
+    setMessage('リンクをコピーしました');
+  };
+
+  if (authLoading) return <PageLoading />;
+  if (!user) return null;
+
+  return (
+    <PageShell maxWidth="medium">
+      <div style={s.header}>
+        <h1 style={s.title}>予約ミラー (Google 予約スケジュール完全反映)</h1>
+        <button onClick={() => router.push('/booking-mirror-links/new')} style={s.addBtn}>
+          + 新規作成
+        </button>
+      </div>
+
+      <p style={s.intro}>
+        Google 予約スケジュールの公開ページ URL を登録すると、その内容がそのまま CalendarHub
+        上の公開予約ページとして表示されます。
+      </p>
+
+      {message && (
+        <div style={s.toast} onClick={() => setMessage('')}>
+          {message}
+        </div>
+      )}
+
+      {loading ? (
+        <div style={s.loadingMsg}>読み込み中...</div>
+      ) : links.length === 0 ? (
+        <div style={s.empty}>
+          <p style={s.emptyText}>ミラーリンクがまだありません</p>
+          <p style={s.emptyHint}>
+            「+ 新規作成」から Google 予約スケジュールの公開 URL を貼り付けて作成してください
+          </p>
+        </div>
+      ) : (
+        <div style={s.list}>
+          {links.map((link) => (
+            <div key={link.id} style={s.card}>
+              <div style={s.cardHeader}>
+                <div>
+                  <h3 style={s.cardTitle}>{link.title}</h3>
+                  <span style={s.cardSourceUrl}>{link.sourceUrl}</span>
+                </div>
+                <span
+                  style={{
+                    ...s.statusBadge,
+                    background:
+                      link.status === 'active' ? 'rgba(76,175,80,0.15)' : 'rgba(255,152,0,0.15)',
+                    color: link.status === 'active' ? '#81c784' : '#ffb74d',
+                  }}
+                >
+                  {link.status === 'active' ? '有効' : '一時停止'}
+                </span>
+              </div>
+
+              {link.description && <p style={s.cardDesc}>{link.description}</p>}
+
+              <div style={s.cardActions}>
+                <button onClick={() => handleCopyLink(link.id)} style={s.actionBtn}>
+                  URLコピー
+                </button>
+                <button
+                  onClick={() => window.open(`/book-mirror/${link.id}`, '_blank')}
+                  style={s.actionBtn}
+                >
+                  プレビュー
+                </button>
+                <button onClick={() => handleToggleStatus(link)} style={s.actionBtn}>
+                  {link.status === 'active' ? '一時停止' : '有効化'}
+                </button>
+                <button
+                  onClick={() => handleDelete(link.id)}
+                  style={{ ...s.actionBtn, color: '#ef9a9a' }}
+                >
+                  削除
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </PageShell>
+  );
+}
+
+const s: Record<string, React.CSSProperties> = {
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '12px',
+    flexWrap: 'wrap',
+    gap: '12px',
+  },
+  title: { fontFamily: 'var(--font-display)', fontSize: '22px', fontWeight: 600 },
+  intro: {
+    fontSize: '13px',
+    color: 'var(--color-text-muted)',
+    marginBottom: '24px',
+    lineHeight: 1.6,
+  },
+  addBtn: {
+    padding: '10px 20px',
+    background: 'var(--color-accent)',
+    color: '#fff',
+    border: 'none',
+    borderRadius: '10px',
+    fontSize: '14px',
+    fontWeight: 500,
+    cursor: 'pointer',
+    fontFamily: 'inherit',
+  },
+  toast: {
+    padding: '10px 16px',
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-border)',
+    borderRadius: '8px',
+    fontSize: '13px',
+    marginBottom: '16px',
+    cursor: 'pointer',
+    color: 'var(--color-accent)',
+  },
+  loadingMsg: {
+    textAlign: 'center',
+    padding: '40px',
+    color: 'var(--color-text-muted)',
+    fontSize: '13px',
+  },
+  empty: { textAlign: 'center', padding: '60px 20px' },
+  emptyText: { fontSize: '16px', fontWeight: 500, marginBottom: '8px' },
+  emptyHint: { fontSize: '13px', color: 'var(--color-text-muted)', lineHeight: 1.6 },
+  list: { display: 'flex', flexDirection: 'column', gap: '12px' },
+  card: {
+    padding: '20px',
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-border)',
+    borderRadius: 'var(--radius)',
+  },
+  cardHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: '8px',
+    gap: '12px',
+  },
+  cardTitle: { fontSize: '16px', fontWeight: 600, marginBottom: '4px' },
+  cardSourceUrl: {
+    fontSize: '11px',
+    color: 'var(--color-text-muted)',
+    fontFamily: 'var(--font-mono, monospace)',
+    wordBreak: 'break-all',
+  },
+  statusBadge: { fontSize: '11px', padding: '4px 10px', borderRadius: '6px', fontWeight: 500 },
+  cardDesc: {
+    fontSize: '13px',
+    color: 'var(--color-text-muted)',
+    lineHeight: 1.5,
+    marginBottom: '12px',
+  },
+  cardActions: {
+    display: 'flex',
+    gap: '8px',
+    flexWrap: 'wrap',
+    borderTop: '1px solid var(--color-border)',
+    paddingTop: '12px',
+    marginTop: '4px',
+  },
+  actionBtn: {
+    padding: '6px 14px',
+    background: 'none',
+    border: '1px solid var(--color-border)',
+    borderRadius: '6px',
+    fontSize: '12px',
+    fontWeight: 500,
+    color: 'var(--color-text-muted)',
+    cursor: 'pointer',
+    fontFamily: 'inherit',
+    transition: 'all 0.2s ease',
+  },
+};

--- a/apps/web/src/app/booking-mirror-links/new/new-mirror-link-content.tsx
+++ b/apps/web/src/app/booking-mirror-links/new/new-mirror-link-content.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useRequireAuth } from '../../../hooks/useRequireAuth';
+import { apiPost } from '../../../lib/api';
+import { PageShell, PageLoading } from '../../../components/PageShell';
+import type { BookingMirrorLink, CreateBookingMirrorLinkInput } from '@calendar-hub/shared';
+
+export function NewMirrorLinkContent() {
+  const { user, loading: authLoading } = useRequireAuth();
+  const router = useRouter();
+
+  const [sourceUrl, setSourceUrl] = useState('');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [notificationEmail, setNotificationEmail] = useState('');
+  const [rangeDays, setRangeDays] = useState(30);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async () => {
+    setError('');
+    if (!sourceUrl.trim()) {
+      setError('Google 予約スケジュール URL は必須です');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const input: CreateBookingMirrorLinkInput = {
+        sourceUrl: sourceUrl.trim(),
+        title: title.trim() || undefined,
+        description: description.trim() || undefined,
+        notificationEmail: notificationEmail.trim() || undefined,
+        rangeDays,
+      };
+      await apiPost<{ link: BookingMirrorLink }>('/api/booking-mirror-links', input);
+      router.push('/booking-mirror-links');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '作成に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (authLoading) return <PageLoading />;
+  if (!user) return null;
+
+  return (
+    <PageShell maxWidth="medium">
+      <button onClick={() => router.back()} style={s.backBtn}>
+        ← 戻る
+      </button>
+
+      <h1 style={s.title}>新規ミラーリンク作成</h1>
+      <p style={s.intro}>
+        Google 予約スケジュールの公開ページ URL を貼り付けると、その内容がそのまま CalendarHub
+        の公開予約ページに反映されます。Google 側設定（営業時間 / 既存予定 / Buffer 等）はすべて
+        Google 予約スケジュールの判定をそのまま使います。
+      </p>
+
+      {error && <div style={s.errorBox}>{error}</div>}
+
+      <div style={s.section}>
+        <label style={s.label}>
+          Google 予約スケジュール URL <span style={s.required}>*</span>
+        </label>
+        <input
+          type="url"
+          value={sourceUrl}
+          onChange={(e) => setSourceUrl(e.target.value)}
+          placeholder="https://calendar.app.google/XXX または完全 URL"
+          style={s.input}
+          autoFocus
+        />
+        <span style={s.hint}>
+          短縮 URL (`calendar.app.google/...`) と完全 URL
+          (`calendar.google.com/calendar/.../schedules/...`) のどちらも入力可能です
+        </span>
+
+        <label style={s.label}>タイトル (任意)</label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="例: 【本田】予約スケジュール"
+          style={s.input}
+        />
+        <span style={s.hint}>未入力時は「【ミラー】予約スケジュール」になります</span>
+
+        <label style={s.label}>説明 (任意)</label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="ご相談・お打ち合わせのご予約はこちらから（60分）"
+          rows={3}
+          style={{ ...s.input, resize: 'vertical' as const }}
+        />
+
+        <label style={s.label}>通知先メール (任意)</label>
+        <input
+          type="email"
+          value={notificationEmail}
+          onChange={(e) => setNotificationEmail(e.target.value)}
+          placeholder="hy.unimail.11@gmail.com"
+          style={s.input}
+        />
+        <span style={s.hint}>未入力時は hy.unimail.11@gmail.com に通知が送られます</span>
+
+        <label style={s.label}>公開日数</label>
+        <select
+          value={rangeDays}
+          onChange={(e) => setRangeDays(Number(e.target.value))}
+          style={s.input}
+        >
+          {[7, 14, 30, 45, 60].map((d) => (
+            <option key={d} value={d}>
+              {d} 日先まで
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <button
+        onClick={handleSubmit}
+        disabled={!sourceUrl.trim() || submitting}
+        style={{ ...s.submitBtn, opacity: !sourceUrl.trim() || submitting ? 0.5 : 1 }}
+      >
+        {submitting ? '作成中...' : 'ミラーリンクを作成'}
+      </button>
+    </PageShell>
+  );
+}
+
+const s: Record<string, React.CSSProperties> = {
+  backBtn: {
+    background: 'none',
+    border: 'none',
+    color: 'var(--color-text-muted)',
+    cursor: 'pointer',
+    fontSize: '13px',
+    padding: '0',
+    marginBottom: '20px',
+    fontFamily: 'inherit',
+  },
+  title: {
+    fontFamily: 'var(--font-display)',
+    fontSize: '22px',
+    fontWeight: 600,
+    marginBottom: '8px',
+  },
+  intro: {
+    fontSize: '13px',
+    color: 'var(--color-text-muted)',
+    marginBottom: '24px',
+    lineHeight: 1.6,
+  },
+  errorBox: {
+    padding: '10px 14px',
+    background: 'rgba(229,57,53,0.1)',
+    border: '1px solid rgba(229,57,53,0.2)',
+    borderRadius: '8px',
+    marginBottom: '16px',
+    fontSize: '13px',
+    color: '#ef9a9a',
+  },
+  section: {
+    padding: '20px',
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-border)',
+    borderRadius: 'var(--radius)',
+    marginBottom: '24px',
+  },
+  label: {
+    display: 'block',
+    fontSize: '13px',
+    fontWeight: 500,
+    color: 'var(--color-text-muted)',
+    marginTop: '12px',
+    marginBottom: '6px',
+  },
+  required: { color: 'var(--color-accent)' },
+  input: {
+    width: '100%',
+    padding: '12px 14px',
+    background: 'var(--color-bg)',
+    border: '1px solid var(--color-border)',
+    borderRadius: '10px',
+    color: 'var(--color-text)',
+    fontSize: '14px',
+    fontFamily: 'inherit',
+    outline: 'none',
+    boxSizing: 'border-box',
+  },
+  hint: {
+    display: 'block',
+    fontSize: '11px',
+    color: 'var(--color-text-muted)',
+    marginTop: '-2px',
+    lineHeight: 1.5,
+  },
+  submitBtn: {
+    width: '100%',
+    padding: '14px',
+    background: 'var(--color-accent)',
+    color: '#fff',
+    border: 'none',
+    borderRadius: '12px',
+    fontSize: '15px',
+    fontWeight: 600,
+    fontFamily: 'inherit',
+    cursor: 'pointer',
+  },
+};

--- a/apps/web/src/app/booking-mirror-links/new/page.tsx
+++ b/apps/web/src/app/booking-mirror-links/new/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+
+const NewMirrorLinkContent = dynamic(
+  () => import('./new-mirror-link-content').then((m) => m.NewMirrorLinkContent),
+  { ssr: false },
+);
+
+export default function NewBookingMirrorLinkPage() {
+  return (
+    <Suspense fallback={<div style={{ minHeight: '100vh' }} />}>
+      <NewMirrorLinkContent />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/booking-mirror-links/page.tsx
+++ b/apps/web/src/app/booking-mirror-links/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+
+const BookingMirrorLinksContent = dynamic(
+  () => import('./booking-mirror-links-content').then((m) => m.BookingMirrorLinksContent),
+  { ssr: false },
+);
+
+export default function BookingMirrorLinksPage() {
+  return (
+    <Suspense fallback={<div style={{ minHeight: '100vh' }} />}>
+      <BookingMirrorLinksContent />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/AppNav.tsx
+++ b/apps/web/src/components/AppNav.tsx
@@ -7,6 +7,7 @@ const NAV_ITEMS = [
   { href: '/calendar', label: 'カレンダー', icon: '◎' },
   { href: '/sync-settings', label: '同期', icon: '⟳' },
   { href: '/booking-links', label: '予約', icon: '◈' },
+  { href: '/booking-mirror-links', label: 'ミラー', icon: '◆' },
   { href: '/ai', label: 'AI提案', icon: '◇' },
   { href: '/settings', label: '設定', icon: '⚙' },
 ];

--- a/docs/specs/2026-06-26-booking-mirror-v2-grpc-design.md
+++ b/docs/specs/2026-06-26-booking-mirror-v2-grpc-design.md
@@ -1,0 +1,317 @@
+# 設計仕様書: Google 予約スケジュール完全反映ミラー (v2 / gRPC-web 直叩き)
+
+- 作成日: 2026-06-26
+- ステータス: v2.1 (本田様承認済み / Codex review 反映済み / C2 採用)
+- 関連: `docs/specs/2026-06-24-booking-mirror-design.md` (v1、Calendar API 自前算出方針) を **置き換える**
+- ブランチ予定: `feat/booking-mirror-v2`
+
+---
+
+## 1. 概要
+
+v1 (Calendar API 自前算出) は Google 予約スケジュール内部の Working Hours / Buffer / 1h スロット境界ルールが Calendar API では取得不可で、本田様が求める「**Google 予約スケジュール公開ページの完全反映**」を満たせなかった。
+
+v2 では Google 予約スケジュール公開ページが内部で叩いている **gRPC-web 公開 API** を CalendarHub サーバから直接叩き、Google 予約スケジュールが算出した空き枠リストをそのまま CalendarHub UI に表示する。
+
+ブレークスルー (2026-06-26 PoC で実証):
+
+```
+POST https://calendar-pa.clients6.google.com/$rpc/google.internal.calendar.v1.AppointmentBookingService/ListAvailableSlots?key=<API_KEY>
+Body: [null, null, "<schedule-id>", null, [[<start-unix>], [<end-unix>]]]
+
+→ 200 OK
+[[[["<unix-timestamp>"], <duration-min>]], ...]
+```
+
+- 認証不要 (X-Goog-Api-Key を query param で渡すだけ、SAPISIDHASH / Cookie 不要)
+- 公開 API (Google 予約スケジュールの公開ページから誰でも叩いている同じ endpoint)
+- レスポンスは構造化 JSON（unix timestamp 配列）
+- Image #14 の枠と完全一致を実証済み
+
+## 2. 動機
+
+| 項目                  | v1 (Calendar API)               | v2 (gRPC-web)                                |
+| --------------------- | ------------------------------- | -------------------------------------------- |
+| 反映度                | Calendar 上の **実 event** のみ | Google 予約スケジュールの公開枠 **そのまま** |
+| Working Hours 設定    | 取得不可                        | 反映済み (Google 側で計算済)                 |
+| Buffer 設定           | 取得不可                        | 反映済み                                     |
+| 半端時間枠 (06:30 等) | 出ない                          | Google 通り                                  |
+| OAuth 連携            | `yasushi.honda` 必要            | **不要**                                     |
+| 規約リスク            | なし (公式 SDK)                 | やや有り (`internal` namespace)              |
+
+本田様の決定 (2026-06-26): 「完全反映されないと意味がない」「完全別枠でも良い」。v1 を廃止し v2 を新規実装する方針。
+
+## 3. 要件
+
+### 3.1 機能要件
+
+| ID   | 要件                                                                                                                            |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------- |
+| FR-1 | 本田様が管理画面で **Google 予約スケジュール短縮 URL** (`calendar.app.google/XXX`) を入力するだけで新規ミラー link を作成できる |
+| FR-2 | 公開ページ `/book-mirror/<linkId>` で Google 予約スケジュール公開ページと**同じ空き枠**を表示する                               |
+| FR-3 | ゲストが枠を選択 → 氏名 (必須) / メール (任意) / メッセージ (任意) を入力するフォームを表示する (既存 UI 流用)                  |
+| FR-4 | 予約成立時に本田様の通知先メール (`hy.unimail.11@gmail.com`) に通知を送信                                                       |
+| FR-5 | ゲストがメールを入力した場合、確認メールも送信                                                                                  |
+| FR-6 | Google Calendar への event 自動作成は**行わない** (Google 予約スケジュール側で別途処理されるため、二重登録回避)                 |
+| FR-7 | 二重予約防止 (Firestore transaction、既存ロジック流用)                                                                          |
+| FR-8 | 既存の `bookingLink` 機能 (v1) とは**完全別物**として共存。v1 link は無効化 / 削除可能                                          |
+| FR-9 | 公開ページを開いた時 / リロード時 / 60s ポーリング / visibility / focus で最新化 (既存 book-content.tsx の挙動と同じ)           |
+
+### 3.2 非機能要件
+
+| ID    | 要件                                                                                                                       |
+| ----- | -------------------------------------------------------------------------------------------------------------------------- |
+| NFR-1 | 既存 Cloud Run service `calendar-hub-api` / `calendar-hub-web` を流用                                                      |
+| NFR-2 | gRPC-web API 直叩きは **サーバサイド (Cloud Run api)** から行う (FE から直接叩くと CORS で blocked、また API Key 露出回避) |
+| NFR-3 | Google API レスポンス構造が変わったときの fallback / 検出機構 (graceful failure + ログ)                                    |
+
+## 4. アーキテクチャ
+
+```
+┌──────────────────────────────────────────────┐
+│ Google 予約スケジュール公開 API               │
+│  POST .../AppointmentBookingService/         │
+│       ListAvailableSlots                      │
+│  POST .../GetAppointmentServiceDefinition    │
+└──────────────────────────────────────────────┘
+           │ HTTPS (X-Goog-Api-Key query param)
+           ▼
+┌──────────────────────────────────────────────┐
+│ Calendar Hub API (Cloud Run / Hono)           │
+│  ├ GET /api/public/booking-mirror/:linkId     │
+│  │    → Firestore から link 情報取得         │
+│  ├ GET /api/public/booking-mirror/:linkId/slots│
+│  │    → resolveScheduleId(shortUrl)           │
+│  │    → fetchAvailableSlots(scheduleId, range)│
+│  │    → convertToBookingSlots(slots)          │
+│  └ POST /api/public/booking-mirror/:linkId/book│
+│       → Firestore に Booking 保存             │
+│       → メール通知 (hy.unimail.11 経由)        │
+└──────────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────┐
+│ Next.js 公開ページ (apps/web/src/app/book-mirror/[linkId]) │
+│  既存 book-content.tsx のセクション化 UI を流用 │
+└──────────────────────────────────────────────┘
+```
+
+### 4.1 schedule ID 解決ロジック
+
+短縮 URL → 完全 schedule ID への解決:
+
+1. `https://calendar.app.google/<short-id>` を fetch、リダイレクト先 URL を取得 (HTTP 30x の Location ヘッダ)
+2. リダイレクト先は `https://calendar.google.com/calendar/u/0/appointments/schedules/<full-schedule-id>`
+3. `<full-schedule-id>` を抽出して保持
+
+**最適化案**: link 作成時に解決して Firestore に保存しておけば、毎回の slots 取得で再解決不要。仕様変更で短縮 URL が変わった場合のみ再解決。
+
+### 4.2 gRPC-web 呼び出し
+
+```ts
+async function fetchAvailableSlots(
+  scheduleId: string,
+  startUnix: number,
+  endUnix: number,
+): Promise<Array<{ startUnix: number; durationMinutes: number }>> {
+  const url = `https://calendar-pa.clients6.google.com/$rpc/google.internal.calendar.v1.AppointmentBookingService/ListAvailableSlots?key=${API_KEY}`;
+  const body = JSON.stringify([null, null, scheduleId, null, [[startUnix], [endUnix]]]);
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json+protobuf',
+      'X-User-Agent': 'grpc-web-javascript/0.1',
+      'X-Goog-AuthUser': '0',
+      Origin: 'https://calendar.google.com',
+      Referer: 'https://calendar.google.com/',
+    },
+    body,
+  });
+  if (!res.ok) throw new Error(`gRPC-web failed: ${res.status}`);
+  const data = (await res.json()) as unknown;
+  return parseSlotResponse(data);
+}
+
+function parseSlotResponse(data: unknown): Array<{ startUnix: number; durationMinutes: number }> {
+  // [[[[["1782466200"], 60]], ...]]
+  // 外側 [0] -> slots array
+  // 各 slot: [[[<unix-str>], <duration>]]
+  const outer = (data as unknown[])[0] as unknown[];
+  return outer.map((slot) => {
+    const inner = (slot as unknown[])[0] as unknown[];
+    const startUnixStr = (inner[0] as unknown[])[0] as string;
+    const durationMinutes = inner[1] as number;
+    return { startUnix: parseInt(startUnixStr, 10), durationMinutes };
+  });
+}
+```
+
+## 5. データモデル
+
+### 5.1 新規 Firestore collection: `bookingMirrorLinks`
+
+```typescript
+export interface BookingMirrorLink {
+  id: string; // nanoid(12)
+  ownerUid: string; // Firebase Auth uid
+  title: string; // 例: 「【本田】予約スケジュール (mirror)」
+  description?: string; // 任意の案内文
+  shortUrl: string; // calendar.app.google/<short-id> ← 必須
+  scheduleId: string; // 解決済み full schedule ID (cache、空のときは毎回再解決)
+  notificationEmail: string; // 通知先 (デフォルト: hy.unimail.11@gmail.com)
+  rangeDays: number; // 公開日数 (デフォルト 30、最大 60)
+  status: 'active' | 'paused';
+  expiresAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+```
+
+### 5.2 関連: `bookings` collection
+
+既存 `bookings` collection を流用。`linkId` フィールドに `bookingMirrorLinks` の id を入れて区別。
+
+## 6. インターフェース変更
+
+### 6.1 新規 API endpoint
+
+#### `GET /api/booking-mirror-links` (オーナー用)
+
+owner の mirror link 一覧を返す。`requireAuth` 必須。
+
+#### `POST /api/booking-mirror-links` (オーナー用)
+
+新規 mirror link 作成。入力: `{ title, shortUrl, notificationEmail?, rangeDays? }`。
+作成時に shortUrl から scheduleId を解決して保存。
+
+#### `DELETE /api/booking-mirror-links/:linkId` (オーナー用)
+
+mirror link 削除。
+
+#### `GET /api/public/booking-mirror/:linkId` (公開)
+
+link 情報の public-safe subset を返す (タイトル / 説明 / 受付状態)。
+
+#### `GET /api/public/booking-mirror/:linkId/slots` (公開)
+
+空き枠取得。サーバ側で gRPC-web API を叩く。レスポンスは既存 `book-content.tsx` の `BookingSlot[]` 形式に変換。
+
+#### `POST /api/public/booking-mirror/:linkId/book` (公開)
+
+予約成立。Firestore に保存 + 通知メール。Google Calendar への event 作成は**行わない** (FR-6)。
+
+### 6.2 新規 FE ページ
+
+#### `apps/web/src/app/book-mirror/[linkId]/`
+
+公開ページ。`page.tsx` + `book-mirror-content.tsx` で構成。
+
+既存 `book-content.tsx` の **時間帯セクション化 UI / JST grouping bug 修正 / ポーリング ロジック** を流用 (コード重複は最小化、可能なら共通化)。
+
+#### `apps/web/src/app/booking-mirror-links/`
+
+管理画面。`booking-mirror-links-content.tsx` で link 一覧 + 「+ 新規作成」ボタン。
+新規作成画面 `apps/web/src/app/booking-mirror-links/new/new-mirror-link-content.tsx` で:
+
+- タイトル
+- Google 予約スケジュール短縮 URL (入力時に format validate)
+- 受付状態 (デフォルト active)
+
+## 7. エラー処理
+
+| 状況                                    | 挙動                                                                  |
+| --------------------------------------- | --------------------------------------------------------------------- |
+| gRPC-web API 200 + 空配列               | 「利用可能な日程がありません」表示                                    |
+| gRPC-web API 非 200 (4xx, 5xx)          | ログ記録 + 公開ページで「現在予約システムに障害が発生しています」表示 |
+| schedule ID 解決失敗 (短縮 URL invalid) | link 作成時に 400 error返却                                           |
+| Google API 仕様変更でレスポンス構造変化 | `parseSlotResponse` で例外 → ログ + 「障害」表示                      |
+
+## 8. テスト戦略
+
+### 8.1 Acceptance Criteria
+
+| AC   | 内容                                                                     | 検証                                               |
+| ---- | ------------------------------------------------------------------------ | -------------------------------------------------- |
+| AC-1 | 短縮 URL `calendar.app.google/2jkd3Ve8yvhPGtwdA` で mirror link 作成成功 | 手動確認 (本田様)                                  |
+| AC-2 | mirror link の `/book-mirror/<linkId>` で Image #14 と同じ枠が表示される | 手動確認 (Google 予約スケジュール公開ページと比較) |
+| AC-3 | ゲストが予約 → `hy.unimail.11@gmail.com` に通知メール届く                | 手動確認                                           |
+| AC-4 | `parseSlotResponse` が unix timestamp 配列を正しく変換する               | unit test (fixture: PoC で取得した実 JSON)         |
+| AC-5 | 短縮 URL invalid のとき POST `/api/booking-mirror-links` が 400 を返す   | unit test                                          |
+
+### 8.2 unit test 対象
+
+- `apps/api/src/lib/google-booking-mirror.ts`:
+  - `resolveScheduleId(shortUrl)` — リダイレクト先パース
+  - `parseSlotResponse(data)` — JSON 配列パース (PoC 取得 fixture を使用)
+- `apps/api/src/routes/booking-mirror-links.ts`:
+  - POST 入力バリデーション
+  - DELETE 権限チェック (ownerUid 一致)
+
+## 9. スコープ外 / 将来課題
+
+| 項目                                     | 理由                                              |
+| ---------------------------------------- | ------------------------------------------------- |
+| Google Calendar への event 自動作成 (C1) | C2 採用により本リリースでは実装しない (§9.1 参照) |
+| 独自ドメイン                             | 既存方針通り                                      |
+| spam 対策 (hCaptcha 等)                  | 既存方針通り                                      |
+| 既存 v1 bookingLink との移行ツール       | v1 廃止方針なので不要                             |
+
+### 9.1 二重予約リスクの取り扱い (C2 採用)
+
+Codex review (2026-06-26) で指摘された High リスク: Calendar Hub フォームで予約完了しても Google Appointment Schedule には予約が入らない。その枠は Google 公開ページ上では空いたままで、同枠を Google 経由で別ゲストが予約すると二重予約になる。
+
+本リリースでは **C2 = 個人運用としてリスク受容** を本田様判断で採用。理由:
+
+- オーナー 1 名運用、ターゲット限定の予約系
+- Google 予約スケジュール側と CalendarHub mirror 側で公開先を分離する運用は可能
+- C1 (Google Calendar への block event 書き込み) には `yasushi.honda@aozora-cg.com` 等の OAuth 連携 + `calendar.events` write 権限が必要だが、本田様の方針で当該連携を削除済
+
+将来 C2 から C1 に移行する場合の拡張点:
+
+1. 対象カレンダーを CalendarHub に OAuth 連携
+2. `BookingMirrorLink` に `blockCalendarId` / `blockAccountId` フィールド追加
+3. POST `/book` 処理に `createBlockEvent` を追加
+
+### 9.2 Codex review 反映の technical 改善点
+
+- `durationMinutes` はモデル固定値ではなく gRPC レスポンス (各 slot の duration) から動的取得
+- 通知メール: **送信者** `hy.unimail.11@gmail.com` (Gmail send 権限利用) / **宛先** = link 作成時の `notificationEmail` 設定値 (デフォルト hy.unimail.11)
+- POST `/book` で予約直前に `ListAvailableSlots` を再取得し、選択 slot の妥当性を再検証 (stale slot / 任意 slot POST 防止)
+- gRPC 4xx/5xx / 非 JSON / 構造化エラー時は `invalid_shape` / `empty_slots` / `google_error_payload` / `non_json` に分類して structured log
+- API Key は環境変数 (`GOOGLE_BOOKING_MIRROR_API_KEY`) から取得、Cloud Run env で設定、ログ出力時はマスク
+- `bookings` collection に `linkType: 'bookingLink' | 'bookingMirrorLink'` を追加 (既存は default 'bookingLink')
+- `fetch` には `AbortSignal.timeout(8_000)` を必ず付与、タイムアウト時は 503 変換
+- `/api/public/booking-mirror/*` は既存 `/api/public/booking/*` と同等の rate limit を適用
+- 短縮 URL `calendar.app.google/<id>` と完全 URL `calendar.google.com/calendar/.../schedules/<full-id>` の両方を入力受付 (短縮 URL 仕様変更耐性)
+
+## 10. Open Questions / 検証必要事項
+
+実装着手前に検証 (PoC で一部既に確認済み):
+
+- [x] gRPC-web API が認証なし (API Key のみ) で叩けるか → ✅ 200 OK 確認
+- [x] レスポンスが構造化 JSON か → ✅ 配列形式確認
+- [x] Image #14 と一致するデータが返るか → ✅ unix timestamp デコードで一致確認
+- [ ] schedule ID の最大有効期間 (例: 1 年先まで取れる?)
+- [ ] gRPC-web API の rate limit (公開 API key の上限)
+- [ ] レスポンスにエラー時の structured error が含まれるか (scheduleID 無効時の挙動)
+- [ ] Cloud Run から `calendar.app.google` への HTTPS リダイレクト解決が正常動作するか (egress 制限の有無)
+
+## 11. 実装フェーズ計画
+
+| Phase       | 内容                                                                             | 所要 (目安) |
+| ----------- | -------------------------------------------------------------------------------- | ----------- |
+| **Phase 1** | `apps/api/src/lib/google-booking-mirror.ts` 実装 + unit test                     | 30 分       |
+| **Phase 2** | Firestore collection schema + `apps/api/src/routes/booking-mirror-links.ts` 実装 | 45 分       |
+| **Phase 3** | `apps/api/src/routes/public-booking-mirror.ts` 実装 (slots / book)               | 45 分       |
+| **Phase 4** | `apps/web/src/app/booking-mirror-links/` 管理画面                                | 30 分       |
+| **Phase 5** | `apps/web/src/app/book-mirror/[linkId]/` 公開画面                                | 30 分       |
+| **Phase 6** | E2E 動作確認 (本田様の `2jkd3Ve8yvhPGtwdA` で Image #14 と比較)                  | 15 分       |
+
+合計推定 ~3 時間。1 つの PR にまとめて段階 commit。
+
+## 12. 参考
+
+- v1 設計仕様: `docs/specs/2026-06-24-booking-mirror-design.md`
+- PoC 実機データ: 本ブランチ作業ディレクトリの `listavailableslots-response.json` (Image #14 と一致)
+- Image #14: Google 予約スケジュール `calendar.app.google/2jkd3Ve8yvhPGtwdA` 7/3 表示
+- 関連 ADR: ADR-002 (calendar-integration)

--- a/infra/deploy-api.sh
+++ b/infra/deploy-api.sh
@@ -47,7 +47,7 @@ gcloud run deploy "$SERVICE_NAME" \
   --min-instances=0 \
   --max-instances=3 \
   --set-env-vars="GCP_PROJECT_ID=$PROJECT_ID,FRONTEND_URL=$WEB_URL,GOOGLE_REDIRECT_URI=$API_URL/api/auth/callback/google" \
-  --set-secrets="GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,TOKEN_ENCRYPTION_KEY=token-encryption-key:latest,SYNC_SCHEDULER_TOKEN=sync-scheduler-token:latest"
+  --set-secrets="GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,TOKEN_ENCRYPTION_KEY=token-encryption-key:latest,SYNC_SCHEDULER_TOKEN=sync-scheduler-token:latest,GOOGLE_BOOKING_MIRROR_API_KEY=google-booking-mirror-api-key:latest"
 
 # Cloud Run の traffic ピン留め回避 (Issue #119) — 詳細は infra/promote-traffic.sh
 PROJECT_ID="$PROJECT_ID" REGION="$REGION" \

--- a/packages/shared/src/booking-mirror-types.ts
+++ b/packages/shared/src/booking-mirror-types.ts
@@ -1,0 +1,73 @@
+// Google 予約スケジュール完全反映ミラー (v2) の型定義
+// 経緯: docs/specs/2026-06-26-booking-mirror-v2-grpc-design.md
+
+export type BookingMirrorLinkStatus = 'active' | 'paused';
+
+/** Firestore document `bookingMirrorLinks/{linkId}` */
+export interface BookingMirrorLink {
+  id: string;
+  ownerUid: string;
+  /** ユーザー表示用タイトル */
+  title: string;
+  description?: string;
+  /** 入力された Google 予約スケジュール URL (短縮 or 完全) */
+  sourceUrl: string;
+  /** 短縮 URL から解決した完全 schedule ID (cache、空のとき毎回再解決) */
+  scheduleId: string;
+  /** 予約成立時の通知先メール */
+  notificationEmail: string;
+  /** 公開日数 (slots 取得の range)。デフォルト 30、最大 60 */
+  rangeDays: number;
+  status: BookingMirrorLinkStatus;
+  expiresAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** 公開ページに返す safe subset (ownerUid / scheduleId 等を隠す) */
+export interface PublicBookingMirrorLinkInfo {
+  id: string;
+  title: string;
+  description?: string;
+  ownerDisplayName: string;
+  status: BookingMirrorLinkStatus;
+}
+
+/** POST /api/booking-mirror-links 入力 */
+export interface CreateBookingMirrorLinkInput {
+  sourceUrl: string;
+  title?: string;
+  description?: string;
+  notificationEmail?: string;
+  rangeDays?: number;
+  expiresAt?: string | null;
+}
+
+/** PATCH /api/booking-mirror-links/:linkId 入力 */
+export interface UpdateBookingMirrorLinkInput {
+  title?: string;
+  description?: string | null;
+  notificationEmail?: string;
+  rangeDays?: number;
+  status?: BookingMirrorLinkStatus;
+  expiresAt?: string | null;
+}
+
+/** 公開 slots API レスポンス 1 件 */
+export interface BookingMirrorSlot {
+  start: string; // ISO 8601 UTC
+  end: string;
+  durationMinutes: number;
+}
+
+/** POST /api/public/booking-mirror/:linkId/book 入力 */
+export interface CreateBookingMirrorInput {
+  slotStart: string; // ISO 8601 UTC
+  slotEnd: string;
+  guestName: string;
+  guestEmail?: string;
+  guestMessage?: string;
+}
+
+/** 既存 `bookings` collection の document に追加するフィールド */
+export type BookingLinkType = 'bookingLink' | 'bookingMirrorLink';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,6 +24,16 @@ export {
   type CreateBookingInput,
 } from './booking-types.js';
 export {
+  type BookingMirrorLinkStatus,
+  type BookingMirrorLink,
+  type PublicBookingMirrorLinkInfo,
+  type CreateBookingMirrorLinkInput,
+  type UpdateBookingMirrorLinkInput,
+  type BookingMirrorSlot,
+  type CreateBookingMirrorInput,
+  type BookingLinkType,
+} from './booking-mirror-types.js';
+export {
   SYNC_INTERVAL_OPTIONS,
   type SyncIntervalMinutes,
   type SyncConfig,


### PR DESCRIPTION
## Summary

Google 予約スケジュール公開ページが内部で叩いている **gRPC-web 公開 API** を Cloud Run api から直接叩き、Google が算出した空き枠リストを **そのまま** CalendarHub に表示する新機能を実装する。

v1 (\`docs/specs/2026-06-24-booking-mirror-design.md\`) は Google Calendar API events.list 自前算出方式だったが、Google 予約スケジュール内部の Working Hours / Buffer / 1h スロット境界などが反映されず破綻していた。

v2 は完全別ルート (\`/book-mirror/[linkId]\`、新規 collection \`bookingMirrorLinks\`) として既存 \`bookingLink\` 機能を一切壊さない。

## PoC (2026-06-26 実証)

\`\`\`
POST https://calendar-pa.clients6.google.com/$rpc/google.internal.calendar.v1.AppointmentBookingService/ListAvailableSlots?key=<API_KEY>
Body: [null, null, "<schedule-id>", null, [[<start-unix>], [<end-unix>]]]

→ 200 OK
[[[[<unix-string>], <duration-min>], ...]]
\`\`\`

- 認証ヘッダ不要 (X-Goog-Api-Key を query param で渡すだけ)
- 構造化 JSON で取得 (unix timestamp + duration)
- 本田様の運用予約スケジュール (\`calendar.app.google/2jkd3Ve8yvhPGtwdA\`) の公開ページと完全一致

## Codex review 反映 (2026-06-26、verdict: 修正後進める)

詳細は spec §9.2 参照。主な指摘の反映:

- **High「二重予約リスク」** → 個人運用として C2 受容、将来 C1 (Google Calendar block event) 拡張余地を spec §9.1 に記載
- **High「直前再検証なし」** → POST /book で gRPC slots を再取得して slot 妥当性を再検証
- **High「durationMinutes 固定値前提」** → 各 slot の duration を Google API レスポンスから動的取得
- **High「通知メール責務曖昧」** → 送信者 = hy.unimail.11、宛先 = link.notificationEmail に責務分離
- Medium / Low 指摘 (構造化エラー分類 / API Key env 化 / linkType / fetch timeout / rate limit / 完全 URL 受付) も全て反映

## 変更ファイル

**新規 13 ファイル**:
- \`packages/shared/src/booking-mirror-types.ts\` — 型定義 (7 型)
- \`apps/api/src/lib/google-booking-mirror.ts\` — gRPC-web client (resolveScheduleId / fetchAvailableSlots / parseSlotResponse + 構造化エラー)
- \`apps/api/src/__tests__/google-booking-mirror.test.ts\` — 10 tests (parse fixture / resolve / エラー分岐)
- \`apps/api/src/routes/booking-mirror-links.ts\` — owner CRUD (GET / POST / PATCH / DELETE)
- \`apps/api/src/routes/public-booking-mirror.ts\` — 公開 (info / slots / book + 直前再検証)
- \`apps/web/src/app/booking-mirror-links/{page,booking-mirror-links-content}.tsx\` — 管理画面 (一覧)
- \`apps/web/src/app/booking-mirror-links/new/{page,new-mirror-link-content}.tsx\` — 管理画面 (新規作成、URL 1 フィールド)
- \`apps/web/src/app/book-mirror/[linkId]/{page,layout,book-mirror-content}.tsx\` — 公開ページ (既存 book-content の時間帯セクション化を流用)
- \`docs/specs/2026-06-26-booking-mirror-v2-grpc-design.md\` — 設計仕様書 (v2.1)

**既存変更 5 ファイル**:
- \`packages/shared/src/index.ts\` (新型 export)
- \`apps/api/src/app.ts\` (新 route + rate limit)
- \`apps/web/src/components/AppNav.tsx\` (「ミラー」ナビ追加)
- \`.github/workflows/deploy.yml\` + \`infra/deploy-api.sh\` (env \`GOOGLE_BOOKING_MIRROR_API_KEY\` 追加)

## Test plan

- [x] \`pnpm --filter @calendar-hub/shared build\` ✅
- [x] \`pnpm --filter @calendar-hub/api type-check\` ✅
- [x] \`pnpm --filter @calendar-hub/api lint\` ✅
- [x] \`pnpm --filter @calendar-hub/web type-check\` ✅
- [x] \`pnpm --filter @calendar-hub/web lint\` ✅
- [x] \`pnpm test\` → 224 tests pass (新規 10 含む) ✅
- [ ] PR merge + Deploy → 管理画面「ミラー」タブで \`calendar.app.google/2jkd3Ve8yvhPGtwdA\` を貼り付けて作成、\`/book-mirror/<linkId>\` 公開ページ表示が Google 予約スケジュール公開ページと一致すること (手動確認)
- [ ] 予約ボタン → hy.unimail.11 にメール通知 (手動確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added booking mirror management pages for creating, viewing, updating, and deleting mirror links.
  * Added a public booking flow that shows live availability and lets guests reserve slots.
  * Added navigation entry for the new mirror booking section.

* **Bug Fixes**
  * Improved slot availability handling and booking validation to reduce stale or overlapping bookings.
  * Added tests for URL parsing, slot parsing, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->