### PR TITLE
chore(infra): bookingMirrorLinks composite index 作成 script

### DIFF
--- a/infra/setup-firestore-indexes.sh
+++ b/infra/setup-firestore-indexes.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+# Calendar Hub Firestore composite indexes 作成
+#
+# 冪等: 既存 index は再作成しない (gcloud は AlreadyExists を warning として無視)。
+# 前提: gcloud 認証済み + firestore.googleapis.com 有効化済み。
+#
+# 経緯:
+# - `bookingMirrorLinks` collection は `listConnectedAccounts` 同等パターンの query
+#     `where('ownerUid','==',uid).orderBy('createdAt','desc')`
+#   を発行するが、初回本番稼働時に composite index 不在で 500 エラーが発生 (PR #162)。
+# - 既存 collection 用 index は Firebase Console で個別作成済みのため、
+#   本 script は新規 collection 用の追加分のみ管理する。
+#
+# 新環境構築 (e.g. staging / disaster recovery) 時は本 script を一度実行すれば
+# 同等の query が機能する状態になる。
+
+PROJECT_ID="${GCP_PROJECT_ID:-calendar-hub-prod}"
+
+command -v gcloud >/dev/null 2>&1 || {
+  echo "::error::gcloud CLI not found"
+  exit 127
+}
+
+echo "=== Firestore composite indexes setup (project: $PROJECT_ID) ==="
+
+# bookingMirrorLinks: list query (owner の link 一覧、新しい順)
+echo "[1/1] bookingMirrorLinks: ownerUid + createdAt DESC"
+gcloud firestore indexes composite create \
+  --collection-group=bookingMirrorLinks \
+  --field-config=field-path=ownerUid,order=ASCENDING \
+  --field-config=field-path=createdAt,order=DESCENDING \
+  --project="$PROJECT_ID" \
+  --async 2>&1 | grep -v "ALREADY_EXISTS" || true
+
+echo ""
+echo "=== Setup Complete ==="
+echo "Index 作成は非同期で実行されます。状態確認:"
+echo "  gcloud firestore indexes composite list --project=$PROJECT_ID | grep bookingMirrorLinks"
+echo "READY になれば反映完了。通常 1-10 分です。"


### PR DESCRIPTION
## Summary

PR #162 (booking-mirror v2) 初回本番稼働時に \`bookingMirrorLinks\` collection の query \`where('ownerUid','==',uid).orderBy('createdAt','desc')\` で composite index 不在の 500 エラーが発生 (\`FAILED_PRECONDITION: The query requires an index\`)。

本番では gcloud で即時作成済みだが、新環境構築 (staging / disaster recovery) 時に同等 query が機能する状態を再現するため \`infra/setup-firestore-indexes.sh\` に IaC 化する。

## 設計判断

- 既存 \`bookingLinks\` / \`bookings\` / sync 関連 collection の composite index は Firebase Console で個別作成済みのため、本 script は **新規 collection 用の追加分のみ管理** する (既存と衝突しない最小侵襲アプローチ)
- \`firebase.json\` + \`firestore.indexes.json\` フルセット導入は将来の TODO (既存 index の export → JSON 化 + 整合性確認が必要なため、本 PR スコープ外)

## Test plan

- [x] \`bash -n infra/setup-firestore-indexes.sh\` (syntax OK)
- [ ] 本番では既に index 作成済み (本 PR は IaC 記録のみ、再実行しても \`AlreadyExists\` で skip され実害なし)

## 関連

- PR #162 (booking-mirror v2 本体)
- 本番動作確認は完了済み (E2E 成功、Image #21/#22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)