### PR TITLE
feat(email): 通知メールに「Google カレンダーに追加」ボタンを追加

### DIFF
--- a/apps/api/src/__tests__/email-render-url.test.ts
+++ b/apps/api/src/__tests__/email-render-url.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { buildGoogleCalendarRenderUrl, buildBookingNotificationHtml } from '../lib/email.js';
+
+describe('buildGoogleCalendarRenderUrl', () => {
+  it('action=TEMPLATE と必須パラメータ (text / dates) を含む URL を生成する', () => {
+    const url = buildGoogleCalendarRenderUrl({
+      title: 'テスト予約',
+      start: new Date('2026-07-04T08:00:00Z'),
+      end: new Date('2026-07-04T09:00:00Z'),
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.origin + parsed.pathname).toBe('https://calendar.google.com/calendar/render');
+    expect(parsed.searchParams.get('action')).toBe('TEMPLATE');
+    expect(parsed.searchParams.get('text')).toBe('テスト予約');
+    expect(parsed.searchParams.get('dates')).toBe('20260704T080000Z/20260704T090000Z');
+  });
+
+  it('details が渡された場合は URL パラメータに含める', () => {
+    const url = buildGoogleCalendarRenderUrl({
+      title: '予約',
+      start: new Date('2026-07-04T08:00:00Z'),
+      end: new Date('2026-07-04T09:00:00Z'),
+      details: '予約者: テスト\nメール: t@example.com',
+    });
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('details')).toBe('予約者: テスト\nメール: t@example.com');
+  });
+
+  it('details が undefined の場合は URL パラメータに含めない', () => {
+    const url = buildGoogleCalendarRenderUrl({
+      title: '予約',
+      start: new Date('2026-07-04T08:00:00Z'),
+      end: new Date('2026-07-04T09:00:00Z'),
+    });
+    const parsed = new URL(url);
+    expect(parsed.searchParams.has('details')).toBe(false);
+  });
+
+  it('dates フォーマット: ミリ秒は削除、ハイフン / コロンは除去、Z 終端を維持', () => {
+    const url = buildGoogleCalendarRenderUrl({
+      title: 't',
+      start: new Date('2026-12-31T23:59:00Z'),
+      end: new Date('2027-01-01T00:30:00Z'),
+    });
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('dates')).toBe('20261231T235900Z/20270101T003000Z');
+  });
+});
+
+describe('buildBookingNotificationHtml の Google カレンダー追加ボタン', () => {
+  it('Google Calendar render URL を含む <a> タグが本文に挿入される', () => {
+    const html = buildBookingNotificationHtml({
+      linkTitle: 'テスト予約スケジュール',
+      guestName: '山田太郎',
+      guestEmail: 'guest@example.com',
+      guestMessage: 'よろしくお願いします',
+      slotStart: new Date('2026-07-04T08:00:00Z'),
+      slotEnd: new Date('2026-07-04T09:00:00Z'),
+    });
+
+    // ボタンの存在 + Google Calendar URL の埋め込みを確認
+    expect(html).toContain('https://calendar.google.com/calendar/render');
+    expect(html).toContain('action=TEMPLATE');
+    // URL.searchParams は `/` を `%2F` にエンコードする (Google 側は両方 accept)
+    expect(html).toMatch(/dates=20260704T080000Z(%2F|\/)20260704T090000Z/);
+    expect(html).toContain('Google カレンダーに追加');
+  });
+
+  it('title は「<linkTitle> - <guestName>」形式で URL エンコードされる', () => {
+    const html = buildBookingNotificationHtml({
+      linkTitle: '【本田】予約',
+      guestName: 'テスト',
+      slotStart: new Date('2026-07-04T08:00:00Z'),
+      slotEnd: new Date('2026-07-04T09:00:00Z'),
+    });
+
+    // URLSearchParams は日本語 + space を自動エンコードする
+    expect(html).toMatch(/text=[^&]*-[^&]*/);
+  });
+
+  it('guestEmail / guestMessage が未指定の場合でも details が組み立てられる', () => {
+    const html = buildBookingNotificationHtml({
+      linkTitle: '予約',
+      guestName: 'テスト',
+      slotStart: new Date('2026-07-04T08:00:00Z'),
+      slotEnd: new Date('2026-07-04T09:00:00Z'),
+    });
+
+    // details に予約者行は必ず含まれる
+    expect(html).toMatch(/details=[^&]+/);
+  });
+});

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -227,6 +227,39 @@ export function buildTestEmailHtml(): string {
 /**
  * 予約通知メールのHTML生成（オーナー向け）
  */
+/**
+ * Google Calendar の event 作成画面 (deep link) を開く URL を生成する。
+ *
+ * - クリック → Google にログイン中のユーザーで「予定を作成」画面がプレフィルされた状態で開く
+ * - OAuth scope / API 呼び出し不要
+ * - ユーザーが「保存」を押すまで予定は作成されない (= 確認後に登録できる)
+ *
+ * @see https://stackoverflow.com/questions/22757908/google-calendar-render-action-template-parameter-documentation
+ */
+export function buildGoogleCalendarRenderUrl(params: {
+  title: string;
+  start: Date;
+  end: Date;
+  details?: string;
+}): string {
+  const { title, start, end, details } = params;
+  const u = new URL('https://calendar.google.com/calendar/render');
+  u.searchParams.set('action', 'TEMPLATE');
+  u.searchParams.set('text', title);
+  u.searchParams.set('dates', `${formatGCalDate(start)}/${formatGCalDate(end)}`);
+  if (details) u.searchParams.set('details', details);
+  return u.toString();
+}
+
+/** Google Calendar render URL の `dates` パラメータ形式 `YYYYMMDDTHHMMSSZ` (basic ISO 8601 UTC) */
+function formatGCalDate(d: Date): string {
+  // 2026-07-04T08:00:00.000Z → 20260704T080000Z
+  return d
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}/, '');
+}
+
 export function buildBookingNotificationHtml(params: {
   linkTitle: string;
   guestName: string;
@@ -247,6 +280,20 @@ export function buildBookingNotificationHtml(params: {
     ? `<p style="margin:8px 0;padding:12px;background:#f5f5f5;border-radius:6px;font-size:14px;">${escapeHtml(guestMessage)}</p>`
     : '';
 
+  // Google Calendar event 作成画面への deep link
+  // タイトル: 「<linkTitle> - <guestName>」、詳細: 予約者・メール・メッセージ
+  const detailsLines = [
+    `予約者: ${guestName}`,
+    guestEmail ? `メール: ${guestEmail}` : '',
+    guestMessage ? `メッセージ: ${guestMessage}` : '',
+  ].filter(Boolean);
+  const gcalUrl = buildGoogleCalendarRenderUrl({
+    title: `${linkTitle} - ${guestName}`,
+    start: slotStart,
+    end: slotEnd,
+    details: detailsLines.join('\n'),
+  });
+
   return `
 <!DOCTYPE html>
 <html>
@@ -259,6 +306,12 @@ export function buildBookingNotificationHtml(params: {
     ${guestEmailHtml}
     <p style="margin:4px 0;font-size:14px;"><strong>日時:</strong> ${escapeHtml(startStr)} 〜 ${escapeHtml(endStr)}</p>
     ${messageHtml}
+  </div>
+  <div style="text-align:center;margin:20px 0;">
+    <a href="${escapeHtml(gcalUrl)}" target="_blank" rel="noopener" style="display:inline-block;padding:12px 24px;background:#1a73e8;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;font-size:14px;">
+      📅 Google カレンダーに追加
+    </a>
+    <p style="font-size:11px;color:#999;margin:8px 0 0;">ボタンを押すと予定の作成画面が開きます (保存するまで登録されません)</p>
   </div>
   <hr style="border:none;border-top:1px solid #eee;margin:24px 0;">
   <p style="font-size:12px;color:#999;">Calendar Hub から自動送信されています。</p>


### PR DESCRIPTION
## Summary

ミラー機能 (PR #162) は本田様判断で C2 (Google Calendar への自動 event 作成なし) を採用したため、ゲスト予約のたびに本田様が手動で \`hy.unimail.11\` の Google Calendar に予定を入力する手間が発生していた。

OAuth 連携を増やさず最小コストで解決するため、通知メール本文に **Google Calendar event 作成画面 (deep link)** を開くボタンを追加する。

## 動作

1. 予約成立 → 通知メール送信 (現状通り)
2. 本田様がメールを開き **「📅 Google カレンダーに追加」** ボタンをクリック
3. ブラウザで `hy.unimail.11` でログイン中の Google Calendar が **「予定を作成」画面** をプレフィル状態で開く (タイトル / 日時 / 詳細 自動入力済)
4. 「保存」ボタンで予定登録完了

OAuth scope / API 呼び出し / 既存連携アカウント不要。

## 実装

- **新規 helper**: \`buildGoogleCalendarRenderUrl(title, start, end, details)\`
  - URL 形式: \`https://calendar.google.com/calendar/render?action=TEMPLATE&...\`
  - \`dates\` パラメータは \`YYYYMMDDTHHMMSSZ\` (basic ISO 8601 UTC)
  - \`details\` に予約者・メール・メッセージを改行区切り
- **メール HTML 改修**: \`buildBookingNotificationHtml\` に \`<a>\` ボタン (青背景 + 📅 emoji) を予約情報の下に挿入
  - \`target="_blank"\` + \`rel="noopener"\`
  - 補足テキスト「ボタンを押すと予定の作成画面が開きます (保存するまで登録されません)」も併記

## Test plan

- [x] \`pnpm --filter @calendar-hub/api type-check\` ✅
- [x] \`pnpm --filter @calendar-hub/api lint\` ✅
- [x] 新規 unit test 7 件 全 pass
  - URL 構造 (action / text / dates)
  - dates フォーマット (basic ISO 8601 UTC)
  - details 含み有無の分岐
  - HTML 本文へのボタン埋め込み
- [ ] PR merge + Deploy → 実機メールでボタン表示と Google Calendar 画面遷移を確認 (本田様作業)

🤖 Generated with [Claude Code](https://claude.com/claude-code)