### PR TITLE
fix(email): ゲスト確認メール改修 + 主催者名空欄 bug 修正

### DIFF
--- a/apps/api/src/__tests__/email-render-url.test.ts
+++ b/apps/api/src/__tests__/email-render-url.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { buildGoogleCalendarRenderUrl, buildBookingNotificationHtml } from '../lib/email.js';
+import {
+  buildGoogleCalendarRenderUrl,
+  buildBookingNotificationHtml,
+  buildBookingConfirmationHtml,
+} from '../lib/email.js';
 
 describe('buildGoogleCalendarRenderUrl', () => {
   it('action=TEMPLATE と必須パラメータ (text / dates) を含む URL を生成する', () => {
@@ -89,5 +93,68 @@ describe('buildBookingNotificationHtml の Google カレンダー追加ボタン
 
     // details に予約者行は必ず含まれる
     expect(html).toMatch(/details=[^&]+/);
+  });
+});
+
+describe('buildBookingConfirmationHtml の Google カレンダー追加ボタン', () => {
+  it('Google Calendar render URL を含む <a> タグが本文に挿入される', () => {
+    const html = buildBookingConfirmationHtml({
+      linkTitle: 'テスト予約スケジュール',
+      ownerDisplayName: '本田泰',
+      guestName: '山田太郎',
+      slotStart: new Date('2026-07-04T08:00:00Z'),
+      slotEnd: new Date('2026-07-04T09:00:00Z'),
+      durationMinutes: 60,
+    });
+
+    expect(html).toContain('https://calendar.google.com/calendar/render');
+    expect(html).toContain('action=TEMPLATE');
+    expect(html).toMatch(/dates=20260704T080000Z(%2F|\/)20260704T090000Z/);
+    expect(html).toContain('Google カレンダーに追加');
+  });
+
+  it('title は「<linkTitle> - <ownerDisplayName>」形式 (ゲスト視点で誰との予定か明示)', () => {
+    const html = buildBookingConfirmationHtml({
+      linkTitle: '【30分】MTG',
+      ownerDisplayName: '本田泰',
+      guestName: '山田',
+      slotStart: new Date('2026-07-04T08:00:00Z'),
+      slotEnd: new Date('2026-07-04T08:30:00Z'),
+      durationMinutes: 30,
+    });
+
+    // text パラメータに linkTitle と ownerDisplayName が両方含まれる
+    expect(html).toMatch(/text=[^&]*MTG[^&]*/);
+    // %20-%20 (= " - ") もしくは + 区切りで含まれる
+    expect(html).toContain('text=');
+  });
+
+  it('details に主催者・所要時間が含まれる', () => {
+    const html = buildBookingConfirmationHtml({
+      linkTitle: '予約',
+      ownerDisplayName: '本田',
+      guestName: 'テスト',
+      slotStart: new Date('2026-07-04T08:00:00Z'),
+      slotEnd: new Date('2026-07-04T08:30:00Z'),
+      durationMinutes: 30,
+    });
+
+    expect(html).toMatch(/details=[^&]+/);
+  });
+
+  it('既存の予約情報 (主催者・日時・所要時間) も維持される', () => {
+    const html = buildBookingConfirmationHtml({
+      linkTitle: 'テスト予約',
+      ownerDisplayName: '本田泰',
+      guestName: '山田太郎',
+      slotStart: new Date('2026-07-04T08:00:00Z'),
+      slotEnd: new Date('2026-07-04T09:00:00Z'),
+      durationMinutes: 60,
+    });
+
+    expect(html).toContain('山田太郎');
+    expect(html).toContain('本田泰');
+    expect(html).toContain('60分');
+    expect(html).toContain('予約が確定しました');
   });
 });

--- a/apps/api/src/__tests__/owner-display-name.test.ts
+++ b/apps/api/src/__tests__/owner-display-name.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { pickOwnerDisplayName } from '../lib/owner-display-name.js';
+
+describe('pickOwnerDisplayName', () => {
+  it('displayName が非空文字列なら displayName を返す', () => {
+    expect(pickOwnerDisplayName({ displayName: '本田泰', email: 'h@example.com' })).toBe('本田泰');
+  });
+
+  it('displayName が空文字なら email にフォールバックする (主因 bug の再現)', () => {
+    expect(pickOwnerDisplayName({ displayName: '', email: 'h@example.com' })).toBe('h@example.com');
+  });
+
+  it('displayName が undefined なら email にフォールバックする', () => {
+    expect(pickOwnerDisplayName({ email: 'h@example.com' })).toBe('h@example.com');
+  });
+
+  it('displayName が null なら email にフォールバックする', () => {
+    expect(pickOwnerDisplayName({ displayName: null, email: 'h@example.com' })).toBe(
+      'h@example.com',
+    );
+  });
+
+  it('displayName と email が両方空文字なら "User" にフォールバックする', () => {
+    expect(pickOwnerDisplayName({ displayName: '', email: '' })).toBe('User');
+  });
+
+  it('displayName と email が両方 undefined なら "User" にフォールバックする', () => {
+    expect(pickOwnerDisplayName({})).toBe('User');
+  });
+
+  it('data 自体が undefined なら "User" にフォールバックする (Firestore doc 不在ケース)', () => {
+    expect(pickOwnerDisplayName(undefined)).toBe('User');
+  });
+
+  it('displayName が空白のみの文字列ならそのまま返す (trim はしない、明示的な空白は意図的扱い)', () => {
+    expect(pickOwnerDisplayName({ displayName: '   ', email: 'h@example.com' })).toBe('   ');
+  });
+});

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -334,6 +334,16 @@ export function buildBookingConfirmationHtml(params: {
   const startStr = formatJstDateTime(slotStart);
   const endStr = formatJstTime(slotEnd);
 
+  // Google Calendar event 作成画面への deep link (ゲスト視点)
+  // タイトル: 「<linkTitle> - <ownerDisplayName>」、詳細: 主催者・所要時間
+  const detailsLines = [`主催者: ${ownerDisplayName}`, `所要時間: ${durationMinutes}分`];
+  const gcalUrl = buildGoogleCalendarRenderUrl({
+    title: `${linkTitle} - ${ownerDisplayName}`,
+    start: slotStart,
+    end: slotEnd,
+    details: detailsLines.join('\n'),
+  });
+
   return `
 <!DOCTYPE html>
 <html>
@@ -346,6 +356,12 @@ export function buildBookingConfirmationHtml(params: {
     <p style="margin:4px 0;font-size:14px;"><strong>主催者:</strong> ${escapeHtml(ownerDisplayName)}</p>
     <p style="margin:4px 0;font-size:14px;"><strong>日時:</strong> ${escapeHtml(startStr)} 〜 ${escapeHtml(endStr)}</p>
     <p style="margin:4px 0;font-size:14px;"><strong>所要時間:</strong> ${durationMinutes}分</p>
+  </div>
+  <div style="text-align:center;margin:20px 0;">
+    <a href="${escapeHtml(gcalUrl)}" target="_blank" rel="noopener" style="display:inline-block;padding:12px 24px;background:#1a73e8;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;font-size:14px;">
+      📅 Google カレンダーに追加
+    </a>
+    <p style="font-size:11px;color:#999;margin:8px 0 0;">ボタンを押すと予定の作成画面が開きます (保存するまで登録されません)</p>
   </div>
   <hr style="border:none;border-top:1px solid #eee;margin:24px 0;">
   <p style="font-size:12px;color:#999;">このメールは Calendar Hub から自動送信されています。</p>

--- a/apps/api/src/lib/owner-display-name.ts
+++ b/apps/api/src/lib/owner-display-name.ts
@@ -1,0 +1,17 @@
+export interface OwnerDisplayNameSource {
+  displayName?: string | null;
+  email?: string | null;
+}
+
+/**
+ * Firestore users/{uid} document data から表示名を抽出する。
+ *
+ * 優先度: displayName > email > 'User'
+ *
+ * `||` を使うのは空文字 (`displayName: ''`) も fallback したいため。
+ * `??` だと undefined/null のみ fallback され、空文字はそのまま返り
+ * 確認メールで「主催者: 」が空欄になる bug が発生する。
+ */
+export function pickOwnerDisplayName(data: OwnerDisplayNameSource | undefined | null): string {
+  return data?.displayName || data?.email || 'User';
+}

--- a/apps/api/src/routes/public-booking-mirror.ts
+++ b/apps/api/src/routes/public-booking-mirror.ts
@@ -17,6 +17,7 @@ import {
   type GoogleSlot,
 } from '../lib/google-booking-mirror.js';
 import { assertE2EMockSafe } from '../lib/e2e-guard.js';
+import { pickOwnerDisplayName } from '../lib/owner-display-name.js';
 import type {
   BookingMirrorLink,
   BookingMirrorSlot,
@@ -63,8 +64,7 @@ async function getActiveLink(linkId: string): Promise<LinkResult> {
 async function getOwnerDisplayName(ownerUid: string): Promise<string> {
   const db = getDb();
   const doc = await db.collection('users').doc(ownerUid).get();
-  const data = doc.data();
-  return data?.displayName ?? data?.email ?? 'User';
+  return pickOwnerDisplayName(doc.data());
 }
 
 /** GoogleSlot[] を CalendarHub の BookingMirrorSlot[] に変換 */

--- a/apps/api/src/routes/public-booking.ts
+++ b/apps/api/src/routes/public-booking.ts
@@ -25,6 +25,7 @@ import {
   shouldCreateCalendarEvent,
 } from '../lib/booking-link-utils.js';
 import { assertE2EMockSafe } from '../lib/e2e-guard.js';
+import { pickOwnerDisplayName } from '../lib/owner-display-name.js';
 
 export const publicBookingRoutes = new Hono();
 
@@ -59,8 +60,7 @@ async function getActiveBookingLink(linkId: string): Promise<LinkResult> {
 async function getOwnerDisplayName(ownerUid: string): Promise<string> {
   const db = getDb();
   const doc = await db.collection('users').doc(ownerUid).get();
-  const data = doc.data();
-  return data?.displayName ?? data?.email ?? 'User';
+  return pickOwnerDisplayName(doc.data());
 }
 
 async function fetchOwnerEvents(


### PR DESCRIPTION
## Summary

handoff 第 6 編 (PR #164) で次セッション持ち越しと判断された 2 件を対応。

- **ゲスト向け確認メール (`buildBookingConfirmationHtml`) に Google カレンダー追加ボタン** — PR #165 (owner 通知側) と同等の改修。タイトルは「<linkTitle> - <ownerDisplayName>」(ゲスト視点で誰との予定か明示)、詳細は主催者・所要時間。
- **主催者名空欄 bug 修正** — `getOwnerDisplayName` で `displayName: ''` (空文字) のとき `??` が空文字を fallback せず確認メールで「主催者: 」が空欄になっていた問題。`||` に変更しつつ pure helper `pickOwnerDisplayName` を `lib/owner-display-name.ts` に集約 (`public-booking.ts` + `public-booking-mirror.ts` の重複定義 2 箇所を統一)。

> 補足: global rule `error-handling.md` §2 は `??` 推奨だが、本ケースは「空文字を fallback したい」のが意図そのものでアンチパターン (0/空文字を意図的な値として扱いたい場合) には該当しない。helper コメントで意図を明示した。

## Test plan

- [x] `pnpm vitest run` (API): **150 tests pass** (helper 8 件 + confirmation html 4 件 追加、前 138 → 150)
- [x] `pnpm test` (全パッケージ): **243 tests pass** (15 files)
- [x] `pnpm --filter @calendar-hub/api lint`: clean
- [x] `pnpm turbo type-check`: 8 packages successful
- [x] `/safe-refactor`: 自動修正対象なし
- [x] `/code-review low`: findings 0
- [ ] CI quality / e2e / GitGuardian / CodeRabbit 通過
- [ ] 本番デプロイ後、ゲスト予約 → 確認メール受信 → 「主催者: 本田泰」表示確認 + 「Google カレンダーに追加」ボタンクリックで予定作成画面が開く確認 (decision-maker 領分、AI は能動依頼しない)

## 変更ファイル

| ファイル | 内容 |
| --- | --- |
| `apps/api/src/lib/owner-display-name.ts` (新規) | `pickOwnerDisplayName` pure helper + intent コメント |
| `apps/api/src/lib/email.ts` | `buildBookingConfirmationHtml` に Google カレンダーボタン + URL 構築 |
| `apps/api/src/routes/public-booking.ts` | `getOwnerDisplayName` を helper 経由に |
| `apps/api/src/routes/public-booking-mirror.ts` | 同上 |
| `apps/api/src/__tests__/owner-display-name.test.ts` (新規) | helper 単体テスト 8 件 (境界値) |
| `apps/api/src/__tests__/email-render-url.test.ts` | confirmation html ボタン挿入テスト 4 件 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)