### PR TITLE
fix(book-mirror): モバイル UI 大幅改善 (media query bug 修正 + touch target / 2 列 slot grid)

### DIFF
--- a/apps/web/src/app/book-mirror/[linkId]/book-mirror-content.tsx
+++ b/apps/web/src/app/book-mirror/[linkId]/book-mirror-content.tsx
@@ -223,6 +223,7 @@ export function BookMirrorContent() {
 
       {/* Main layout */}
       <div
+        className="book-layout"
         style={{
           ...s.layout,
           opacity: mounted ? 1 : 0,
@@ -230,13 +231,15 @@ export function BookMirrorContent() {
         }}
       >
         {/* Left: Info panel */}
-        <aside style={s.infoPanel}>
+        <aside className="book-info-panel" style={s.infoPanel}>
           <a href="/" style={s.logo}>
             Calendar<span style={s.logoAccent}>Hub</span>
           </a>
 
           <div style={s.ownerName}>{linkInfo.ownerDisplayName}</div>
-          <h1 style={s.meetingTitle}>{linkInfo.title}</h1>
+          <h1 className="book-meeting-title" style={s.meetingTitle}>
+            {linkInfo.title}
+          </h1>
 
           {slots.length > 0 && (
             <div style={s.durationBadge}>
@@ -245,12 +248,17 @@ export function BookMirrorContent() {
             </div>
           )}
 
-          {linkInfo.description && <p style={s.description}>{linkInfo.description}</p>}
+          {linkInfo.description && (
+            <p className="book-description" style={s.description}>
+              {linkInfo.description}
+            </p>
+          )}
 
-          <div style={s.divider} />
+          <div className="book-divider" style={s.divider} />
 
-          <div style={s.steps}>
+          <div className="book-steps" style={s.steps}>
             <div
+              className="book-step"
               style={{
                 ...s.stepItem,
                 color: step === 'select' ? 'var(--color-accent)' : 'var(--color-text-muted)',
@@ -259,6 +267,7 @@ export function BookMirrorContent() {
               <span style={s.stepNum}>1</span> 日時を選択
             </div>
             <div
+              className="book-step"
               style={{
                 ...s.stepItem,
                 color: step === 'form' ? 'var(--color-accent)' : 'var(--color-text-muted)',
@@ -267,6 +276,7 @@ export function BookMirrorContent() {
               <span style={s.stepNum}>2</span> 情報を入力
             </div>
             <div
+              className="book-step"
               style={{
                 ...s.stepItem,
                 color: step === 'confirmed' ? 'var(--color-accent)' : 'var(--color-text-muted)',
@@ -278,7 +288,7 @@ export function BookMirrorContent() {
         </aside>
 
         {/* Right: Content area */}
-        <main style={s.contentPanel}>
+        <main className="book-content-panel" style={s.contentPanel}>
           {error && <div style={s.errorBanner}>{error}</div>}
 
           {step === 'select' && (
@@ -291,7 +301,7 @@ export function BookMirrorContent() {
                 <div style={s.noSlots}>利用可能な日程がありません</div>
               ) : (
                 <>
-                  <div style={s.dateCardsWrap}>
+                  <div className="book-date-cards-wrap" style={s.dateCardsWrap}>
                     <div style={s.dateCards}>
                       {availableDates.map((date) => (
                         <button
@@ -301,7 +311,7 @@ export function BookMirrorContent() {
                             setSelectedDate(date);
                             setSelectedSlot(null);
                           }}
-                          className="date-card"
+                          className="date-card book-date-card"
                           style={{
                             ...s.dateCard,
                             borderColor:
@@ -338,13 +348,13 @@ export function BookMirrorContent() {
                         slotsByTimeBand.map(({ band, slots: bandSlots }) => (
                           <div key={band.key} style={s.timeBandWrap}>
                             <div style={s.timeBandLabel}>【{band.label}】</div>
-                            <div style={s.slotsGrid}>
+                            <div className="book-slots-grid" style={s.slotsGrid}>
                               {bandSlots.map((slot) => (
                                 <button
                                   key={slot.start}
                                   data-testid={`slot-btn-${slot.start}`}
                                   onClick={() => handleSelectSlot(slot)}
-                                  className="slot-btn"
+                                  className="slot-btn book-slot-btn"
                                   style={s.slotBtn}
                                 >
                                   {formatTime(slot.start)}
@@ -384,6 +394,7 @@ export function BookMirrorContent() {
                   value={guestName}
                   onChange={(e) => setGuestName(e.target.value)}
                   placeholder="山田 太郎"
+                  className="book-input"
                   style={s.input}
                   autoFocus
                 />
@@ -394,6 +405,7 @@ export function BookMirrorContent() {
                   value={guestEmail}
                   onChange={(e) => setGuestEmail(e.target.value)}
                   placeholder="email@example.com"
+                  className="book-input"
                   style={s.input}
                 />
                 <span style={s.hint}>入力すると確認メールをお送りします</span>
@@ -404,6 +416,7 @@ export function BookMirrorContent() {
                   onChange={(e) => setGuestMessage(e.target.value)}
                   placeholder="ご要望など"
                   rows={3}
+                  className="book-input"
                   style={{ ...s.input, resize: 'vertical' as const }}
                 />
               </div>
@@ -412,7 +425,7 @@ export function BookMirrorContent() {
                 onClick={handleSubmit}
                 disabled={!guestName.trim() || submitting}
                 data-testid="submit-btn"
-                className="submit-btn"
+                className="submit-btn book-submit-btn"
                 style={{
                   ...s.submitBtn,
                   opacity: !guestName.trim() || submitting ? 0.5 : 1,
@@ -547,15 +560,77 @@ const keyframes = `
   .submit-btn:hover:not(:disabled) {
     background: #c86840 !important;
   }
-  @media (max-width: 768px) {
+  @media (max-width: 767px) {
     .book-layout {
       flex-direction: column !important;
+      margin: 12px 12px 8px !important;
+      min-height: auto !important;
+      border-radius: 16px !important;
     }
     .book-info-panel {
+      width: 100% !important;
+      min-width: 0 !important;
       border-right: none !important;
       border-bottom: 1px solid var(--color-border) !important;
-      max-width: 100% !important;
-      padding: 24px !important;
+      padding: 20px 20px 16px !important;
+    }
+    .book-meeting-title {
+      font-size: 20px !important;
+      margin-bottom: 10px !important;
+    }
+    .book-description {
+      font-size: 12px !important;
+      line-height: 1.6 !important;
+      margin-bottom: 4px !important;
+    }
+    .book-divider {
+      margin: 12px 0 4px !important;
+    }
+    .book-steps {
+      margin-top: 4px !important;
+      flex-direction: row !important;
+      gap: 12px !important;
+      justify-content: flex-start !important;
+      flex-wrap: wrap !important;
+    }
+    .book-step {
+      font-size: 11px !important;
+      gap: 6px !important;
+    }
+    .book-content-panel {
+      padding: 20px 18px 24px !important;
+      max-height: none !important;
+      overflow-y: visible !important;
+    }
+    .book-date-cards-wrap {
+      margin: 0 -18px 20px !important;
+      padding: 0 18px 8px !important;
+      -webkit-overflow-scrolling: touch;
+    }
+    .book-date-card {
+      min-width: 64px !important;
+      min-height: 76px !important;
+      padding: 12px 14px !important;
+    }
+    .book-slots-grid {
+      grid-template-columns: repeat(2, 1fr) !important;
+      gap: 10px !important;
+    }
+    .book-slot-btn {
+      padding: 14px 8px !important;
+      min-height: 48px !important;
+      font-size: 15px !important;
+      border-radius: 10px !important;
+    }
+    .book-input {
+      min-height: 44px !important;
+      font-size: 16px !important;
+    }
+    .book-submit-btn {
+      min-height: 52px !important;
+      font-size: 16px !important;
+      position: sticky;
+      bottom: 12px;
     }
   }
 `;


### PR DESCRIPTION
## Summary

- book-mirror ページの 390px モバイル表示が著しく使いにくかった問題を修正
- 根本原因: keyframes 内の `@media (max-width: 768px)` は className `book-layout` / `book-info-panel` を対象にしていたが、JSX 側に該当 className **未付与** でモバイルでも 2 カラム横並び (info 38.2% / content 61.8%) が押し込まれていた
- レイアウト主要要素に className を付与し、`@media (max-width: 767px)` を mobile-first 思想で再設計

## 主な変更点

### Bug fix
- JSX 側に `book-layout` / `book-info-panel` / `book-content-panel` / `book-slots-grid` / `book-slot-btn` / `book-date-card` / `book-input` / `book-submit-btn` / `book-meeting-title` / `book-description` / `book-divider` / `book-steps` / `book-step` を付与 → 既存 media query が初めて機能するように

### Mobile UX 改善 (≤ 767px)
- 縦並びレイアウト + `min-height: auto !important` で空白除去
- info panel を compact 化 (padding 圧縮、description / divider 縮小)
- step indicator を inline 横並び (`flex-direction: row` + `flex-wrap: wrap`)
- content panel の `max-height: 80vh` 解除でスムーススクロール
- 時間枠 grid を `repeat(2, 1fr)` 強制 2 列化 (従来は autofit で実質 1 列)
- touch target 44x44px 以上確保:
  - date-card: 64x76px
  - slot-btn: min-height 48px
  - input/textarea: min-height 44px + **font-size 16px (iOS Safari zoom 抑止)**
  - submit-btn: min-height 52px + sticky bottom (キーボード表示時の視認性)

## 検証

- pnpm --filter @calendar-hub/web lint: ✅ No warnings or errors
- pnpm --filter @calendar-hub/web type-check: ✅ pass
- pnpm --filter @calendar-hub/web build: ✅ 16 pages generated (book-mirror/[linkId] 含む)

## Test plan

- [ ] 本番デプロイ後、iPhone 12 Pro (390x844) viewport で `/book-mirror/<linkId>` を表示
- [ ] info panel が画面上部に compact 表示され、下部に時間枠 grid が 2 列で並ぶことを確認
- [ ] 日付カード横スクロールが滑らかに動作
- [ ] 時間枠ボタンを長押し / タップで反応 (44px+ 確保)
- [ ] フォーム画面に進み、入力欄が画面幅にフィット、submit ボタンが画面下に sticky で出現
- [ ] iPad / desktop ブレークポイント (768px+) で従来 2 カラム表示が維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved booking page structure with clearer semantic class names for layout, cards, slots, and form controls.
  * Updated mobile styling to better handle spacing, typography, grid layout, and button/input sizing on smaller screens.
  * Added a sticky submit button on mobile for easier checkout flow.
* **Refactor**
  * Reorganized some booking page markup for readability without changing booking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->