### PR TITLE
fix(infra): SLO sync-success userLabels の 63 chars 制約違反を修正

### DIFF
--- a/infra/slos/sync-success.json
+++ b/infra/slos/sync-success.json
@@ -16,7 +16,7 @@
   "userLabels": {
     "managed_by": "setup-slo-sh",
     "issue": "81",
-    "note": "ADR-010 sync 成功率 99%/day の Pragmatic 実装。総 sync 数メトリクス未整備のため windowsBased で 1h 単位 failure 0 件 = good window と定義",
-    "todo_metric_kind": "metricSumInRange が MetricKind=GAUGE を要求する場合は適用失敗。fallback は (1) sync_failed を GAUGE custom metric 化 or (2) windowsBased.goodBadMetricFilter 切替"
+    "adr": "010",
+    "impl": "pragmatic-windows-based"
   }
 }


### PR DESCRIPTION
## Summary

- PR #155 で導入された `infra/slos/sync-success.json` の `userLabels` に長文注釈 (note: 110 chars / todo_metric_kind: 142 chars) が含まれており、GCP SLO API の **label value 63 chars 制限** で create が失敗していた
- 本セッションで `bash infra/setup-slo.sh` を本番適用しようとして発見
- 設計意図 (Pragmatic windowsBased + GAUGE fallback) は ADR-010 / handoff archive で記録済みなので、userLabels からは短縮ラベル (`adr=010` / `impl=pragmatic-windows-based`) のみ残した

## 検証

- bash infra/setup-slo.sh を再実行 → SLO 4 種全 create success:
  - `calendar-hub-api/api-availability`
  - `calendar-hub-api/api-latency-p95`
  - `calendar-hub-api/sync-success` ← 今回修正
  - `calendar-hub-web/web-availability`

## Test plan

- [x] 本番に SLO 4 種が作成されていることを確認 (Cloud Console: https://console.cloud.google.com/monitoring/services?project=calendar-hub-prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metadata labels in the sync success configuration.
  * Replaced longer descriptive text with shorter structured labels for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->