### PR TITLE
fix(calendar-sdk): TimeTreeAdapter の 401/400/403 エラー分類とreLogin観測性を改善

### DIFF
--- a/packages/calendar-sdk/src/__tests__/timetree-adapter.test.ts
+++ b/packages/calendar-sdk/src/__tests__/timetree-adapter.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { TimeTreeAdapter, normalizeAllDayEnd, type TimeTreeSession } from '../adapters/timetree.js';
+import {
+  TimeTreeAdapter,
+  TimeTreeSessionExpiredError,
+  normalizeAllDayEnd,
+  type TimeTreeSession,
+} from '../adapters/timetree.js';
 
 const TEST_ACCOUNT_ID = 'timetree_test_acc_001';
 
@@ -225,8 +230,8 @@ describe('TimeTreeAdapter session expiry observability', () => {
     return fn;
   }
 
-  it.each([400, 401, 403])(
-    'should log [TT-SESSION-EXPIRED] reason=httpStatus when %i received without reLoginFn',
+  it.each([400, 403])(
+    'should log [TT-SESSION-EXPIRED] and throw generic error when %i received without reLoginFn (permanent, not session-related)',
     async (status) => {
       fetchSpy = mockFetchSequence([{ status }]);
       vi.stubGlobal('fetch', fetchSpy);
@@ -244,6 +249,68 @@ describe('TimeTreeAdapter session expiry observability', () => {
       expect(warned).toContain('reLoginAvailable=false');
     },
   );
+
+  it.each([400, 403])(
+    'should NOT attempt reLogin when %i received even if reLoginFn is provided (permanent error classification)',
+    async (status) => {
+      fetchSpy = mockFetchSequence([{ status }]);
+      vi.stubGlobal('fetch', fetchSpy);
+      const reLoginFn = vi.fn().mockResolvedValue({
+        sessionId: 'new-sid',
+        csrfToken: 'new-csrf',
+        expiresAt: Date.now() + 60 * 60 * 1000,
+      });
+
+      const adapter = new TimeTreeAdapter(validSession, { accountId: TEST_ACCOUNT_ID, reLoginFn });
+      await expect(adapter.listCalendars()).rejects.toThrow(
+        new RegExp(`TimeTree listCalendars failed: ${status}`),
+      );
+
+      expect(reLoginFn).not.toHaveBeenCalled();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('should throw TimeTreeSessionExpiredError when 401 received without reLoginFn', async () => {
+    fetchSpy = mockFetchSequence([{ status: 401 }]);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const adapter = new TimeTreeAdapter(validSession, { accountId: TEST_ACCOUNT_ID });
+    let caught: unknown;
+    try {
+      await adapter.listCalendars();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TimeTreeSessionExpiredError);
+    expect((caught as Error).message).toContain(`accountId=${TEST_ACCOUNT_ID}`);
+
+    const warned = warnSpy.mock.calls.flat().join(' ');
+    expect(warned).toContain('[TT-SESSION-EXPIRED]');
+    expect(warned).toContain('reason=httpStatus');
+    expect(warned).toContain('status=401');
+    expect(warned).toContain('reLoginAvailable=false');
+  });
+
+  it('should log [TT-SESSION-RELOGIN-INEFFECTIVE] when retry after reLogin still fails', async () => {
+    fetchSpy = mockFetchSequence([{ status: 401 }, { status: 401 }]);
+    vi.stubGlobal('fetch', fetchSpy);
+    const reLoginFn = vi.fn().mockResolvedValue({
+      sessionId: 'new-sid',
+      csrfToken: 'new-csrf',
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    });
+
+    const adapter = new TimeTreeAdapter(validSession, { accountId: TEST_ACCOUNT_ID, reLoginFn });
+    await expect(adapter.listCalendars()).rejects.toThrow(/TimeTree listCalendars failed: 401/);
+
+    expect(reLoginFn).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const warned = warnSpy.mock.calls.flat().join(' ');
+    expect(warned).toContain('[TT-SESSION-RELOGIN-INEFFECTIVE]');
+    expect(warned).toContain(`accountId=${TEST_ACCOUNT_ID}`);
+    expect(warned).toContain('status=401');
+  });
 
   it('should log [TT-SESSION-EXPIRED] reason=expiresAt when session is past expiresAt', async () => {
     fetchSpy = mockFetchOk({ calendars: [] });

--- a/packages/calendar-sdk/src/adapters/timetree.ts
+++ b/packages/calendar-sdk/src/adapters/timetree.ts
@@ -16,6 +16,20 @@ export interface TimeTreeSession {
 /** Session期限切れ時に再ログインするためのコールバック */
 export type TimeTreeReLoginFn = () => Promise<TimeTreeSession>;
 
+/**
+ * TimeTree session が失効し、かつ reLoginFn が未注入のため自動復旧できない場合に throw されるエラー。
+ * 上位レイヤー（sync ジョブ等）が汎用エラーと区別して「ユーザー再連携待ち」の運用に分岐できるようにする。
+ */
+export class TimeTreeSessionExpiredError extends Error {
+  constructor(
+    readonly accountId: string,
+    readonly url: string,
+  ) {
+    super(`TimeTree session expired: accountId=${accountId} url=${url} (no re-login available)`);
+    this.name = 'TimeTreeSessionExpiredError';
+  }
+}
+
 /** TimeTreeAdapter constructor options */
 export interface TimeTreeAdapterOptions {
   /** 連携アカウントID (例: timetree_xxx)。session expired ログ出力時のグルーピングキー */
@@ -112,14 +126,28 @@ export class TimeTreeAdapter implements CalendarAdapter {
 
     const res = await fetch(url, { ...init, headers: { ...this.headers, ...init?.headers } });
 
-    // 401/403で再ログイン試行（1回のみ）
     if (res.status === 400 || res.status === 401 || res.status === 403) {
       console.warn(
         `[TT-SESSION-EXPIRED] accountId=${this.accountId} reason=httpStatus url=${url} status=${res.status} reLoginAvailable=${Boolean(this.reLoginFn)}`,
       );
-      if (this.reLoginFn) {
-        await this.refreshSession();
-        return fetch(url, { ...init, headers: { ...this.headers, ...init?.headers } });
+
+      // 401のみ session 失効として reLogin 対象にする。400(malformed)/403(権限不足) は
+      // permanent error (rules/error-handling.md §3) であり reLogin では解決しないため試みない
+      if (res.status === 401) {
+        if (this.reLoginFn) {
+          await this.refreshSession();
+          const retryRes = await fetch(url, {
+            ...init,
+            headers: { ...this.headers, ...init?.headers },
+          });
+          if (!retryRes.ok) {
+            console.warn(
+              `[TT-SESSION-RELOGIN-INEFFECTIVE] accountId=${this.accountId} url=${url} status=${retryRes.status}`,
+            );
+          }
+          return retryRes;
+        }
+        throw new TimeTreeSessionExpiredError(this.accountId, url);
       }
     }
 

--- a/packages/calendar-sdk/src/index.ts
+++ b/packages/calendar-sdk/src/index.ts
@@ -9,5 +9,5 @@ export {
   type UpdateEventInput,
 } from './types.js';
 export { GoogleCalendarAdapter } from './adapters/google.js';
-export { TimeTreeAdapter } from './adapters/timetree.js';
+export { TimeTreeAdapter, TimeTreeSessionExpiredError } from './adapters/timetree.js';
 export type { TimeTreeSession, TimeTreeReLoginFn } from './adapters/timetree.js';


### PR DESCRIPTION
## Summary
ADR-009 (docs/adr/009-timetree-session-management.md) の「既存ロジックの強化候補」3件に対応:

- 400(malformed)/403(権限不足) は reLoginFn が注入されていてもreLoginを試みないよう変更（permanent error、`rules/error-handling.md §3` の transient/permanent 分類に整合。reLoginで解決しない性質の失敗）
- reLoginFn 不在時の401は汎用エラーではなく `TimeTreeSessionExpiredError` を明示throw（上位レイヤーが「session失効・再連携待ち」を判別可能に）
- reLogin後のretry fetchが依然失敗した場合 `[TT-SESSION-RELOGIN-INEFFECTIVE]` ログを追加（観測性ギャップの解消）

`TimeTreeSessionExpiredError` は `packages/calendar-sdk` のpublic exportに追加。本番の `adapter-factory.ts` は現状 `reLoginFn` を注入していないため、既存の呼び出し元・エラーハンドリング（`apps/api/src/routes/sync.ts` の汎用catch）には影響なし。

## Test plan
- [x] TDD: 既存400/401/403 混在テストを分割 + 新規4テスト追加（400/403でreLogin未実行確認、401のTimeTreeSessionExpiredError throw確認、reLogin後retry失敗時のINEFFECTIVEログ確認）
- [x] `pnpm --filter @calendar-hub/calendar-sdk vitest run timetree-adapter` — 35 tests PASS
- [x] `pnpm turbo type-check` — 8/8 packages PASS
- [x] `pnpm lint` — 全PASS
- [x] `pnpm test`（モノレポ全体）— 246 tests PASS
- [x] `/code-review low` 実施 — findings 0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)