### PR TITLE
docs(handoff): 第 14 編 — Dependabot alert 完全解消 (16→0) + override陳腐化パターンの構造的発見

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -453,3 +453,142 @@ ADR-009 既存ロジック強化 3 件（旧項目 3 の一部）は本セッシ
 - Issue Net 変化 = 0 / 0
 - 同根再発候補 0 件（計画的 debt 解消）／対症療法疑いなし
 - 残留プロセスなし
+
+---
+
+## 2026-07-25/26 セッション総括 (第 14 編): Dependabot alert 完全解消 (16→0) + pnpm.overrides 陳腐化パターンの構造的発見・是正
+
+catchup が新規検出した「fast-uri の Dependabot Updates workflow 失敗」を発端に段階的に調査範囲を拡大し、最終的に open Dependabot alert 16 件を全解消。過程で `pnpm.overrides` が時間経過で静かに陳腐化する構造的パターンを 4 パッケージ連続で発見し、§4.6 同根再発スキャンで第 10〜12 編との連続性を確認。再発防止のプロセス改善（memory 化 + CLAUDE.md 明記）まで実施した。
+
+### PR 一覧
+
+| PR   | 内容                                                                  | 規模              | 結果                                              |
+| ---- | --------------------------------------------------------------------- | ----------------- | ------------------------------------------------- |
+| #186 | chore(deps): bump @hono/node-server from 1.19.13 to 2.0.10            | 2 files           | ✅ merge (CI green 確認済み)                      |
+| #188 | fix(deps): fast-uri を pnpm.overrides で >=3.1.4 に固定               | 2 files +6/-4     | ✅ merge (CI 全 PASS 後)                          |
+| #189 | fix(deps): tar/js-yaml/@hono/node-server の陳腐化した override を更新 | 2 files +18/-26   | ✅ merge (CI 全 PASS 後)                          |
+| #190 | fix(deps): next/postcss/sharp/brace-expansion の脆弱性を解消          | 3 files +233/-197 | ✅ merge (large tier → `/code-review low` 実施後) |
+| #191 | docs(claude-md): catchup 時の Dependabot alert 横断確認を明記         | 1 file +5/-1      | ✅ merge (CI 全 PASS 後)                          |
+
+### 主要成果
+
+#### M1: catchup 起点 — Dependabot open alert 16 件 → 0 件の完全解消
+
+catchup が検出した fast-uri（`security_update_not_possible`）の調査を起点に、`gh api dependabot/alerts` で全件を横断確認しながら段階的に対応範囲を拡大。最終的に 5 PR で以下を解消:
+
+| package                       | 問題                                                                    | 対応                                         |
+| ----------------------------- | ----------------------------------------------------------------------- | -------------------------------------------- |
+| @hono/node-server             | apps/api 直接依存が 1.19.13 で fix 版未満                               | 2.0.10 へ更新 (PR #186)                      |
+| fast-uri                      | devDependency (firebase-tools 配下) が 3.1.2 で fix 版未満              | override 追加 (PR #188)                      |
+| tar                           | 既存 override target (第 12 編で追加) が新規 CVE 未カバー               | target 引き上げ (PR #189)                    |
+| js-yaml                       | 既存 override target (第 10-11 編で追加) が 5.x 系の別 CVE を誘発       | 単一ルールへ統合し target 引き上げ (PR #189) |
+| @hono/node-server(transitive) | `@google/genai` → MCP SDK peer 経由の別インスタンスが未解消             | override 追加 (PR #189)                      |
+| next                          | apps/web 直接依存の lockfile が古いまま (override 無関係の単純ドリフト) | `pnpm update next`（PR #190）                |
+| postcss                       | 既存 override target が新規 CVE 未カバー                                | target 引き上げ (PR #190)                    |
+| sharp                         | next の optionalDependencies が旧バージョンに固定                       | override 新規追加 (PR #190)                  |
+| brace-expansion               | 既存 override target が新規 CVE 未カバー                                | target 引き上げ (PR #190)                    |
+
+#### M2:【重要な発見】pnpm.overrides の構造的陳腐化パターン（同根再発、詳細は § 4.6）
+
+tar/js-yaml/postcss/brace-expansion の 4 件で共通して「override 追加時点の CVE は解消したが、後発の新規 CVE には自動追随しない」パターンを検出。js-yaml では上限なし `>=X.Y.Z` ターゲットが「その時点の latest」に解決されるため別 major の新規 CVE を誘発する挙動、および pnpm のローカル metadata cache（`~/Library/Caches/pnpm/metadata-v1.3/`）が古い `dist-tags.latest` を保持し override 修正後も解決結果が変わらないケースを実測で確認・解消した。
+
+#### M3: 再発防止のプロセス改善
+
+- memory 化: `reference_pnpm_overrides_staleness_pitfall.md`（`platform-pitfalls-index.md` にインデックス追加）
+- decision-maker に AskUserQuestion で再発防止策を確認 → 「catchup 時に Dependabot alert 横断確認を追加」を採用
+- `CLAUDE.md` に「Dependency Security」節を新設（PR #191）。次回以降の `/catchup` で既存 override のあるパッケージも横断確認対象に含める運用を明記
+
+### 検証
+
+- 各 PR で `pnpm turbo build` / `pnpm lint` / `pnpm turbo type-check` / `pnpm test`（246 tests）全 PASS を個別確認
+- 各 PR の CI（quality/e2e/GitGuardian/CodeRabbit）全 green を fresh 確認後、番号単位の明示認可を得てマージ
+- PR #190 は diff 規模（+233/-197、3 files）が hook の large tier 判定に該当し `/code-review low package.json apps/web/package.json pnpm-lock.yaml` を実施（findings 0 件、sharp の Node 要求バージョン変更を CI/Docker 双方で Node 22 が満たすことを個別確認）
+- 全 5 PR のマージ後デプロイ（`deploy.yml`）を `gh run view` で fresh 確認し、5 回とも success
+- 最終状態: `gh api dependabot/alerts` で open 件数 **0**（fresh 確認、複数回計測して回帰なし）
+
+### 同根再発スキャン (§ 4.6)
+
+本セッション修正 PR: PR #188 / #189 / #190（いずれも `fix(deps):`）。
+
+- **同根確定（4 セッションにまたがる構造的パターン）**: 「pnpm.overrides は追加時点の CVE のみ固定し、再監査の仕組みがない」という根本原因が、第 10-11 編（websocket-driver/js-yaml override 新規追加）→ 第 12 編（tar override 新規追加、M3 で peer-dependency 無効化パターンのスイープ実施も target 陳腐化は未検知）→ 本セッション（tar/js-yaml の再陳腐化 + postcss/brace-expansion の新規陳腐化発覚）と繰り返し発症
+  - 第 12 編の M3 スイープは「override が peer dependency 経由で無効化されていないか」のみを検出対象としており、「override target 自体が最新 CVE データに対して十分か」は検証範囲外だった。これが今回の見逃しの直接要因
+  - 根本原因仮説（3 つ）: ① override はワンショットの point-in-time 対応で、CI 上に「既存 override target が最新 Dependabot データを満たしているか」を継続検証する仕組みがない ② 上限なし `>=` ターゲットは pnpm のローカル metadata cache 次第で解決結果が変動しうる（実測確認済み） ③ direct dependency（next）は override 機構と無関係に、単純な `pnpm update` 未実施でも同様にドリフトする
+  - 「もう 1 件同根が出るとしたら」: 既存 override 全 23 件（第 12 編時点）のうち今回検証しなかった残り約 19 件（websocket-driver / esbuild / ws / @grpc/grpc-js / form-data / qs / uuid / node-forge / minimatch / picomatch / yaml / lodash 等）のいずれかに、今後新規 CVE が公開された際に同じ形で再発しうる
+- 過去 7 日 archive を `override` / `Dependabot` / `pnpm.overrides` で grep → 第 11-12 編（本ファイル内）に直接該当。新規の別セッション同根なし（既知の継続パターンとして扱う）
+
+→ **同根再発 1 件（override 陳腐化パターン、4 セッション目の再発）を検出。今回は個別パッケージの target 修正に加えて、根本原因（再監査プロセスの欠如）に対するプロセス改善（CLAUDE.md 明記 + memory 化）まで実施し、対症療法で終わらせなかった** ✅
+
+### 対症療法判定 (§ 4.7)
+
+| #   | 基準                                              | 判定                                                                                                                                                                                                                           |
+| --- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | retry/timeout/fallback/文言修正のみで調査ログなし | ❌ `pnpm why` によるバージョン解決経路の実測確認 + CVE の `first_patched_version` 照合を全パッケージで実施                                                                                                                     |
+| 2   | WebSearch / changelog 確認なし                    | ⚠️ 該当（基準 3 がヒットしたため § 4.7 手順に従い WebSearch を実施。pnpm エコシステムの公式見解として「override は定期的な再監査・クリーンアップが必要」というベストプラクティスを確認、外部要因として構造的に説明可能と判定） |
+| 3   | 同症状 PR が過去 30 日に 1 件以上                 | ✅ 該当（tar: 第 12 編 PR #182 → 本セッション PR #189、js-yaml: 第 11 編 PR #178 → 本セッション PR #189）                                                                                                                      |
+| 4   | smoke のみで構造的検証なし                        | ❌ 全 PR で build/lint/type-check/test/CI/Deploy を個別 fresh 確認、metadata cache 陳腐化の根本原因まで実測特定                                                                                                                |
+
+→ **対症療法ではないが、外部要因（エコシステム共通のベストプラクティスギャップ）による構造的再発と判定** ⚠️。基準 3 がヒットした際の § 4.7 の要求に従い、個別パッケージ修正だけで終わらせず M3（memory 化 + CLAUDE.md プロセス明記）で再発防止まで実施済み
+
+### グローバル memory scope (§ 4.5)
+
+- 新規作成: `reference_pnpm_overrides_staleness_pitfall.md`（type: reference）
+- 既存類似 grep 実施 → 該当なし（新規作成が妥当と判定）
+- スコープ判定: 汎用的な pnpm/エコシステムの技術的知見であり、Why 欄に PR 番号・プロジェクト名・人名は含めず一般化して記述 → グローバル配置が適切
+- `platform-pitfalls-index.md` にインデックス追加済み
+
+### 構造的整合性 (§ 4)
+
+`package.json`（`pnpm.overrides`/`devDependencies`）+ `pnpm-lock.yaml` + `apps/web/package.json` + `CLAUDE.md` の設定・doc 変更のみ。型・共有ロジック・API 変更なし → ⏭️ スキップ
+
+### Issue Net 変化 (第 14 編)
+
+- Close 数: 0 件
+- 起票数: 0 件
+- **Net: 0**（全て PR ベースの対応で Issue 起票不要な軽微修正のため）
+
+### 次のアクション (第 14 編 update)
+
+#### 即着手タスク
+
+なし。
+
+#### 条件待ち (明示 trigger 付き) — 第 13 編の 5 件、内容変化なし
+
+| #   | 項目                                                                    | trigger                                                        | trigger 充足時のタスク                                           |
+| --- | ----------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------- |
+| 1   | C1 拡張 (booking-mirror に Google Calendar 自動登録追加)                | decision-maker から「C1 着手」明示指示                         | spec §9.1 末尾参照 (第 9 編から継続)                             |
+| 2   | gRPC-web API 仕様変更時の運用 fallback                                  | Google 側で `internal` namespace 変更 / API Key 失効           | `parseSlotResponse` の structured log alert 化 (第 9 編から継続) |
+| 3   | ADR-010 Future Work 残り 2 件（Error Budget アラート / PII 直書き検知） | decision-maker 起点指示（本番 GCP 変更を伴うため個別認可必須） | ADR-010 実装フェーズ §4-5 参照                                   |
+| 4   | Issue #145 の 3 連続 PASS 厳密化                                        | 万一 main 上で flaky 再発                                      | diagnostic PR 起動 (第 9 編から継続)                             |
+| 5   | book-mirror デスクトップ (≥ 768px) UI レビュー                          | decision-maker 起点指示                                        | モバイル改修は desktop 非 touch (第 9 編から継続)                |
+
+#### 却下候補 (記録のみ)
+
+第 9-10 編の却下候補は変化なし。
+
+### 再開可能性判定 (第 14 編)
+
+| 項目                       | 状態                                                                                                          |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| OPEN PR                    | 0 件 ✅ (PR #186/#188/#189/#190/#191 merge 済)                                                                |
+| active Issue               | 0 件 ✅                                                                                                       |
+| Git clean                  | ✅                                                                                                            |
+| 残留プロセス               | ✅ なし                                                                                                       |
+| Security alert(Dependabot) | **0 件**（前セッションから 16 件全解消、fresh 確認済み）                                                      |
+| Deploy CI                  | ✅ success（5 PR とも fresh 確認で success）                                                                  |
+| 構造的整合性               | ⏭️ スキップ (設定ファイル + doc のみ)                                                                         |
+| 同根再発                   | ⚠️ 1 件検出（override 陳腐化、4 セッション目の再発）。個別修正 + プロセス改善（CLAUDE.md/memory）まで実施済み |
+| 対症療法疑い               | ⚠️ 外部要因による構造的再発と判定、再発防止プロセスを追加済み                                                 |
+| グローバル memory scope    | ✅ 新規 1 件、スコープ判定済み                                                                                |
+
+---
+
+## 最終結論 (第 14 編)
+
+✅ **セッション終了可** — Dependabot open alert 16 件 → 0 件を完全解消、同根再発パターンの根本原因分析と再発防止プロセス（CLAUDE.md 明記 + memory 化）まで実施済み
+
+- OPEN PR ゼロ、active Issue ゼロ、Git clean、残留プロセスなし
+- 即着手タスク = 0 / 条件待ち = 5 件（すべて decision-maker 領分または外部 trigger 待ち、第 13 編から変化なし）
+- Issue Net 変化 = 0 / 0
+- **同根再発 1 件検出**（pnpm.overrides 陳腐化、第 10〜12 編から続く 4 セッション目の再発）— 対症療法では終わらせず、次回 catchup から Dependabot alert 横断確認を定例化する仕組み（CLAUDE.md「Dependency Security」節）まで構築
+- 次回セッション以降、同パターンが解消されたか（catchup で Dependabot alert 0 件を維持できているか）を注視ポイントとして引き継ぐ


### PR DESCRIPTION
## Summary
本セッションのハンドオフ記録。catchup起点のfast-uri調査から段階的に対応範囲を拡大し、Dependabot open alert 16件を0件に完全解消（PR #186/#188/#189/#190/#191）。過程で `pnpm.overrides` の構造的陳腐化パターンを発見し、第10-12編との同根再発と確認、再発防止プロセス（memory化 + CLAUDE.md「Dependency Security」節新設）まで実施した記録。

詳細は `docs/handoff/LATEST.md` 第14編を参照。

## Test plan
doc-onlyの変更のため、内容の整合性確認のみ。
- [x] 記載したPR番号・commit・CI/デプロイ結果は全てfresh確認済み（本セッション内で実施）
- [x] 最長行653文字（1,500文字閾値未満）・ファイルサイズ57KB（60KB backstop未満）を確認、アーカイブ不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 依存関係に関するセキュリティアラート16件を解消し、未対応アラートを0件にした記録を追加しました。
  * 依存関係の再発防止策、確認手順、CI・デプロイ検証結果をドキュメントに反映しました。
  * 今後の定期確認や問題発生時の対応手順を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->