### PR TITLE
fix(booking-mirror): mirrorの空き枠から自前の確定予約を差し引く

### DIFF
--- a/apps/api/src/__tests__/booking-events.test.ts
+++ b/apps/api/src/__tests__/booking-events.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { toOverlappingBookingEvents } from '../lib/booking-events.js';
+
+// Firestore Timestamp のダミー実装 (toDate() のみ持てば十分)
+function fakeTimestamp(date: Date) {
+  return { toDate: () => date };
+}
+
+describe('toOverlappingBookingEvents', () => {
+  it('timeMin より完全に前で終了している予約は除外する', () => {
+    const docs = [
+      {
+        id: 'b1',
+        slotStart: fakeTimestamp(new Date('2026-08-01T08:00:00Z')),
+        slotEnd: fakeTimestamp(new Date('2026-08-01T09:00:00Z')),
+      },
+    ];
+    const timeMin = new Date('2026-08-01T10:00:00Z');
+
+    const result = toOverlappingBookingEvents(docs, timeMin);
+
+    expect(result).toEqual([]);
+  });
+
+  it('timeMin 開始前から始まりまだ終了していない (進行中の) 予約は含める', () => {
+    // 回帰テスト: slotStart >= timeMin だけのクエリではこのケースが漏れ、
+    // 該当時間帯の Google slot がそのまま「空き」として返ってしまうバグがあった
+    const docs = [
+      {
+        id: 'b1',
+        slotStart: fakeTimestamp(new Date('2026-08-01T10:00:00Z')),
+        slotEnd: fakeTimestamp(new Date('2026-08-01T10:30:00Z')),
+      },
+    ];
+    const timeMin = new Date('2026-08-01T10:15:00Z'); // 予約の途中
+
+    const result = toOverlappingBookingEvents(docs, timeMin);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('b1');
+  });
+
+  it('予約が timeMin ちょうどに終了する場合は除外する (隣接は重複ではない)', () => {
+    const docs = [
+      {
+        id: 'b1',
+        slotStart: fakeTimestamp(new Date('2026-08-01T09:00:00Z')),
+        slotEnd: fakeTimestamp(new Date('2026-08-01T10:00:00Z')),
+      },
+    ];
+    const timeMin = new Date('2026-08-01T10:00:00Z');
+
+    const result = toOverlappingBookingEvents(docs, timeMin);
+
+    expect(result).toEqual([]);
+  });
+
+  it('timeMin 以降に完全に収まる予約は含める', () => {
+    const docs = [
+      {
+        id: 'b1',
+        slotStart: fakeTimestamp(new Date('2026-08-01T11:00:00Z')),
+        slotEnd: fakeTimestamp(new Date('2026-08-01T12:00:00Z')),
+      },
+    ];
+    const timeMin = new Date('2026-08-01T10:00:00Z');
+
+    const result = toOverlappingBookingEvents(docs, timeMin);
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('CalendarEvent への変換内容が正しい', () => {
+    const docs = [
+      {
+        id: 'b1',
+        slotStart: fakeTimestamp(new Date('2026-08-01T10:00:00Z')),
+        slotEnd: fakeTimestamp(new Date('2026-08-01T11:00:00Z')),
+      },
+    ];
+
+    const result = toOverlappingBookingEvents(docs, new Date('2026-08-01T00:00:00Z'));
+
+    expect(result[0]).toEqual({
+      id: 'b1',
+      source: 'google',
+      originalId: 'b1',
+      calendarId: 'booking',
+      title: 'Reserved',
+      start: new Date('2026-08-01T10:00:00Z'),
+      end: new Date('2026-08-01T11:00:00Z'),
+      isAllDay: false,
+      status: 'confirmed',
+    });
+  });
+});

--- a/apps/api/src/__tests__/booking-mirror-link-utils.test.ts
+++ b/apps/api/src/__tests__/booking-mirror-link-utils.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildBookingMirrorLinkFromFirestoreData,
+  excludeOverlappingSlots,
+} from '../lib/booking-mirror-link-utils.js';
+import type { GoogleSlot } from '../lib/google-booking-mirror.js';
+
+// Firestore Timestamp のダミー実装 (toDate() のみ持てば十分)
+function fakeTimestamp(date: Date) {
+  return { toDate: () => date };
+}
+
+describe('buildBookingMirrorLinkFromFirestoreData', () => {
+  it('必須フィールドをそのまま引き継ぐ', () => {
+    const data = {
+      id: 'link1',
+      ownerUid: 'u1',
+      title: 'タイトル',
+      sourceUrl: 'https://calendar.app.google/abc',
+      scheduleId: 'sched1',
+      notificationEmail: 'owner@example.com',
+      rangeDays: 30,
+      status: 'active',
+      expiresAt: null,
+      createdAt: fakeTimestamp(new Date('2026-01-01T00:00:00Z')),
+      updatedAt: fakeTimestamp(new Date('2026-01-02T00:00:00Z')),
+    };
+
+    const link = buildBookingMirrorLinkFromFirestoreData(data);
+
+    expect(link.id).toBe('link1');
+    expect(link.ownerUid).toBe('u1');
+    expect(link.title).toBe('タイトル');
+    expect(link.sourceUrl).toBe('https://calendar.app.google/abc');
+    expect(link.scheduleId).toBe('sched1');
+    expect(link.notificationEmail).toBe('owner@example.com');
+    expect(link.rangeDays).toBe(30);
+    expect(link.status).toBe('active');
+  });
+
+  it('Firestore Timestamp を Date に変換する', () => {
+    const data = {
+      id: 'link1',
+      ownerUid: 'u1',
+      title: 't',
+      sourceUrl: 'https://calendar.app.google/abc',
+      scheduleId: 'sched1',
+      notificationEmail: 'owner@example.com',
+      rangeDays: 30,
+      status: 'active',
+      expiresAt: fakeTimestamp(new Date('2026-06-01T00:00:00Z')),
+      createdAt: fakeTimestamp(new Date('2026-01-01T00:00:00Z')),
+      updatedAt: fakeTimestamp(new Date('2026-01-02T00:00:00Z')),
+    };
+
+    const link = buildBookingMirrorLinkFromFirestoreData(data);
+
+    expect(link.createdAt).toEqual(new Date('2026-01-01T00:00:00Z'));
+    expect(link.updatedAt).toEqual(new Date('2026-01-02T00:00:00Z'));
+    expect(link.expiresAt).toEqual(new Date('2026-06-01T00:00:00Z'));
+  });
+
+  it('expiresAt が無ければ null を返す', () => {
+    const data = {
+      id: 'link1',
+      ownerUid: 'u1',
+      title: 't',
+      sourceUrl: 'https://calendar.app.google/abc',
+      scheduleId: 'sched1',
+      notificationEmail: 'owner@example.com',
+      rangeDays: 30,
+      status: 'active',
+      createdAt: fakeTimestamp(new Date()),
+      updatedAt: fakeTimestamp(new Date()),
+    };
+
+    const link = buildBookingMirrorLinkFromFirestoreData(data);
+
+    expect(link.expiresAt).toBeNull();
+  });
+
+  it('description が無ければ undefined を返す', () => {
+    const data = {
+      id: 'link1',
+      ownerUid: 'u1',
+      title: 't',
+      sourceUrl: 'https://calendar.app.google/abc',
+      scheduleId: 'sched1',
+      notificationEmail: 'owner@example.com',
+      rangeDays: 30,
+      status: 'active',
+      createdAt: fakeTimestamp(new Date()),
+      updatedAt: fakeTimestamp(new Date()),
+    };
+
+    const link = buildBookingMirrorLinkFromFirestoreData(data);
+
+    expect(link.description).toBeUndefined();
+  });
+
+  it('createdAt/updatedAt が無ければ現在時刻にフォールバックする', () => {
+    const data = {
+      id: 'link1',
+      ownerUid: 'u1',
+      title: 't',
+      sourceUrl: 'https://calendar.app.google/abc',
+      scheduleId: 'sched1',
+      notificationEmail: 'owner@example.com',
+      rangeDays: 30,
+      status: 'active',
+    };
+
+    const link = buildBookingMirrorLinkFromFirestoreData(data);
+
+    expect(link.createdAt).toBeInstanceOf(Date);
+    expect(link.updatedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('excludeOverlappingSlots', () => {
+  function slot(startIso: string, durationMinutes: number): GoogleSlot {
+    return {
+      startUnix: Math.floor(new Date(startIso).getTime() / 1000),
+      durationMinutes,
+    };
+  }
+
+  it('確定予約が無ければ全ての slot をそのまま返す', () => {
+    const slots = [slot('2026-08-01T10:00:00Z', 60)];
+
+    const result = excludeOverlappingSlots(slots, []);
+
+    expect(result).toEqual(slots);
+  });
+
+  it('slot と完全一致する確定予約があれば除外する', () => {
+    const slots = [slot('2026-08-01T10:00:00Z', 60)];
+    const booked = [
+      { start: new Date('2026-08-01T10:00:00Z'), end: new Date('2026-08-01T11:00:00Z') },
+    ];
+
+    const result = excludeOverlappingSlots(slots, booked);
+
+    expect(result).toEqual([]);
+  });
+
+  it('確定予約が slot の一部と重なるだけでも除外する', () => {
+    const slots = [slot('2026-08-01T10:00:00Z', 60)]; // 10:00-11:00
+    const booked = [
+      // 10:30-10:45 (slot の内側に完全に収まる部分重複)
+      { start: new Date('2026-08-01T10:30:00Z'), end: new Date('2026-08-01T10:45:00Z') },
+    ];
+
+    const result = excludeOverlappingSlots(slots, booked);
+
+    expect(result).toEqual([]);
+  });
+
+  it('確定予約が slot の終了時刻ちょうどに開始する場合は除外しない (隣接は重複ではない)', () => {
+    const slots = [slot('2026-08-01T10:00:00Z', 60)]; // 10:00-11:00
+    const booked = [
+      { start: new Date('2026-08-01T11:00:00Z'), end: new Date('2026-08-01T12:00:00Z') },
+    ];
+
+    const result = excludeOverlappingSlots(slots, booked);
+
+    expect(result).toEqual(slots);
+  });
+
+  it('確定予約が slot の開始時刻ちょうどに終了する場合は除外しない (隣接は重複ではない)', () => {
+    const slots = [slot('2026-08-01T10:00:00Z', 60)]; // 10:00-11:00
+    const booked = [
+      { start: new Date('2026-08-01T09:00:00Z'), end: new Date('2026-08-01T10:00:00Z') },
+    ];
+
+    const result = excludeOverlappingSlots(slots, booked);
+
+    expect(result).toEqual(slots);
+  });
+
+  it('複数 slot のうち重なるものだけを除外する', () => {
+    const slotA = slot('2026-08-01T10:00:00Z', 60); // 10:00-11:00 (重複させる)
+    const slotB = slot('2026-08-01T14:00:00Z', 60); // 14:00-15:00 (無関係)
+    const booked = [
+      { start: new Date('2026-08-01T10:30:00Z'), end: new Date('2026-08-01T10:45:00Z') },
+    ];
+
+    const result = excludeOverlappingSlots([slotA, slotB], booked);
+
+    expect(result).toEqual([slotB]);
+  });
+
+  it('複数の確定予約のいずれかと重なれば除外する', () => {
+    const slots = [slot('2026-08-01T10:00:00Z', 60)];
+    const booked = [
+      { start: new Date('2026-08-01T08:00:00Z'), end: new Date('2026-08-01T09:00:00Z') }, // 無関係
+      { start: new Date('2026-08-01T10:30:00Z'), end: new Date('2026-08-01T10:45:00Z') }, // 重複
+    ];
+
+    const result = excludeOverlappingSlots(slots, booked);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/api/src/__tests__/booking-mirror-link-utils.test.ts
+++ b/apps/api/src/__tests__/booking-mirror-link-utils.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  buildBookingMirrorLinkFromFirestoreData,
-  excludeOverlappingSlots,
-} from '../lib/booking-mirror-link-utils.js';
-import type { GoogleSlot } from '../lib/google-booking-mirror.js';
+import { buildBookingMirrorLinkFromFirestoreData } from '../lib/booking-mirror-link-utils.js';
 
 // Firestore Timestamp のダミー実装 (toDate() のみ持てば十分)
 function fakeTimestamp(date: Date) {
@@ -98,6 +94,50 @@ describe('buildBookingMirrorLinkFromFirestoreData', () => {
     expect(link.description).toBeUndefined();
   });
 
+  it('description が Firestore 上 null で保存されていても undefined に変換する (spread化での回帰防止)', () => {
+    // 作成 API は description 未指定時に null を明示保存するため (booking-mirror-links.ts)、
+    // spread ベースの mapper でも null が漏れ出ないことを固定する
+    const data = {
+      id: 'link1',
+      ownerUid: 'u1',
+      title: 't',
+      description: null,
+      sourceUrl: 'https://calendar.app.google/abc',
+      scheduleId: 'sched1',
+      notificationEmail: 'owner@example.com',
+      rangeDays: 30,
+      status: 'active',
+      createdAt: fakeTimestamp(new Date()),
+      updatedAt: fakeTimestamp(new Date()),
+    };
+
+    const link = buildBookingMirrorLinkFromFirestoreData(data);
+
+    expect(link.description).toBeUndefined();
+  });
+
+  it('未知のフィールドが Firestore data にあっても spread で自動的に引き継がれる', () => {
+    // 将来 BookingMirrorLink に追加されるフィールド (C1 拡張の autoCreateBlockEvent 等) が
+    // このマッパーの更新漏れでサイレントに欠落しないことを保証する
+    const data = {
+      id: 'link1',
+      ownerUid: 'u1',
+      title: 't',
+      sourceUrl: 'https://calendar.app.google/abc',
+      scheduleId: 'sched1',
+      notificationEmail: 'owner@example.com',
+      rangeDays: 30,
+      status: 'active',
+      createdAt: fakeTimestamp(new Date()),
+      updatedAt: fakeTimestamp(new Date()),
+      futureField: 'future-value',
+    };
+
+    const link = buildBookingMirrorLinkFromFirestoreData(data);
+
+    expect((link as unknown as Record<string, unknown>).futureField).toBe('future-value');
+  });
+
   it('createdAt/updatedAt が無ければ現在時刻にフォールバックする', () => {
     const data = {
       id: 'link1',
@@ -114,91 +154,5 @@ describe('buildBookingMirrorLinkFromFirestoreData', () => {
 
     expect(link.createdAt).toBeInstanceOf(Date);
     expect(link.updatedAt).toBeInstanceOf(Date);
-  });
-});
-
-describe('excludeOverlappingSlots', () => {
-  function slot(startIso: string, durationMinutes: number): GoogleSlot {
-    return {
-      startUnix: Math.floor(new Date(startIso).getTime() / 1000),
-      durationMinutes,
-    };
-  }
-
-  it('確定予約が無ければ全ての slot をそのまま返す', () => {
-    const slots = [slot('2026-08-01T10:00:00Z', 60)];
-
-    const result = excludeOverlappingSlots(slots, []);
-
-    expect(result).toEqual(slots);
-  });
-
-  it('slot と完全一致する確定予約があれば除外する', () => {
-    const slots = [slot('2026-08-01T10:00:00Z', 60)];
-    const booked = [
-      { start: new Date('2026-08-01T10:00:00Z'), end: new Date('2026-08-01T11:00:00Z') },
-    ];
-
-    const result = excludeOverlappingSlots(slots, booked);
-
-    expect(result).toEqual([]);
-  });
-
-  it('確定予約が slot の一部と重なるだけでも除外する', () => {
-    const slots = [slot('2026-08-01T10:00:00Z', 60)]; // 10:00-11:00
-    const booked = [
-      // 10:30-10:45 (slot の内側に完全に収まる部分重複)
-      { start: new Date('2026-08-01T10:30:00Z'), end: new Date('2026-08-01T10:45:00Z') },
-    ];
-
-    const result = excludeOverlappingSlots(slots, booked);
-
-    expect(result).toEqual([]);
-  });
-
-  it('確定予約が slot の終了時刻ちょうどに開始する場合は除外しない (隣接は重複ではない)', () => {
-    const slots = [slot('2026-08-01T10:00:00Z', 60)]; // 10:00-11:00
-    const booked = [
-      { start: new Date('2026-08-01T11:00:00Z'), end: new Date('2026-08-01T12:00:00Z') },
-    ];
-
-    const result = excludeOverlappingSlots(slots, booked);
-
-    expect(result).toEqual(slots);
-  });
-
-  it('確定予約が slot の開始時刻ちょうどに終了する場合は除外しない (隣接は重複ではない)', () => {
-    const slots = [slot('2026-08-01T10:00:00Z', 60)]; // 10:00-11:00
-    const booked = [
-      { start: new Date('2026-08-01T09:00:00Z'), end: new Date('2026-08-01T10:00:00Z') },
-    ];
-
-    const result = excludeOverlappingSlots(slots, booked);
-
-    expect(result).toEqual(slots);
-  });
-
-  it('複数 slot のうち重なるものだけを除外する', () => {
-    const slotA = slot('2026-08-01T10:00:00Z', 60); // 10:00-11:00 (重複させる)
-    const slotB = slot('2026-08-01T14:00:00Z', 60); // 14:00-15:00 (無関係)
-    const booked = [
-      { start: new Date('2026-08-01T10:30:00Z'), end: new Date('2026-08-01T10:45:00Z') },
-    ];
-
-    const result = excludeOverlappingSlots([slotA, slotB], booked);
-
-    expect(result).toEqual([slotB]);
-  });
-
-  it('複数の確定予約のいずれかと重なれば除外する', () => {
-    const slots = [slot('2026-08-01T10:00:00Z', 60)];
-    const booked = [
-      { start: new Date('2026-08-01T08:00:00Z'), end: new Date('2026-08-01T09:00:00Z') }, // 無関係
-      { start: new Date('2026-08-01T10:30:00Z'), end: new Date('2026-08-01T10:45:00Z') }, // 重複
-    ];
-
-    const result = excludeOverlappingSlots(slots, booked);
-
-    expect(result).toEqual([]);
   });
 });

--- a/apps/api/src/__tests__/booking-mirror-slots.test.ts
+++ b/apps/api/src/__tests__/booking-mirror-slots.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { excludeOverlappingSlots } from '../lib/booking-mirror-slots.js';
+import type { GoogleSlot } from '../lib/google-booking-mirror.js';
+
+describe('excludeOverlappingSlots', () => {
+  function slot(startIso: string, durationMinutes: number): GoogleSlot {
+    return {
+      startUnix: Math.floor(new Date(startIso).getTime() / 1000),
+      durationMinutes,
+    };
+  }
+
+  it('確定予約が無ければ全ての slot をそのまま返す', () => {
+    const slots = [slot('2026-08-01T10:00:00Z', 60)];
+
+    const result = excludeOverlappingSlots(slots, []);
+
+    expect(result).toEqual(slots);
+  });
+
+  it('slot と完全一致する確定予約があれば除外する', () => {
+    const slots = [slot('2026-08-01T10:00:00Z', 60)];
+    const booked = [
+      { start: new Date('2026-08-01T10:00:00Z'), end: new Date('2026-08-01T11:00:00Z') },
+    ];
+
+    const result = excludeOverlappingSlots(slots, booked);
+
+    expect(result).toEqual([]);
+  });
+
+  it('確定予約が slot の一部と重なるだけでも除外する', () => {
+    const slots = [slot('2026-08-01T10:00:00Z', 60)]; // 10:00-11:00
+    const booked = [
+      // 10:30-10:45 (slot の内側に完全に収まる部分重複)
+      { start: new Date('2026-08-01T10:30:00Z'), end: new Date('2026-08-01T10:45:00Z') },
+    ];
+
+    const result = excludeOverlappingSlots(slots, booked);
+
+    expect(result).toEqual([]);
+  });
+
+  it('確定予約が slot の終了時刻ちょうどに開始する場合は除外しない (隣接は重複ではない)', () => {
+    const slots = [slot('2026-08-01T10:00:00Z', 60)]; // 10:00-11:00
+    const booked = [
+      { start: new Date('2026-08-01T11:00:00Z'), end: new Date('2026-08-01T12:00:00Z') },
+    ];
+
+    const result = excludeOverlappingSlots(slots, booked);
+
+    expect(result).toEqual(slots);
+  });
+
+  it('確定予約が slot の開始時刻ちょうどに終了する場合は除外しない (隣接は重複ではない)', () => {
+    const slots = [slot('2026-08-01T10:00:00Z', 60)]; // 10:00-11:00
+    const booked = [
+      { start: new Date('2026-08-01T09:00:00Z'), end: new Date('2026-08-01T10:00:00Z') },
+    ];
+
+    const result = excludeOverlappingSlots(slots, booked);
+
+    expect(result).toEqual(slots);
+  });
+
+  it('複数 slot のうち重なるものだけを除外する', () => {
+    const slotA = slot('2026-08-01T10:00:00Z', 60); // 10:00-11:00 (重複させる)
+    const slotB = slot('2026-08-01T14:00:00Z', 60); // 14:00-15:00 (無関係)
+    const booked = [
+      { start: new Date('2026-08-01T10:30:00Z'), end: new Date('2026-08-01T10:45:00Z') },
+    ];
+
+    const result = excludeOverlappingSlots([slotA, slotB], booked);
+
+    expect(result).toEqual([slotB]);
+  });
+
+  it('複数の確定予約のいずれかと重なれば除外する', () => {
+    const slots = [slot('2026-08-01T10:00:00Z', 60)];
+    const booked = [
+      { start: new Date('2026-08-01T08:00:00Z'), end: new Date('2026-08-01T09:00:00Z') }, // 無関係
+      { start: new Date('2026-08-01T10:30:00Z'), end: new Date('2026-08-01T10:45:00Z') }, // 重複
+    ];
+
+    const result = excludeOverlappingSlots(slots, booked);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/api/src/lib/booking-events.ts
+++ b/apps/api/src/lib/booking-events.ts
@@ -1,0 +1,43 @@
+import { getDb } from './firebase-admin.js';
+import type { CalendarEvent } from '@calendar-hub/shared';
+
+/**
+ * 指定オーナーの確定済み予約 (`bookings` collection, status='confirmed') を
+ * ダミーイベントとしてマージするための変換。
+ *
+ * 予約リンク種別 (`bookingLink` / `bookingMirrorLink`) を問わず同一オーナーの
+ * 全予約を対象にする。空き時間計算に混ぜることで、Google Calendar 側にまだ
+ * 反映されていない (あるいはそもそも反映されない) 確定予約による二重予約を防止する。
+ *
+ * `public-booking.ts` (非ミラー版) と `public-booking-mirror.ts` (ミラー版) の
+ * 両方から呼ばれる共通ロジック。
+ */
+export async function getConfirmedBookingEventsForOwner(
+  ownerUid: string,
+  timeMin: Date,
+  timeMax: Date,
+): Promise<CalendarEvent[]> {
+  const db = getDb();
+  const snap = await db
+    .collection('bookings')
+    .where('ownerUid', '==', ownerUid)
+    .where('status', '==', 'confirmed')
+    .where('slotStart', '>=', timeMin)
+    .where('slotStart', '<=', timeMax)
+    .get();
+
+  return snap.docs.map((doc) => {
+    const data = doc.data();
+    return {
+      id: doc.id,
+      source: 'google' as const, // CalendarEvent型に合わせるためのダミー値
+      originalId: doc.id,
+      calendarId: 'booking',
+      title: 'Reserved',
+      start: data.slotStart.toDate(),
+      end: data.slotEnd.toDate(),
+      isAllDay: false,
+      status: 'confirmed' as const,
+    };
+  });
+}

--- a/apps/api/src/lib/booking-events.ts
+++ b/apps/api/src/lib/booking-events.ts
@@ -2,6 +2,42 @@ import { getDb } from './firebase-admin.js';
 import type { CalendarEvent } from '@calendar-hub/shared';
 
 /**
+ * `slotStart` だけで区切ったクエリでは検出できない「timeMin より前に始まり、
+ * まだ終了していない (進行中の)」予約を取りこぼさないための、クエリ下限の
+ * 巻き戻し幅。個人運用規模の予約枠として現実的にありえない長さ (24時間) を
+ * 十分に超える値を取り、真の重複判定は `toOverlappingBookingEvents` の
+ * `end > timeMin` フィルタで行う。
+ */
+const OVERLAP_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+
+interface RawBookingDoc {
+  id: string;
+  slotStart: { toDate(): Date };
+  slotEnd: { toDate(): Date };
+}
+
+/**
+ * Firestore から取得した確定予約 doc を CalendarEvent[] に変換し、`timeMin`
+ * 以降に終了するものだけを残す (`slotStart` の範囲クエリだけでは、timeMin
+ * より前に始まってまだ終了していない予約を検出できないため)。
+ */
+export function toOverlappingBookingEvents(docs: RawBookingDoc[], timeMin: Date): CalendarEvent[] {
+  return docs
+    .map((doc) => ({
+      id: doc.id,
+      source: 'google' as const, // CalendarEvent型に合わせるためのダミー値
+      originalId: doc.id,
+      calendarId: 'booking',
+      title: 'Reserved',
+      start: doc.slotStart.toDate(),
+      end: doc.slotEnd.toDate(),
+      isAllDay: false,
+      status: 'confirmed' as const,
+    }))
+    .filter((event) => event.end > timeMin);
+}
+
+/**
  * 指定オーナーの確定済み予約 (`bookings` collection, status='confirmed') を
  * ダミーイベントとしてマージするための変換。
  *
@@ -18,26 +54,18 @@ export async function getConfirmedBookingEventsForOwner(
   timeMax: Date,
 ): Promise<CalendarEvent[]> {
   const db = getDb();
+  const queryLowerBound = new Date(timeMin.getTime() - OVERLAP_LOOKBACK_MS);
   const snap = await db
     .collection('bookings')
     .where('ownerUid', '==', ownerUid)
     .where('status', '==', 'confirmed')
-    .where('slotStart', '>=', timeMin)
+    .where('slotStart', '>=', queryLowerBound)
     .where('slotStart', '<=', timeMax)
     .get();
 
-  return snap.docs.map((doc) => {
+  const rawDocs = snap.docs.map((doc) => {
     const data = doc.data();
-    return {
-      id: doc.id,
-      source: 'google' as const, // CalendarEvent型に合わせるためのダミー値
-      originalId: doc.id,
-      calendarId: 'booking',
-      title: 'Reserved',
-      start: data.slotStart.toDate(),
-      end: data.slotEnd.toDate(),
-      isAllDay: false,
-      status: 'confirmed' as const,
-    };
+    return { id: doc.id, slotStart: data.slotStart, slotEnd: data.slotEnd };
   });
+  return toOverlappingBookingEvents(rawDocs, timeMin);
 }

--- a/apps/api/src/lib/booking-mirror-link-utils.ts
+++ b/apps/api/src/lib/booking-mirror-link-utils.ts
@@ -1,0 +1,52 @@
+import type { DocumentData } from 'firebase-admin/firestore';
+import type { BookingMirrorLink } from '@calendar-hub/shared';
+import type { GoogleSlot } from './google-booking-mirror.js';
+
+/**
+ * Firestore document data から BookingMirrorLink を構築する。
+ * Timestamp → Date 変換を一括で行う。
+ *
+ * 管理 CRUD (`routes/booking-mirror-links.ts`) と公開 API
+ * (`routes/public-booking-mirror.ts`) の双方から呼ばれる、唯一の mapper。
+ * 旧実装ではこの変換ロジックが2箇所に手書きで重複しており、片方だけへの
+ * フィールド追加が「管理画面では保存できるのに予約処理では常に無効」という
+ * サイレント障害を生む構造的リスクがあったため、ここに一本化する。
+ */
+export function buildBookingMirrorLinkFromFirestoreData(data: DocumentData): BookingMirrorLink {
+  return {
+    id: data.id,
+    ownerUid: data.ownerUid,
+    title: data.title,
+    description: data.description ?? undefined,
+    sourceUrl: data.sourceUrl,
+    scheduleId: data.scheduleId,
+    notificationEmail: data.notificationEmail,
+    rangeDays: data.rangeDays,
+    status: data.status,
+    expiresAt: data.expiresAt?.toDate?.() ?? null,
+    createdAt: data.createdAt?.toDate?.() ?? new Date(),
+    updatedAt: data.updatedAt?.toDate?.() ?? new Date(),
+  };
+}
+
+/**
+ * gRPC-web から取得した空き slot のうち、Calendar Hub 側で既に確定済みの予約
+ * (`bookedRanges`) と重なるものを除外する。
+ *
+ * Google Appointment Schedule 側は Calendar Hub 経由の予約を認識しないため、
+ * 何もしないとミラーページ上で「予約済みのはずの枠」が空きとして表示され続け、
+ * 次のゲストが予約しようとすると 409 を返す (自前 DB だけで確実に防げる不整合)。
+ *
+ * 重なり判定は `start < slotEnd && end > slotStart` (区間の共通部分が存在するか)。
+ * 境界がちょうど接するだけ (隣接) は重複として扱わない。
+ */
+export function excludeOverlappingSlots(
+  slots: GoogleSlot[],
+  bookedRanges: { start: Date; end: Date }[],
+): GoogleSlot[] {
+  return slots.filter((slot) => {
+    const slotStart = new Date(slot.startUnix * 1000);
+    const slotEnd = new Date((slot.startUnix + slot.durationMinutes * 60) * 1000);
+    return !bookedRanges.some((range) => range.start < slotEnd && range.end > slotStart);
+  });
+}

--- a/apps/api/src/lib/booking-mirror-link-utils.ts
+++ b/apps/api/src/lib/booking-mirror-link-utils.ts
@@ -1,6 +1,5 @@
 import type { DocumentData } from 'firebase-admin/firestore';
 import type { BookingMirrorLink } from '@calendar-hub/shared';
-import type { GoogleSlot } from './google-booking-mirror.js';
 
 /**
  * Firestore document data から BookingMirrorLink を構築する。
@@ -11,42 +10,19 @@ import type { GoogleSlot } from './google-booking-mirror.js';
  * 旧実装ではこの変換ロジックが2箇所に手書きで重複しており、片方だけへの
  * フィールド追加が「管理画面では保存できるのに予約処理では常に無効」という
  * サイレント障害を生む構造的リスクがあったため、ここに一本化する。
+ *
+ * spread ベースにしているのは、将来 `BookingMirrorLink` にフィールドを追加した際
+ * (例: C1 拡張の `autoCreateBlockEvent` 等) にこの関数を手で更新し忘れても
+ * 素通りで転記されるようにするため (非ミラー版 `buildBookingLinkFromFirestoreData`
+ * と同じ方針)。ただし `description` は Firestore 上 `null` で保存されうるのに対し
+ * 型は `string | undefined` のため、ここだけは明示的に変換する。
  */
 export function buildBookingMirrorLinkFromFirestoreData(data: DocumentData): BookingMirrorLink {
   return {
-    id: data.id,
-    ownerUid: data.ownerUid,
-    title: data.title,
+    ...data,
     description: data.description ?? undefined,
-    sourceUrl: data.sourceUrl,
-    scheduleId: data.scheduleId,
-    notificationEmail: data.notificationEmail,
-    rangeDays: data.rangeDays,
-    status: data.status,
     expiresAt: data.expiresAt?.toDate?.() ?? null,
     createdAt: data.createdAt?.toDate?.() ?? new Date(),
     updatedAt: data.updatedAt?.toDate?.() ?? new Date(),
-  };
-}
-
-/**
- * gRPC-web から取得した空き slot のうち、Calendar Hub 側で既に確定済みの予約
- * (`bookedRanges`) と重なるものを除外する。
- *
- * Google Appointment Schedule 側は Calendar Hub 経由の予約を認識しないため、
- * 何もしないとミラーページ上で「予約済みのはずの枠」が空きとして表示され続け、
- * 次のゲストが予約しようとすると 409 を返す (自前 DB だけで確実に防げる不整合)。
- *
- * 重なり判定は `start < slotEnd && end > slotStart` (区間の共通部分が存在するか)。
- * 境界がちょうど接するだけ (隣接) は重複として扱わない。
- */
-export function excludeOverlappingSlots(
-  slots: GoogleSlot[],
-  bookedRanges: { start: Date; end: Date }[],
-): GoogleSlot[] {
-  return slots.filter((slot) => {
-    const slotStart = new Date(slot.startUnix * 1000);
-    const slotEnd = new Date((slot.startUnix + slot.durationMinutes * 60) * 1000);
-    return !bookedRanges.some((range) => range.start < slotEnd && range.end > slotStart);
-  });
+  } as BookingMirrorLink;
 }

--- a/apps/api/src/lib/booking-mirror-slots.ts
+++ b/apps/api/src/lib/booking-mirror-slots.ts
@@ -1,0 +1,23 @@
+import type { GoogleSlot } from './google-booking-mirror.js';
+
+/**
+ * gRPC-web から取得した空き slot のうち、Calendar Hub 側で既に確定済みの予約
+ * (`bookedRanges`) と重なるものを除外する。
+ *
+ * Google Appointment Schedule 側は Calendar Hub 経由の予約を認識しないため、
+ * 何もしないとミラーページ上で「予約済みのはずの枠」が空きとして表示され続け、
+ * 次のゲストが予約しようとすると 409 を返す (自前 DB だけで確実に防げる不整合)。
+ *
+ * 重なり判定は `start < slotEnd && end > slotStart` (区間の共通部分が存在するか)。
+ * 境界がちょうど接するだけ (隣接) は重複として扱わない。
+ */
+export function excludeOverlappingSlots(
+  slots: GoogleSlot[],
+  bookedRanges: { start: Date; end: Date }[],
+): GoogleSlot[] {
+  return slots.filter((slot) => {
+    const slotStart = new Date(slot.startUnix * 1000);
+    const slotEnd = new Date((slot.startUnix + slot.durationMinutes * 60) * 1000);
+    return !bookedRanges.some((range) => range.start < slotEnd && range.end > slotStart);
+  });
+}

--- a/apps/api/src/routes/booking-mirror-links.ts
+++ b/apps/api/src/routes/booking-mirror-links.ts
@@ -11,6 +11,7 @@ import type {
   UpdateBookingMirrorLinkInput,
 } from '@calendar-hub/shared';
 import { resolveScheduleId, BookingMirrorError } from '../lib/google-booking-mirror.js';
+import { buildBookingMirrorLinkFromFirestoreData } from '../lib/booking-mirror-link-utils.js';
 
 export const bookingMirrorLinkRoutes = new Hono<AppEnv>();
 
@@ -20,23 +21,6 @@ const DEFAULT_NOTIFICATION_EMAIL =
   process.env.DEFAULT_NOTIFICATION_EMAIL ?? 'hy.unimail.11@gmail.com';
 
 // --- ヘルパー ---
-
-function fromFirestoreData(data: FirebaseFirestore.DocumentData): BookingMirrorLink {
-  return {
-    id: data.id,
-    ownerUid: data.ownerUid,
-    title: data.title,
-    description: data.description ?? undefined,
-    sourceUrl: data.sourceUrl,
-    scheduleId: data.scheduleId,
-    notificationEmail: data.notificationEmail,
-    rangeDays: data.rangeDays,
-    status: data.status,
-    expiresAt: data.expiresAt?.toDate?.() ?? null,
-    createdAt: data.createdAt?.toDate?.() ?? new Date(),
-    updatedAt: data.updatedAt?.toDate?.() ?? new Date(),
-  };
-}
 
 function buildPatchUpdate(body: UpdateBookingMirrorLinkInput): Record<string, unknown> {
   const update: Record<string, unknown> = {};
@@ -70,7 +54,7 @@ bookingMirrorLinkRoutes.get('/', requireAuth, async (c) => {
     .where('ownerUid', '==', user.uid)
     .orderBy('createdAt', 'desc')
     .get();
-  const links = snap.docs.map((d) => fromFirestoreData(d.data()));
+  const links = snap.docs.map((d) => buildBookingMirrorLinkFromFirestoreData(d.data()));
   return c.json({ links });
 });
 
@@ -154,7 +138,7 @@ bookingMirrorLinkRoutes.get('/:linkId', requireAuth, async (c) => {
   if (data.ownerUid !== user.uid) {
     return c.json({ error: 'Forbidden' }, 403);
   }
-  return c.json({ link: fromFirestoreData(data) });
+  return c.json({ link: buildBookingMirrorLinkFromFirestoreData(data) });
 });
 
 // 更新
@@ -197,7 +181,7 @@ bookingMirrorLinkRoutes.patch('/:linkId', requireAuth, async (c) => {
   await ref.update(update);
 
   const updated = await ref.get();
-  return c.json({ link: fromFirestoreData(updated.data()!) });
+  return c.json({ link: buildBookingMirrorLinkFromFirestoreData(updated.data()!) });
 });
 
 // 削除

--- a/apps/api/src/routes/public-booking-mirror.ts
+++ b/apps/api/src/routes/public-booking-mirror.ts
@@ -18,6 +18,11 @@ import {
 } from '../lib/google-booking-mirror.js';
 import { assertE2EMockSafe } from '../lib/e2e-guard.js';
 import { pickOwnerDisplayName } from '../lib/owner-display-name.js';
+import {
+  buildBookingMirrorLinkFromFirestoreData,
+  excludeOverlappingSlots,
+} from '../lib/booking-mirror-link-utils.js';
+import { getConfirmedBookingEventsForOwner } from '../lib/booking-events.js';
 import type {
   BookingMirrorLink,
   BookingMirrorSlot,
@@ -38,20 +43,7 @@ async function getActiveLink(linkId: string): Promise<LinkResult> {
     return { link: null, error: 'Booking mirror link not found', statusCode: 404 };
   }
   const data = doc.data()!;
-  const link: BookingMirrorLink = {
-    id: data.id,
-    ownerUid: data.ownerUid,
-    title: data.title,
-    description: data.description ?? undefined,
-    sourceUrl: data.sourceUrl,
-    scheduleId: data.scheduleId,
-    notificationEmail: data.notificationEmail,
-    rangeDays: data.rangeDays,
-    status: data.status,
-    expiresAt: data.expiresAt?.toDate?.() ?? null,
-    createdAt: data.createdAt?.toDate?.() ?? new Date(),
-    updatedAt: data.updatedAt?.toDate?.() ?? new Date(),
-  };
+  const link = buildBookingMirrorLinkFromFirestoreData(data);
   if (link.status !== 'active') {
     return { link: null, error: 'This booking link is currently paused', statusCode: 400 };
   }
@@ -144,7 +136,13 @@ publicBookingMirrorRoutes.get('/:linkId/slots', async (c) => {
     throw err;
   }
 
-  const slots = toMirrorSlots(googleSlots);
+  // Calendar Hub 側で既に確定済みの予約 (mirror/非mirror問わず同一オーナー) を除外する。
+  // Google 側はこの予約を認識しないため、ここで差し引かないと同じ枠がミラーページ上に
+  // 空きとして表示され続け、次のゲストが予約しようとすると 409 になる。
+  const bookedEvents = await getConfirmedBookingEventsForOwner(link.ownerUid, now, endDate);
+  const availableSlots = excludeOverlappingSlots(googleSlots, bookedEvents);
+
+  const slots = toMirrorSlots(availableSlots);
   return c.json({ slots, title: link.title });
 });
 

--- a/apps/api/src/routes/public-booking-mirror.ts
+++ b/apps/api/src/routes/public-booking-mirror.ts
@@ -18,10 +18,8 @@ import {
 } from '../lib/google-booking-mirror.js';
 import { assertE2EMockSafe } from '../lib/e2e-guard.js';
 import { pickOwnerDisplayName } from '../lib/owner-display-name.js';
-import {
-  buildBookingMirrorLinkFromFirestoreData,
-  excludeOverlappingSlots,
-} from '../lib/booking-mirror-link-utils.js';
+import { buildBookingMirrorLinkFromFirestoreData } from '../lib/booking-mirror-link-utils.js';
+import { excludeOverlappingSlots } from '../lib/booking-mirror-slots.js';
 import { getConfirmedBookingEventsForOwner } from '../lib/booking-events.js';
 import type {
   BookingMirrorLink,
@@ -120,10 +118,19 @@ publicBookingMirrorRoutes.get('/:linkId/slots', async (c) => {
     return c.json({ error: 'Failed to resolve schedule id', slots: [] }, 502);
   }
 
-  let googleSlots: GoogleSlot[];
-  try {
-    googleSlots = await fetchAvailableSlots(scheduleId, startUnix, endUnix);
-  } catch (err) {
+  // fetchAvailableSlots (Google gRPC, 最大8s) と getConfirmedBookingEventsForOwner
+  // (Firestore) は互いに独立しているため並列実行する。
+  // 後者は Calendar Hub 側で既に確定済みの予約 (mirror/非mirror問わず同一オーナー) を
+  // 除外するために使う。Google 側はこの予約を認識しないため、ここで差し引かないと
+  // 同じ枠がミラーページ上に空きとして表示され続け、次のゲストが予約しようとすると
+  // 409 になる。
+  const [slotsResult, bookedResult] = await Promise.allSettled([
+    fetchAvailableSlots(scheduleId, startUnix, endUnix),
+    getConfirmedBookingEventsForOwner(link.ownerUid, now, endDate),
+  ]);
+
+  if (slotsResult.status === 'rejected') {
+    const err = slotsResult.reason;
     if (err instanceof BookingMirrorError) {
       console.error(
         `[booking-mirror] fetchAvailableSlots ${err.kind}/${err.subKind} for link ${link.id}: ${err.message}`,
@@ -136,12 +143,15 @@ publicBookingMirrorRoutes.get('/:linkId/slots', async (c) => {
     throw err;
   }
 
-  // Calendar Hub 側で既に確定済みの予約 (mirror/非mirror問わず同一オーナー) を除外する。
-  // Google 側はこの予約を認識しないため、ここで差し引かないと同じ枠がミラーページ上に
-  // 空きとして表示され続け、次のゲストが予約しようとすると 409 になる。
-  const bookedEvents = await getConfirmedBookingEventsForOwner(link.ownerUid, now, endDate);
-  const availableSlots = excludeOverlappingSlots(googleSlots, bookedEvents);
+  if (bookedResult.status === 'rejected') {
+    console.error(
+      `[booking-mirror] getConfirmedBookingEventsForOwner failed for link ${link.id}:`,
+      bookedResult.reason,
+    );
+    return c.json({ error: 'Failed to check existing bookings', slots: [] }, 502);
+  }
 
+  const availableSlots = excludeOverlappingSlots(slotsResult.value, bookedResult.value);
   const slots = toMirrorSlots(availableSlots);
   return c.json({ slots, title: link.title });
 });

--- a/apps/api/src/routes/public-booking.ts
+++ b/apps/api/src/routes/public-booking.ts
@@ -26,6 +26,7 @@ import {
 } from '../lib/booking-link-utils.js';
 import { assertE2EMockSafe } from '../lib/e2e-guard.js';
 import { pickOwnerDisplayName } from '../lib/owner-display-name.js';
+import { getConfirmedBookingEventsForOwner } from '../lib/booking-events.js';
 
 export const publicBookingRoutes = new Hono();
 
@@ -89,37 +90,6 @@ async function fetchOwnerEvents(
   });
 
   return results.filter((r) => r.status === 'fulfilled').flatMap((r) => r.value);
-}
-
-// 既存予約をダミーイベントとしてマージ（全オーナー予約を考慮し二重予約を防止）
-async function getConfirmedBookingEventsForOwner(
-  ownerUid: string,
-  timeMin: Date,
-  timeMax: Date,
-): Promise<CalendarEvent[]> {
-  const db = getDb();
-  const snap = await db
-    .collection('bookings')
-    .where('ownerUid', '==', ownerUid)
-    .where('status', '==', 'confirmed')
-    .where('slotStart', '>=', timeMin)
-    .where('slotStart', '<=', timeMax)
-    .get();
-
-  return snap.docs.map((doc) => {
-    const data = doc.data();
-    return {
-      id: doc.id,
-      source: 'google' as const, // CalendarEvent型に合わせるためのダミー値
-      originalId: doc.id,
-      calendarId: 'booking',
-      title: 'Reserved',
-      start: data.slotStart.toDate(),
-      end: data.slotEnd.toDate(),
-      isAllDay: false,
-      status: 'confirmed' as const,
-    };
-  });
 }
 
 // --- ルート ---


### PR DESCRIPTION
## Summary
- mirror の `GET /:linkId/slots` が Google の gRPC-web レスポンスをそのまま返し、Calendar Hub 経由で確定済みの予約を差し引いていなかった不整合を修正。非ミラー版 `public-booking.ts` は `getConfirmedBookingEventsForOwner` で既に対応済みだったが mirror 側には未移植だった
- `getConfirmedBookingEventsForOwner` を `apps/api/src/lib/booking-events.ts` に抽出し、非ミラー版・ミラー版の双方から再利用
- `BookingMirrorLink` の Firestore mapper が2箇所（`booking-mirror-links.ts` / `public-booking-mirror.ts`）に手書きで重複していたため `buildBookingMirrorLinkFromFirestoreData` に一本化（片方だけへのフィールド追加がサイレント障害を生む構造だったため）

booking-mirror C1 拡張（block event 自動作成）の設計調査中に見つかった、OAuth 連携なしで独立に直せる欠陥として先行対応するもの。

## Test plan
- [x] `pnpm test` — 全 258 件 PASS（新規 unit test 12 件を含む: mapper の Timestamp 変換・default 補完、`excludeOverlappingSlots` の境界値（完全一致/部分重複/隣接非重複/複数slot/複数予約））
- [x] `pnpm lint` — 全パッケージ PASS
- [x] `pnpm turbo type-check` — 全パッケージ PASS
- [x] `pnpm turbo build` — 全パッケージ PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Booking mirror availability now excludes time slots that overlap with confirmed bookings.
  * Confirmed reservations are consistently reflected across booking and calendar availability views.
  * Adjacent time slots remain available when they do not overlap an existing reservation.

* **Bug Fixes**
  * Improved consistency when displaying booking mirror links and their date information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->