### PR TITLE
fix(free-time): 終日予定を空き時間計算でbusy扱いにする

### DIFF
--- a/packages/shared/src/__tests__/free-time.test.ts
+++ b/packages/shared/src/__tests__/free-time.test.ts
@@ -65,11 +65,36 @@ describe('calculateFreeSlots', () => {
     expect(slots[1].start.getHours()).toBe(12);
   });
 
-  it('should skip all-day events', () => {
+  it('should treat all-day events as busy for the entire day (Issue #194: 終日予定を空き扱いすると二重予約になる)', () => {
     const events = [makeEvent('2026-03-21T00:00:00', '2026-03-22T00:00:00', { isAllDay: true })];
     const slots = calculateFreeSlots(events, dayStart, dayEnd);
-    expect(slots).toHaveLength(1); // All-day events are filtered out
+    expect(slots).toHaveLength(0);
+  });
+
+  it('should block only the days actually covered by a multi-day all-day event', () => {
+    const rangeEnd = new Date('2026-03-24T00:00:00'); // 21, 22, 23日の3日分
+    // Google Calendar の all-day event 仕様: end.date は exclusive なので
+    // 21日〜22日の2日間の終日予定は end が23日になる
+    const events = [makeEvent('2026-03-21T00:00:00', '2026-03-23T00:00:00', { isAllDay: true })];
+    const slots = calculateFreeSlots(events, dayStart, rangeEnd);
+    // 21日・22日はブロックされ、23日のみ終日空き
+    expect(slots).toHaveLength(1);
+    expect(slots[0].start.getDate()).toBe(23);
     expect(slots[0].durationMinutes).toBe(14 * 60);
+  });
+
+  it('should combine all-day event blocking with timed events on other days', () => {
+    const rangeEnd = new Date('2026-03-23T00:00:00'); // 21, 22日の2日分
+    const events = [
+      makeEvent('2026-03-21T00:00:00', '2026-03-22T00:00:00', { isAllDay: true }), // 21日を終日ブロック
+      makeEvent('2026-03-22T10:00:00', '2026-03-22T11:00:00'), // 22日の通常予定
+    ];
+    const slots = calculateFreeSlots(events, dayStart, rangeEnd);
+    // 21日は0件、22日は 8-10, 11-22 の2件
+    expect(slots).toHaveLength(2);
+    expect(slots[0].start.getDate()).toBe(22);
+    expect(slots[0].end.getHours()).toBe(10);
+    expect(slots[1].start.getHours()).toBe(11);
   });
 
   it('should respect custom dayStartHour and dayEndHour', () => {

--- a/packages/shared/src/free-time.ts
+++ b/packages/shared/src/free-time.ts
@@ -68,9 +68,9 @@ export function calculateFreeSlots(
   const { dayStartHour = 8, dayEndHour = 22, minSlotMinutes = 30, timezoneOffsetMinutes } = options;
 
   const slots: FreeSlot[] = [];
-  const sortedEvents = [...events]
-    .filter((e) => !e.isAllDay)
-    .sort((a, b) => a.start.getTime() - b.start.getTime());
+  // 終日予定 (休暇・出張等) も busy として扱う。除外すると、その日が丸ごと
+  // 「空き」と判定され二重予約を招くため (Issue #194)。
+  const sortedEvents = [...events].sort((a, b) => a.start.getTime() - b.start.getTime());
 
   // 日ごとに計算
   let current = startOfDayUTC(rangeStart, timezoneOffsetMinutes);


### PR DESCRIPTION
## Summary
- `calculateFreeSlots` が `isAllDay` の予定を busy 判定から完全に除外しており、休暇・出張等の終日予定があってもその日が丸ごと「空き」として計算され、二重予約が起こりうる実バグを修正 (Codex review で発見・検証)
- `isAllDay` フィルタを削除し、既存の日次クリッピングロジックをそのまま適用。単日・複数日にまたがる終日予定の両方を正しくブロックする
- 影響範囲: booking-links / booking-mirror-links の空き枠計算、AI提案(ai.ts)の全呼び出し元

Closes #194

## Test plan
- [x] `pnpm test` — 全267件PASS (新規テスト3件: 終日予定の単日ブロック、複数日にまたがる終日予定、終日予定+通常予定の混在)
- [x] `pnpm lint` — 全パッケージPASS
- [x] `pnpm turbo type-check` — 全パッケージPASS
- [x] `pnpm turbo build` — 全パッケージPASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * All-day events are now correctly treated as busy time when calculating availability.
  * Multi-day all-day events block only the dates they cover, respecting exclusive end dates.
  * All-day and timed events now combine correctly across multi-day availability ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->