### PR TITLE
fix(booking): 予約直前に外部カレンダーとの重複を再検証する

### DIFF
--- a/apps/api/src/__tests__/booking-events.test.ts
+++ b/apps/api/src/__tests__/booking-events.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { toOverlappingBookingEvents } from '../lib/booking-events.js';
+import { toOverlappingBookingEvents, hasOverlappingEvent } from '../lib/booking-events.js';
 
 // Firestore Timestamp のダミー実装 (toDate() のみ持てば十分)
 function fakeTimestamp(date: Date) {
@@ -92,5 +92,51 @@ describe('toOverlappingBookingEvents', () => {
       isAllDay: false,
       status: 'confirmed',
     });
+  });
+});
+
+describe('hasOverlappingEvent', () => {
+  const slotStart = new Date('2026-08-01T10:00:00Z');
+  const slotEnd = new Date('2026-08-01T11:00:00Z');
+
+  it('slotと完全に一致する外部イベントは重複とみなす', () => {
+    const events = [{ start: slotStart, end: slotEnd }];
+    expect(hasOverlappingEvent(events, slotStart, slotEnd)).toBe(true);
+  });
+
+  it('slotの一部と重なる外部イベントは重複とみなす', () => {
+    const events = [
+      { start: new Date('2026-08-01T10:30:00Z'), end: new Date('2026-08-01T12:00:00Z') },
+    ];
+    expect(hasOverlappingEvent(events, slotStart, slotEnd)).toBe(true);
+  });
+
+  it('slot終了時刻ちょうどに始まる隣接イベントは重複とみなさない', () => {
+    const events = [{ start: slotEnd, end: new Date('2026-08-01T12:00:00Z') }];
+    expect(hasOverlappingEvent(events, slotStart, slotEnd)).toBe(false);
+  });
+
+  it('slot開始時刻ちょうどに終わる隣接イベントは重複とみなさない', () => {
+    const events = [{ start: new Date('2026-08-01T09:00:00Z'), end: slotStart }];
+    expect(hasOverlappingEvent(events, slotStart, slotEnd)).toBe(false);
+  });
+
+  it('slotと無関係な時間帯の外部イベントは重複とみなさない', () => {
+    const events = [
+      { start: new Date('2026-08-01T13:00:00Z'), end: new Date('2026-08-01T14:00:00Z') },
+    ];
+    expect(hasOverlappingEvent(events, slotStart, slotEnd)).toBe(false);
+  });
+
+  it('外部イベントが空配列の場合は重複なし', () => {
+    expect(hasOverlappingEvent([], slotStart, slotEnd)).toBe(false);
+  });
+
+  it('複数イベント中1件でも重複すればtrueを返す', () => {
+    const events = [
+      { start: new Date('2026-08-01T13:00:00Z'), end: new Date('2026-08-01T14:00:00Z') },
+      { start: new Date('2026-08-01T10:15:00Z'), end: new Date('2026-08-01T10:45:00Z') },
+    ];
+    expect(hasOverlappingEvent(events, slotStart, slotEnd)).toBe(true);
   });
 });

--- a/apps/api/src/lib/booking-events.ts
+++ b/apps/api/src/lib/booking-events.ts
@@ -38,6 +38,21 @@ export function toOverlappingBookingEvents(docs: RawBookingDoc[], timeMin: Date)
 }
 
 /**
+ * 予約確定直前に再取得した外部カレンダーイベントが、選択された slot と重なるかを判定する。
+ *
+ * 重なり判定は `start < slotEnd && end > slotStart` (区間の共通部分が存在するか)。
+ * 境界がちょうど接するだけ (隣接) は重複として扱わない。mirror側の
+ * `excludeOverlappingSlots` と同一ロジック。
+ */
+export function hasOverlappingEvent(
+  events: { start: Date; end: Date }[],
+  slotStart: Date,
+  slotEnd: Date,
+): boolean {
+  return events.some((event) => event.start < slotEnd && event.end > slotStart);
+}
+
+/**
  * 指定オーナーの確定済み予約 (`bookings` collection, status='confirmed') を
  * ダミーイベントとしてマージするための変換。
  *

--- a/apps/api/src/routes/public-booking.ts
+++ b/apps/api/src/routes/public-booking.ts
@@ -26,7 +26,7 @@ import {
 } from '../lib/booking-link-utils.js';
 import { assertE2EMockSafe } from '../lib/e2e-guard.js';
 import { pickOwnerDisplayName } from '../lib/owner-display-name.js';
-import { getConfirmedBookingEventsForOwner } from '../lib/booking-events.js';
+import { getConfirmedBookingEventsForOwner, hasOverlappingEvent } from '../lib/booking-events.js';
 
 export const publicBookingRoutes = new Hono();
 
@@ -232,6 +232,19 @@ publicBookingRoutes.post('/:linkId/book', async (c) => {
     !link.availableDays.includes(slotDay)
   ) {
     return c.json({ error: 'Slot is outside available hours/days' }, 400);
+  }
+
+  // 予約直前に外部カレンダー (Google/TimeTree) を再取得し、選択 slot が依然空きであることを
+  // 確認する (mirror側の fetchAvailableSlots 再検証と同様のパターン。Codex review P1, Issue #195)
+  const externalEvents = await fetchOwnerEvents(
+    link.ownerUid,
+    link.accountIds,
+    link.calendarIdsForAvailability,
+    slotStart,
+    slotEnd,
+  );
+  if (hasOverlappingEvent(externalEvents, slotStart, slotEnd)) {
+    return c.json({ error: 'This time slot is no longer available' }, 409);
   }
 
   const db = getDb();

--- a/apps/api/src/routes/public-booking.ts
+++ b/apps/api/src/routes/public-booking.ts
@@ -64,12 +64,20 @@ async function getOwnerDisplayName(ownerUid: string): Promise<string> {
   return pickOwnerDisplayName(doc.data());
 }
 
+/**
+ * `options.failClosed` が true の場合、いずれかのアカウントの取得が失敗したら
+ * (握りつぶさず) 例外を投げる。`/slots` の表示用途はベストエフォート (fail-open)
+ * で問題ないが、予約確定直前の安全装置として使う場合、取得失敗を「空き」と
+ * 誤判定すると二重予約防止という目的そのものが無効化されるため fail-closed にする
+ * (mirror側の fetchAvailableSlots 失敗時 502 と同じ考え方)。
+ */
 async function fetchOwnerEvents(
   ownerUid: string,
   accountIds: string[],
   calendarIdsFilter: string[] | null,
   timeMin: Date,
   timeMax: Date,
+  options: { failClosed?: boolean } = {},
 ): Promise<CalendarEvent[]> {
   const results = await Promise.allSettled(
     accountIds.map(async (accountId) => {
@@ -83,11 +91,17 @@ async function fetchOwnerEvents(
     }),
   );
 
+  let hasFailure = false;
   results.forEach((r, i) => {
     if (r.status === 'rejected') {
+      hasFailure = true;
       console.error(`Booking: calendar fetch failed for account ${accountIds[i]}:`, r.reason);
     }
   });
+
+  if (options.failClosed && hasFailure) {
+    throw new Error('EXTERNAL_CALENDAR_FETCH_FAILED');
+  }
 
   return results.filter((r) => r.status === 'fulfilled').flatMap((r) => r.value);
 }
@@ -236,13 +250,19 @@ publicBookingRoutes.post('/:linkId/book', async (c) => {
 
   // 予約直前に外部カレンダー (Google/TimeTree) を再取得し、選択 slot が依然空きであることを
   // 確認する (mirror側の fetchAvailableSlots 再検証と同様のパターン。Codex review P1, Issue #195)
-  const externalEvents = await fetchOwnerEvents(
-    link.ownerUid,
-    link.accountIds,
-    link.calendarIdsForAvailability,
-    slotStart,
-    slotEnd,
-  );
+  let externalEvents: CalendarEvent[];
+  try {
+    externalEvents = await fetchOwnerEvents(
+      link.ownerUid,
+      link.accountIds,
+      link.calendarIdsForAvailability,
+      slotStart,
+      slotEnd,
+      { failClosed: true },
+    );
+  } catch {
+    return c.json({ error: 'Failed to verify slot availability, please try again' }, 502);
+  }
   if (hasOverlappingEvent(externalEvents, slotStart, slotEnd)) {
     return c.json({ error: 'This time slot is no longer available' }, 409);
   }


### PR DESCRIPTION
## Summary
- `POST /:linkId/book` (非mirror版) は営業時間・自前DB(`bookings`)の重複しか検証しておらず、`GET /:linkId/slots` 表示後に外部カレンダー(Google/TimeTree)側で埋まった枠や、そもそも表示されない枠への直接POSTが素通りしていた
- mirror版 (`public-booking-mirror.ts`) には既にある「予約直前の再検証」ステップと同型のロジックを非mirror版にも移植
- 重複判定ロジックは `hasOverlappingEvent` として `booking-events.ts` に切り出し、unit testで境界値(完全一致/部分重複/隣接非重複/前後非重複/複数件)を検証
- `/code-review medium main...HEAD` の指摘を受け追加修正: `fetchOwnerEvents` は元々 `/slots` 表示用のfail-open設計 (アカウント単位の取得失敗を握りつぶして続行) だったが、予約確定の安全装置としてそのまま転用すると取得失敗時に「空き」と誤判定し二重予約防止という目的自体が無効化されるバグがあった。`failClosed` オプションを追加し、予約確定パスのみ取得失敗時に502を返す (mirror側の `fetchAvailableSlots` 失敗時502と同じfail-closedパターンに統一)

Codex (`/codex review`, 全コードベースレビュー, 2026-07-26) で指摘、コードを直接確認して実害を検証済みのIssue。

## Test plan
- [x] `pnpm test` — 274件PASS（新規7件を含む: `hasOverlappingEvent`の境界値テスト）
- [x] `pnpm lint` — 全パッケージPASS
- [x] `pnpm turbo type-check` — 全パッケージPASS
- [x] `pnpm turbo build` — 全パッケージPASS
- [x] `/code-review medium main...HEAD` 実行、fail-open指摘を修正・再検証済み

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)