### PR TITLE
fix(free-time): 当日の空き枠計算がrangeStart以前の過去時間帯を含んでしまう不具合を修正

### DIFF
--- a/packages/shared/src/__tests__/free-time.test.ts
+++ b/packages/shared/src/__tests__/free-time.test.ts
@@ -119,4 +119,56 @@ describe('calculateFreeSlots', () => {
     expect(slots).toHaveLength(1);
     expect(slots[0].durationMinutes).toBe(12 * 60); // 8:00-20:00
   });
+
+  describe('rangeStart が当日の途中の場合 (Issue #198: 過去枠の除外)', () => {
+    it('should start the first day free slot from rangeStart, not dayStartHour, when rangeStart is later in the day', () => {
+      const rangeStart = new Date('2026-03-21T14:00:00'); // dayStartHour(8時)より後
+      const slots = calculateFreeSlots([], rangeStart, dayEnd);
+      expect(slots).toHaveLength(1);
+      expect(slots[0].start.getHours()).toBe(14);
+      expect(slots[0].end.getHours()).toBe(22);
+      expect(slots[0].durationMinutes).toBe(8 * 60);
+    });
+
+    it('should not shift cursor when rangeStart is exactly at dayStartHour (boundary, not "later")', () => {
+      const rangeStart = new Date('2026-03-21T08:00:00');
+      const slots = calculateFreeSlots([], rangeStart, dayEnd);
+      expect(slots).toHaveLength(1);
+      expect(slots[0].start.getHours()).toBe(8);
+      expect(slots[0].durationMinutes).toBe(14 * 60);
+    });
+
+    it('should produce no slots for the first day when rangeStart is after dayEndHour', () => {
+      const rangeStart = new Date('2026-03-21T23:00:00'); // dayEndHour(22時)より後
+      const rangeEnd = new Date('2026-03-23T00:00:00'); // 21, 22日の2日分
+      const slots = calculateFreeSlots([], rangeStart, rangeEnd);
+      // 21日は0件(rangeStartがdayEndを過ぎている)、22日は通常通り8-22
+      expect(slots).toHaveLength(1);
+      expect(slots[0].start.getDate()).toBe(22);
+      expect(slots[0].durationMinutes).toBe(14 * 60);
+    });
+
+    it('should only affect the first day, leaving subsequent days at the normal dayStartHour', () => {
+      const rangeStart = new Date('2026-03-21T14:00:00');
+      const rangeEnd = new Date('2026-03-23T00:00:00'); // 21, 22日の2日分
+      const slots = calculateFreeSlots([], rangeStart, rangeEnd);
+      expect(slots).toHaveLength(2);
+      // 21日: 14:00-22:00 (過去枠を除外)
+      expect(slots[0].start.getDate()).toBe(21);
+      expect(slots[0].start.getHours()).toBe(14);
+      // 22日: 8:00-22:00 (通常通り)
+      expect(slots[1].start.getDate()).toBe(22);
+      expect(slots[1].start.getHours()).toBe(8);
+    });
+
+    it('should still exclude a busy event even when it starts before rangeStart (in-progress event)', () => {
+      const rangeStart = new Date('2026-03-21T14:00:00');
+      const events = [makeEvent('2026-03-21T13:00:00', '2026-03-21T15:00:00')]; // rangeStart時点で進行中
+      const slots = calculateFreeSlots(events, rangeStart, dayEnd);
+      // 14:00時点でまだイベント中 → cursorはevent.endの15:00まで進む、15:00-22:00のみ空き
+      expect(slots).toHaveLength(1);
+      expect(slots[0].start.getHours()).toBe(15);
+      expect(slots[0].end.getHours()).toBe(22);
+    });
+  });
 });

--- a/packages/shared/src/free-time.ts
+++ b/packages/shared/src/free-time.ts
@@ -84,8 +84,10 @@ export function calculateFreeSlots(
       return e.start < dayEnd && e.end > dayStart;
     });
 
-    // イベント間の空きを計算
-    let cursor = dayStart;
+    // イベント間の空きを計算。cursor は dayStart と rangeStart の遅い方から始める
+    // (当日分は rangeStart 以前の、既に過ぎた時間帯を空き枠として出さないため。Issue #198)。
+    // rangeStart は日をまたいでも不変なので、2日目以降は自然に dayStart が優先される。
+    let cursor = dayStart < rangeStart ? rangeStart : dayStart;
     for (const event of dayEvents) {
       const eventStart = event.start < dayStart ? dayStart : event.start;
       const eventEnd = event.end > dayEnd ? dayEnd : event.end;


### PR DESCRIPTION
## Summary
- `calculateFreeSlots` は各日のcursorを常に `dayStartHour` から開始しており、呼び出し元が渡す `rangeStart` (通常は現在時刻) が当日の途中でも無視していた
- `GET /:linkId/slots` を当日午後に開くと、午前中の(既に過ぎた)時間帯の枠も一覧に含まれて表示される劣化したUXになっていた(`POST /:linkId/book` 側に `slotStart < now` の弾きがあるため実際の二重予約には至らない)
- 初日のcursorを `max(dayStart, rangeStart)` にする。`rangeStart` は日をまたいでも不変な値のため、2日目以降は自然に `dayStart` が優先され従来動作を維持する

Codex (`/codex review`, 全コードベースレビュー, 2026-07-26) で指摘、コードを直接確認して実害を検証済みのIssue。

## Test plan
- [x] `pnpm test` — 279件PASS（新規5件を含む: rangeStartが当日途中/境界(=dayStartHour)/dayEndHour超過/複数日/進行中イベントとの組み合わせ）
- [x] `pnpm lint` — 全パッケージPASS
- [x] `pnpm turbo type-check` — 全パッケージPASS
- [x] `pnpm turbo build` — 全パッケージPASS

2ファイル・56行の変更のためCLAUDE.mdの `/code-review` 依頼閾値(3ファイル以上または100行以上)未満、スキップ

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Free-time calculations now exclude time slots that have already passed on the first day of a requested range.
  * Events already in progress at the range start continue to block availability until they end.
  * Subsequent days retain their normal availability hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->