### PR TITLE
fix(booking): 予約重複チェックのFirestoreクエリにslotStart下限を追加

### DIFF
--- a/apps/api/src/lib/booking-events.ts
+++ b/apps/api/src/lib/booking-events.ts
@@ -7,8 +7,11 @@ import type { CalendarEvent } from '@calendar-hub/shared';
  * 巻き戻し幅。個人運用規模の予約枠として現実的にありえない長さ (24時間) を
  * 十分に超える値を取り、真の重複判定は `toOverlappingBookingEvents` の
  * `end > timeMin` フィルタで行う。
+ *
+ * `public-booking.ts` / `public-booking-mirror.ts` の POST `/:linkId/book` に
+ * ある予約確定直前の overlap query (Issue #197) でも同じ下限として再利用する。
  */
-const OVERLAP_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+export const OVERLAP_LOOKBACK_MS = 24 * 60 * 60 * 1000;
 
 interface RawBookingDoc {
   id: string;

--- a/apps/api/src/routes/public-booking-mirror.ts
+++ b/apps/api/src/routes/public-booking-mirror.ts
@@ -20,7 +20,7 @@ import { assertE2EMockSafe } from '../lib/e2e-guard.js';
 import { pickOwnerDisplayName } from '../lib/owner-display-name.js';
 import { buildBookingMirrorLinkFromFirestoreData } from '../lib/booking-mirror-link-utils.js';
 import { excludeOverlappingSlots } from '../lib/booking-mirror-slots.js';
-import { getConfirmedBookingEventsForOwner } from '../lib/booking-events.js';
+import { getConfirmedBookingEventsForOwner, OVERLAP_LOOKBACK_MS } from '../lib/booking-events.js';
 import type {
   BookingMirrorLink,
   BookingMirrorSlot,
@@ -233,10 +233,14 @@ publicBookingMirrorRoutes.post('/:linkId/book', async (c) => {
   const bookingId = nanoid(12);
 
   try {
+    // slotStart に下限を付けず全期間をスキャンすると、予約件数の増加に比例して
+    // 読み取り件数・レイテンシが線形に悪化する (Issue #197、非mirror版と同一パターン)。
+    const overlapQueryLowerBound = new Date(slotStart.getTime() - OVERLAP_LOOKBACK_MS);
     const overlapQuery = db
       .collection('bookings')
       .where('ownerUid', '==', link.ownerUid)
       .where('status', '==', 'confirmed')
+      .where('slotStart', '>=', overlapQueryLowerBound)
       .where('slotStart', '<', slotEnd);
 
     await db.runTransaction(async (tx) => {

--- a/apps/api/src/routes/public-booking.ts
+++ b/apps/api/src/routes/public-booking.ts
@@ -26,7 +26,11 @@ import {
 } from '../lib/booking-link-utils.js';
 import { assertE2EMockSafe } from '../lib/e2e-guard.js';
 import { pickOwnerDisplayName } from '../lib/owner-display-name.js';
-import { getConfirmedBookingEventsForOwner, hasOverlappingEvent } from '../lib/booking-events.js';
+import {
+  getConfirmedBookingEventsForOwner,
+  hasOverlappingEvent,
+  OVERLAP_LOOKBACK_MS,
+} from '../lib/booking-events.js';
 
 export const publicBookingRoutes = new Hono();
 
@@ -271,10 +275,16 @@ publicBookingRoutes.post('/:linkId/book', async (c) => {
   const bookingId = nanoid(12);
 
   try {
+    // slotStart に下限を付けず全期間をスキャンすると、予約件数の増加に比例して
+    // 読み取り件数・レイテンシが線形に悪化する (Issue #197)。実在しうる最長の
+    // 予約時間を十分に超える 24h バックストップを設け、真の重複判定は下の
+    // `existingEnd > slotStart` フィルタで行う (getConfirmedBookingEventsForOwner と同じ考え方)。
+    const overlapQueryLowerBound = new Date(slotStart.getTime() - OVERLAP_LOOKBACK_MS);
     const overlapQuery = db
       .collection('bookings')
       .where('ownerUid', '==', link.ownerUid)
       .where('status', '==', 'confirmed')
+      .where('slotStart', '>=', overlapQueryLowerBound)
       .where('slotStart', '<', slotEnd);
 
     await db.runTransaction(async (tx) => {


### PR DESCRIPTION
## Summary
- `POST /:linkId/book` (非mirror版・mirror版とも) の予約重複チェック用 overlap query が `slotStart` に下限を持たず、当該オーナーの全期間(過去分含む)の確定予約を毎回全件読み取っていた
- 予約件数が増えるほど、予約1件あたりのFirestore読み取り件数・レイテンシ・トランザクション失敗リスクが線形に増加する
- PR #193 (`getConfirmedBookingEventsForOwner`) で導入済みの24hバックストップと同じ考え方を `OVERLAP_LOOKBACK_MS` としてexportし、非mirror版・mirror版の両方のoverlap queryに再利用
- 安全性の確認: `DURATION_OPTIONS`(booking-linksの選択可能な予約時間)の最大値は120分で、24hバックストップに対して十分小さいため、真に重複するはずの予約を取りこぼす心配はない

Codex (`/codex review`, 全コードベースレビュー, 2026-07-26) で指摘、コードを直接確認して実害を検証済みのIssue。mirror側も横断確認し同様の修正が必要と判断し対応。

## Test plan
- [x] `pnpm test` — 279件PASS（既存件数を維持、回帰なし）
- [x] `pnpm lint` — 全パッケージPASS
- [x] `pnpm turbo type-check` — 全パッケージPASS
- [x] `pnpm turbo build` — 全パッケージPASS

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)