### PR TITLE
fix(sync): syncConfigの同期実行をリースで排他制御し二重処理を防ぐ

### DIFF
--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -3,6 +3,8 @@ import {
   buildSyncActions,
   executeSyncActions,
   computeSyncGap,
+  shouldAcquireSyncLease,
+  SYNC_LEASE_STALE_MS,
 } from '../lib/timetree-google-sync.js';
 import type { CalendarEvent } from '@calendar-hub/shared';
 import type { CalendarAdapter } from '@calendar-hub/calendar-sdk';
@@ -624,6 +626,90 @@ describe('Sync Logic', () => {
       const minus1 = computeSyncGap({ ttCount: 9, taggedBefore: 10, created: 0, deleted: 0 });
       expect(minus1.hasGap).toBe(true);
       expect(minus1.diff).toBe(-1);
+    });
+  });
+
+  describe('shouldAcquireSyncLease - リース取得可否判定 (Issue #196: 二重処理防止)', () => {
+    const now = new Date('2026-08-01T12:00:00Z').getTime();
+
+    it('初回同期 (lastSyncedAt未設定) かつリースなしなら取得できる', () => {
+      const acquired = shouldAcquireSyncLease({
+        lastSyncedAtMs: undefined,
+        syncIntervalMinutes: 5,
+        syncLeaseAtMs: undefined,
+        nowMs: now,
+      });
+      expect(acquired).toBe(true);
+    });
+
+    it('インターバル未経過なら取得できない', () => {
+      const acquired = shouldAcquireSyncLease({
+        lastSyncedAtMs: now - 4 * 60_000, // 4分前 (5分インターバル未経過)
+        syncIntervalMinutes: 5,
+        syncLeaseAtMs: undefined,
+        nowMs: now,
+      });
+      expect(acquired).toBe(false);
+    });
+
+    it('インターバルがちょうど経過した境界では取得できる', () => {
+      const acquired = shouldAcquireSyncLease({
+        lastSyncedAtMs: now - 5 * 60_000, // ちょうど5分前
+        syncIntervalMinutes: 5,
+        syncLeaseAtMs: undefined,
+        nowMs: now,
+      });
+      expect(acquired).toBe(true);
+    });
+
+    it('有効なリースが存在する場合は取得できない (他の実行が処理中)', () => {
+      const acquired = shouldAcquireSyncLease({
+        lastSyncedAtMs: now - 10 * 60_000,
+        syncIntervalMinutes: 5,
+        syncLeaseAtMs: now - 1 * 60_000, // 1分前に取得されたリース (10分の失効猶予内)
+        nowMs: now,
+      });
+      expect(acquired).toBe(false);
+    });
+
+    it('リースが失効済み (SYNC_LEASE_STALE_MSを超過) なら取得できる (クラッシュ復旧)', () => {
+      const acquired = shouldAcquireSyncLease({
+        lastSyncedAtMs: now - 10 * 60_000,
+        syncIntervalMinutes: 5,
+        syncLeaseAtMs: now - SYNC_LEASE_STALE_MS - 1, // 失効猶予をわずかに超過
+        nowMs: now,
+      });
+      expect(acquired).toBe(true);
+    });
+
+    it('リースの失効境界ちょうどでは、失効済み (経過側) とみなし取得できる', () => {
+      // インターバル境界 (「ちょうど経過した境界では取得できる」) と同じ扱い:
+      // 「ちょうど」は経過側とみなす (hasOverlappingEvent等と同じ境界規約)
+      const acquired = shouldAcquireSyncLease({
+        lastSyncedAtMs: now - 10 * 60_000,
+        syncIntervalMinutes: 5,
+        syncLeaseAtMs: now - SYNC_LEASE_STALE_MS, // ちょうど失効猶予分前
+        nowMs: now,
+      });
+      expect(acquired).toBe(true);
+    });
+
+    it('syncIntervalMinutes未指定時はデフォルト5分として判定する', () => {
+      const tooSoon = shouldAcquireSyncLease({
+        lastSyncedAtMs: now - 3 * 60_000,
+        syncIntervalMinutes: undefined,
+        syncLeaseAtMs: undefined,
+        nowMs: now,
+      });
+      expect(tooSoon).toBe(false);
+
+      const elapsed = shouldAcquireSyncLease({
+        lastSyncedAtMs: now - 6 * 60_000,
+        syncIntervalMinutes: undefined,
+        syncLeaseAtMs: undefined,
+        nowMs: now,
+      });
+      expect(elapsed).toBe(true);
     });
   });
 });

--- a/apps/api/src/lib/timetree-google-sync.ts
+++ b/apps/api/src/lib/timetree-google-sync.ts
@@ -28,6 +28,82 @@ export function computeSyncGap(input: {
 }
 
 /**
+ * 何らかの理由 (プロセスクラッシュ等) でリースが解放されなかった場合のフェイルセーフ。
+ * 通常の同期処理時間を十分に超える値を取り、放置されたリースが後続の同期を
+ * 永久にブロックしないようにする。
+ */
+export const SYNC_LEASE_STALE_MS = 10 * 60 * 1000; // 10分
+
+/**
+ * syncConfig 単位でリース(実行中フラグ)を取得してよいかを判定する純粋関数。
+ *
+ * 従来の `lastSyncedAt` 経過時間チェックのみでは check-then-act になっており、
+ * Cloud Scheduler の再試行や並列呼び出し時に同一 syncConfig が二重処理され
+ * うるレースコンディションがあった (Issue #196)。インターバル未経過に加えて
+ * 「有効なリースが既に存在する (＝他の実行が処理中)」場合も取得不可とする。
+ */
+export function shouldAcquireSyncLease(params: {
+  lastSyncedAtMs: number | undefined;
+  syncIntervalMinutes: number | undefined;
+  syncLeaseAtMs: number | undefined;
+  nowMs: number;
+}): boolean {
+  const intervalMs = (params.syncIntervalMinutes ?? 5) * 60_000;
+  if (params.nowMs - (params.lastSyncedAtMs ?? 0) < intervalMs) {
+    return false;
+  }
+  if (
+    params.syncLeaseAtMs !== undefined &&
+    params.nowMs - params.syncLeaseAtMs < SYNC_LEASE_STALE_MS
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * syncConfig document 単位でリースをトランザクションで取得する。判定
+ * (`shouldAcquireSyncLease`) とリース書き込みを同一トランザクション内で行う
+ * ことで、読み取り〜更新の間に他の実行が割り込む check-then-act を防ぐ。
+ * 取得できた場合のみ true を返し、呼び出し元は同期処理本体を開始してよい。
+ */
+export async function acquireSyncLease(ownerUid: string, docId: string): Promise<boolean> {
+  const db = getDb();
+  const configRef = db.collection('users').doc(ownerUid).collection('syncConfig').doc(docId);
+
+  return db.runTransaction(async (tx) => {
+    const doc = await tx.get(configRef);
+    if (!doc.exists) return false;
+    const data = doc.data()!;
+
+    const acquired = shouldAcquireSyncLease({
+      lastSyncedAtMs: data.lastSyncedAt?.toDate?.().getTime(),
+      syncIntervalMinutes: data.syncIntervalMinutes,
+      syncLeaseAtMs: data.syncLeaseAt?.toDate?.().getTime(),
+      nowMs: Date.now(),
+    });
+    if (!acquired) return false;
+
+    tx.update(configRef, { syncLeaseAt: FieldValue.serverTimestamp() });
+    return true;
+  });
+}
+
+/**
+ * 同期処理完了 (成功/失敗いずれも) 後にリースを解放する。失敗時は呼び出し元が
+ * `lastSyncedAt` を更新しないため、次回インターバル判定で再試行対象になる。
+ */
+export async function releaseSyncLease(ownerUid: string, docId: string): Promise<void> {
+  const db = getDb();
+  await db
+    .collection('users')
+    .doc(ownerUid)
+    .collection('syncConfig')
+    .doc(docId)
+    .update({ syncLeaseAt: FieldValue.delete() });
+}
+
+/**
  * TimeTreeからイベント取得。
  * 全カレンダーの全イベントを集約。
  */

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -9,6 +9,8 @@ import {
   executeSyncActions,
   recordSyncLog,
   computeSyncGap,
+  acquireSyncLease,
+  releaseSyncLease,
 } from '../lib/timetree-google-sync.js';
 import { nanoid } from 'nanoid';
 import { FieldValue } from 'firebase-admin/firestore';
@@ -63,10 +65,11 @@ syncRoutes.post('/timetree-to-google', async (c) => {
     let failureCount = 0;
 
     for (const { docId, ownerUid, data: config } of configs) {
-      // syncIntervalMinutes に基づく経過時間チェック
-      const lastSyncedAt = config.lastSyncedAt?.getTime() ?? 0;
-      const intervalMs = (config.syncIntervalMinutes ?? 5) * 60_000;
-      if (Date.now() - lastSyncedAt < intervalMs) {
+      // syncIntervalMinutes に基づく経過時間チェック + リース取得をトランザクションで
+      // 原子的に行う (Issue #196: 従来の check-then-act な判定は並列/再試行実行時に
+      // 同一設定を二重処理しうるレースコンディションがあった)。
+      const leaseAcquired = await acquireSyncLease(ownerUid, docId);
+      if (!leaseAcquired) {
         continue;
       }
 
@@ -117,13 +120,13 @@ syncRoutes.post('/timetree-to-google', async (c) => {
         const status = stats.skipped > 0 ? 'partial' : 'success';
         await recordSyncLog(docId, ownerUid, status, stats, Date.now() - configStartTime);
 
-        // lastSyncedAt を更新
+        // lastSyncedAt を更新 (リースも解放)
         await db
           .collection('users')
           .doc(ownerUid)
           .collection('syncConfig')
           .doc(docId)
-          .update({ lastSyncedAt: FieldValue.serverTimestamp() });
+          .update({ lastSyncedAt: FieldValue.serverTimestamp(), syncLeaseAt: FieldValue.delete() });
 
         console.log(
           `Sync completed for ${ownerUid}/${config.googleCalendarId}: ${stats.created} created, ${stats.updated} updated, ${stats.deleted} deleted`,
@@ -140,6 +143,12 @@ syncRoutes.post('/timetree-to-google', async (c) => {
           Date.now() - configStartTime,
           getErrorMessage(err),
         ).catch((e) => console.error('Failed to record sync log:', e));
+
+        // 失敗時もリースは解放する (lastSyncedAt は更新しないため、次回インターバル
+        // 判定で再試行対象になる。状態復旧を最優先し独立したtry-catchで囲む)
+        await releaseSyncLease(ownerUid, docId).catch((e) =>
+          console.error('Failed to release sync lease:', e),
+        );
       }
     }
 

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -68,7 +68,18 @@ syncRoutes.post('/timetree-to-google', async (c) => {
       // syncIntervalMinutes に基づく経過時間チェック + リース取得をトランザクションで
       // 原子的に行う (Issue #196: 従来の check-then-act な判定は並列/再試行実行時に
       // 同一設定を二重処理しうるレースコンディションがあった)。
-      const leaseAcquired = await acquireSyncLease(ownerUid, docId);
+      // 従来の判定は同期的で例外を投げないプロパティ読み取りだったが、Firestore
+      // トランザクションは一時的なエラーで reject しうるため、この呼び出し自体を
+      // ループ本体の try/catch とは独立して捕捉する。捕捉しないと1件のFirestore
+      // エラーがジョブ全体 (残り全configs) を中断させてしまう (/code-review medium指摘)。
+      let leaseAcquired: boolean;
+      try {
+        leaseAcquired = await acquireSyncLease(ownerUid, docId);
+      } catch (err) {
+        failureCount++;
+        console.error(`Failed to acquire sync lease for ${ownerUid}/${docId}:`, err);
+        continue;
+      }
       if (!leaseAcquired) {
         continue;
       }
@@ -135,6 +146,13 @@ syncRoutes.post('/timetree-to-google', async (c) => {
         failureCount++;
         console.error(`Sync failed for ${ownerUid}:`, err);
 
+        // 状態復旧 (リース解放) を最優先で行う (rules/error-handling.md §1:
+        // 状態復旧 > ログ記録 > 通知の優先順)。lastSyncedAt は更新しないため、
+        // 次回インターバル判定で再試行対象になる。独立したtry-catchで囲む。
+        await releaseSyncLease(ownerUid, docId).catch((e) =>
+          console.error('Failed to release sync lease:', e),
+        );
+
         await recordSyncLog(
           docId,
           ownerUid,
@@ -143,12 +161,6 @@ syncRoutes.post('/timetree-to-google', async (c) => {
           Date.now() - configStartTime,
           getErrorMessage(err),
         ).catch((e) => console.error('Failed to record sync log:', e));
-
-        // 失敗時もリースは解放する (lastSyncedAt は更新しないため、次回インターバル
-        // 判定で再試行対象になる。状態復旧を最優先し独立したtry-catchで囲む)
-        await releaseSyncLease(ownerUid, docId).catch((e) =>
-          console.error('Failed to release sync lease:', e),
-        );
       }
     }
 


### PR DESCRIPTION
## Summary
- `sync.ts` の `lastSyncedAt` 判定が check-then-act になっており、読み取り(判定)から更新までの間ロックを取得していなかった
- Cloud Scheduler の再試行や並列呼び出し時に同一 `syncConfig` が二重処理され、重複イベント作成や競合更新(最後に書いた方が勝つ)が起こりうる状態だった
- `syncConfig` document 単位でFirestoreトランザクションにより「インターバル経過判定 + リース(実行中フラグ)取得」を原子的に行うよう変更
- 判定ロジックは `shouldAcquireSyncLease` として純粋関数に切り出し、unit testで境界値を検証(インターバル境界・リース有効中・リース失効(クラッシュ復旧)等)
- リースは成功時・失敗時いずれも解放。失敗時は `lastSyncedAt` を更新しないため、次回のインターバル判定で再試行対象になる従来挙動を維持
- リース失効の猶予は10分(`SYNC_LEASE_STALE_MS`)。プロセスクラッシュ等でリース解放されなかった場合に永久に後続の同期をブロックしないためのフェイルセーフ
- `/code-review medium main...HEAD` の指摘2件に対応: (1) `acquireSyncLease` をper-config try/catchで独立して囲み、Firestore一時エラーがジョブ全体を中断させないよう修正 (2) 失敗時の状態復旧(リース解放)をログ記録より先に実行するよう順序を修正(rules/error-handling.md §1準拠)

Codex (`/codex review`, 全コードベースレビュー, 2026-07-26) で指摘、コードを直接確認して実害を検証済みのIssue。

## Test plan
- [x] `pnpm test` — 286件PASS(新規7件を含む: `shouldAcquireSyncLease`の境界値テスト)
- [x] `pnpm lint` — 全パッケージPASS
- [x] `pnpm turbo type-check` — 全パッケージPASS
- [x] `pnpm turbo build` — 全パッケージPASS
- [x] `/code-review medium main...HEAD` 実行、指摘2件を修正・再検証済み

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)