### PR TITLE
feat(booking-mirror): 予約成立時にGoogleカレンダーへblock eventを自動作成する(C1)

### DIFF
--- a/apps/api/src/__tests__/block-event.test.ts
+++ b/apps/api/src/__tests__/block-event.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { CalendarAdapter } from '@calendar-hub/calendar-sdk';
+import { createBlockEvent } from '../lib/block-event.js';
+
+const SLOT_START = new Date('2026-07-27T01:00:00.000Z');
+const SLOT_END = new Date('2026-07-27T02:00:00.000Z');
+const SLOT_START_UNIX = Math.floor(SLOT_START.getTime() / 1000);
+
+function buildParams(overrides: {
+  createEvent: CalendarAdapter['createEvent'];
+  fetchSlots?: (
+    scheduleId: string,
+    startUnix: number,
+    endUnix: number,
+  ) => Promise<{ startUnix: number; durationMinutes: number }[]>;
+}) {
+  const adapter = {
+    createEvent: overrides.createEvent,
+    updateEvent: vi.fn(),
+    deleteEvent: vi.fn(),
+  } as unknown as CalendarAdapter;
+
+  return {
+    adapter,
+    calendarId: 'cal1',
+    scheduleId: 'sched1',
+    slotStart: SLOT_START,
+    slotEnd: SLOT_END,
+    fetchSlots: overrides.fetchSlots,
+    sleep: vi.fn().mockResolvedValue(undefined), // テストでは実待機しない
+  };
+}
+
+describe('createBlockEvent', () => {
+  it('作成成功 + 枠消失を確認できれば created', async () => {
+    const createEvent = vi.fn().mockResolvedValue({ originalId: 'evt1' });
+    const fetchSlots = vi.fn().mockResolvedValue([]); // 枠が消えている (空配列)
+
+    const result = await createBlockEvent(buildParams({ createEvent, fetchSlots }));
+
+    expect(result).toEqual({ status: 'created', eventId: 'evt1' });
+    expect(createEvent).toHaveBeenCalledTimes(1);
+    expect(createEvent).toHaveBeenCalledWith(
+      'cal1',
+      expect.objectContaining({ transparency: 'opaque', title: '予定あり' }),
+    );
+  });
+
+  it('作成成功だが枠が残っていれば created_unverified (設定ミスの強いシグナル)', async () => {
+    const createEvent = vi.fn().mockResolvedValue({ originalId: 'evt1' });
+    // 2回のリトライ (1s, 3s) いずれも枠が残っている
+    const fetchSlots = vi
+      .fn()
+      .mockResolvedValue([{ startUnix: SLOT_START_UNIX, durationMinutes: 60 }]);
+
+    const result = await createBlockEvent(buildParams({ createEvent, fetchSlots }));
+
+    expect(result).toEqual({ status: 'created_unverified', eventId: 'evt1' });
+    expect(fetchSlots).toHaveBeenCalledTimes(2);
+  });
+
+  it('transient エラー (429) は再試行し、2回目で成功する', async () => {
+    const createEvent = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('rate limited'), { status: 429 }))
+      .mockResolvedValueOnce({ originalId: 'evt1' });
+    const fetchSlots = vi.fn().mockResolvedValue([]);
+
+    const result = await createBlockEvent(buildParams({ createEvent, fetchSlots }));
+
+    expect(result).toEqual({ status: 'created', eventId: 'evt1' });
+    expect(createEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('permanent エラー (401 invalid_grant 相当) は再試行せず即 failed', async () => {
+    const createEvent = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('invalid_grant'), { status: 401 }));
+
+    const result = await createBlockEvent(buildParams({ createEvent }));
+
+    expect(result.status).toBe('failed');
+    expect(createEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('transient エラーが最大リトライ回数を超えても回復しなければ failed', async () => {
+    const createEvent = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('unavailable'), { status: 503 }));
+
+    const result = await createBlockEvent(buildParams({ createEvent }));
+
+    expect(result.status).toBe('failed');
+    // 初回 + 再試行2回 = 最大3回
+    expect(createEvent).toHaveBeenCalledTimes(3);
+  });
+
+  it('タイムアウトは failed (レスポンス無応答で /book が永久に返らないことを防ぐ)', async () => {
+    const createEvent = vi.fn().mockImplementation(() => new Promise(() => {})); // 永久に解決しない
+
+    const params = buildParams({ createEvent });
+    // withTimeout の setTimeout を実時間で待つと遅いのでフェイクタイマーを使う
+    vi.useFakeTimers();
+    const resultPromise = createBlockEvent(params);
+    await vi.advanceTimersByTimeAsync(8_000 * 3 + 1_000); // create timeout × 最大試行回数分
+    const result = await resultPromise;
+    vi.useRealTimers();
+
+    expect(result.status).toBe('failed');
+  });
+});

--- a/apps/api/src/__tests__/block-event.test.ts
+++ b/apps/api/src/__tests__/block-event.test.ts
@@ -43,6 +43,7 @@ describe('createBlockEvent', () => {
     expect(createEvent).toHaveBeenCalledWith(
       'cal1',
       expect.objectContaining({ transparency: 'opaque', title: '予定あり' }),
+      { signal: expect.any(AbortSignal) },
     );
   });
 
@@ -95,17 +96,28 @@ describe('createBlockEvent', () => {
     expect(createEvent).toHaveBeenCalledTimes(3);
   });
 
-  it('タイムアウトは failed (レスポンス無応答で /book が永久に返らないことを防ぐ)', async () => {
-    const createEvent = vi.fn().mockImplementation(() => new Promise(() => {})); // 永久に解決しない
+  it('タイムアウト(abort)は transient として再試行し、最終的に failed (レスポンス無応答で /book が永久に返らないことを防ぐ)', async () => {
+    // 実際に signal.aborted を見て reject するモックにすることで、
+    // withTimeout の見せかけタイムアウトではなく、実際に下層リクエストを
+    // abort する経路であることを検証する (Codex review 指摘の回帰防止)。
+    const createEvent = vi.fn().mockImplementation((_calendarId, _event, options) => {
+      if (options?.signal?.aborted) {
+        return Promise.reject(options.signal.reason);
+      }
+      return new Promise(() => {}); // signal が渡っていなければ永久に解決しない
+    });
+    // createTimeoutSignal を「即座に abort 済みの signal」にすり替え、
+    // 実時間のタイムアウト待ちなしにタイムアウト経路を再現する
+    const createTimeoutSignal = () =>
+      AbortSignal.abort(new DOMException('timed out', 'TimeoutError'));
 
-    const params = buildParams({ createEvent });
-    // withTimeout の setTimeout を実時間で待つと遅いのでフェイクタイマーを使う
-    vi.useFakeTimers();
-    const resultPromise = createBlockEvent(params);
-    await vi.advanceTimersByTimeAsync(8_000 * 3 + 1_000); // create timeout × 最大試行回数分
-    const result = await resultPromise;
-    vi.useRealTimers();
+    const result = await createBlockEvent({
+      ...buildParams({ createEvent }),
+      createTimeoutSignal,
+    });
 
     expect(result.status).toBe('failed');
+    // 初回 + 再試行2回 = 最大3回
+    expect(createEvent).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/api/src/__tests__/booking-mirror-link-utils.test.ts
+++ b/apps/api/src/__tests__/booking-mirror-link-utils.test.ts
@@ -5,6 +5,7 @@ import {
   applyBookingMirrorLinkDefaults,
   shouldCreateBlockEvent,
   validateBookingMirrorLinkInvariant,
+  buildBookingMirrorLinkPatchUpdate,
 } from '../lib/booking-mirror-link-utils.js';
 
 // Firestore Timestamp のダミー実装 (toDate() のみ持てば十分)
@@ -260,5 +261,57 @@ describe('validateBookingMirrorLinkInvariant', () => {
       blockAccountId: 'acc1',
     });
     expect(result.ok).toBe(true);
+  });
+});
+
+describe('buildBookingMirrorLinkPatchUpdate (Partial Update: 更新対象外フィールドは含めない)', () => {
+  it('title のみ指定 → update に title のみ含まれる', () => {
+    const update = buildBookingMirrorLinkPatchUpdate({ title: 'new' });
+    expect(Object.keys(update)).toEqual(['title']);
+    expect(update.title).toBe('new');
+  });
+
+  it('autoCreateBlockEvent のみ指定 → 他フィールドは update に含まれない', () => {
+    const update = buildBookingMirrorLinkPatchUpdate({ autoCreateBlockEvent: true });
+    expect(Object.keys(update)).toEqual(['autoCreateBlockEvent']);
+    expect(update.autoCreateBlockEvent).toBe(true);
+    expect(update.blockCalendarId).toBeUndefined();
+    expect(update.blockAccountId).toBeUndefined();
+    expect(update.title).toBeUndefined();
+    expect(update.status).toBeUndefined();
+  });
+
+  it('blockCalendarId のみ指定 → 他フィールドは update に含まれない', () => {
+    const update = buildBookingMirrorLinkPatchUpdate({ blockCalendarId: 'cal1' });
+    expect(Object.keys(update)).toEqual(['blockCalendarId']);
+    expect(update.autoCreateBlockEvent).toBeUndefined();
+    expect(update.blockAccountId).toBeUndefined();
+  });
+
+  it('description: null を明示指定 → update.description は null (undefined とは区別する)', () => {
+    const update = buildBookingMirrorLinkPatchUpdate({ description: null });
+    expect(Object.keys(update)).toEqual(['description']);
+    expect(update.description).toBeNull();
+  });
+
+  it('expiresAt: null を明示指定 → update.expiresAt は null', () => {
+    const update = buildBookingMirrorLinkPatchUpdate({ expiresAt: null });
+    expect(Object.keys(update)).toEqual(['expiresAt']);
+    expect(update.expiresAt).toBeNull();
+  });
+
+  it('何も指定しない → update は空オブジェクト (Firestore 側の既存値を一切変更しない)', () => {
+    const update = buildBookingMirrorLinkPatchUpdate({});
+    expect(update).toEqual({});
+  });
+
+  it('複数フィールド指定 → 指定分のみ含まれ、他は含まれない', () => {
+    const update = buildBookingMirrorLinkPatchUpdate({
+      status: 'paused',
+      autoCreateBlockEvent: false,
+    });
+    expect(Object.keys(update).sort()).toEqual(['autoCreateBlockEvent', 'status']);
+    expect(update.title).toBeUndefined();
+    expect(update.blockCalendarId).toBeUndefined();
   });
 });

--- a/apps/api/src/__tests__/booking-mirror-link-utils.test.ts
+++ b/apps/api/src/__tests__/booking-mirror-link-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { buildBookingMirrorLinkFromFirestoreData } from '../lib/booking-mirror-link-utils.js';
+import type { BookingMirrorLink } from '@calendar-hub/shared';
+import {
+  buildBookingMirrorLinkFromFirestoreData,
+  applyBookingMirrorLinkDefaults,
+  shouldCreateBlockEvent,
+  validateBookingMirrorLinkInvariant,
+} from '../lib/booking-mirror-link-utils.js';
 
 // Firestore Timestamp のダミー実装 (toDate() のみ持てば十分)
 function fakeTimestamp(date: Date) {
@@ -154,5 +160,105 @@ describe('buildBookingMirrorLinkFromFirestoreData', () => {
 
     expect(link.createdAt).toBeInstanceOf(Date);
     expect(link.updatedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('applyBookingMirrorLinkDefaults', () => {
+  it('既存 document に autoCreateBlockEvent が無ければ false (稼働中リンクが突然書き込みを始めない)', () => {
+    const result = applyBookingMirrorLinkDefaults({ title: 'old-link' });
+    expect(result.autoCreateBlockEvent).toBe(false);
+  });
+
+  it('既存 document に blockCalendarId/blockAccountId が無ければ両方 null', () => {
+    const result = applyBookingMirrorLinkDefaults({});
+    expect(result.blockCalendarId).toBeNull();
+    expect(result.blockAccountId).toBeNull();
+  });
+
+  it('明示的に true が指定されていれば true を返す', () => {
+    const result = applyBookingMirrorLinkDefaults({ autoCreateBlockEvent: true });
+    expect(result.autoCreateBlockEvent).toBe(true);
+  });
+});
+
+function buildMirrorLink(overrides: Partial<BookingMirrorLink>): BookingMirrorLink {
+  return {
+    id: 'link1',
+    ownerUid: 'u1',
+    title: 't',
+    sourceUrl: 'https://calendar.app.google/abc',
+    scheduleId: 'sched1',
+    notificationEmail: 'owner@example.com',
+    rangeDays: 30,
+    status: 'active',
+    expiresAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    autoCreateBlockEvent: false,
+    blockCalendarId: null,
+    blockAccountId: null,
+    ...overrides,
+  };
+}
+
+describe('shouldCreateBlockEvent', () => {
+  it('autoCreateBlockEvent が false なら false', () => {
+    expect(shouldCreateBlockEvent(buildMirrorLink({ autoCreateBlockEvent: false }))).toBe(false);
+  });
+
+  it('autoCreateBlockEvent が true でも blockCalendarId が無ければ false', () => {
+    const link = buildMirrorLink({
+      autoCreateBlockEvent: true,
+      blockCalendarId: null,
+      blockAccountId: 'acc1',
+    });
+    expect(shouldCreateBlockEvent(link)).toBe(false);
+  });
+
+  it('autoCreateBlockEvent が true でも blockAccountId が無ければ false', () => {
+    const link = buildMirrorLink({
+      autoCreateBlockEvent: true,
+      blockCalendarId: 'cal1',
+      blockAccountId: null,
+    });
+    expect(shouldCreateBlockEvent(link)).toBe(false);
+  });
+
+  it('3条件が全て揃えば true', () => {
+    const link = buildMirrorLink({
+      autoCreateBlockEvent: true,
+      blockCalendarId: 'cal1',
+      blockAccountId: 'acc1',
+    });
+    expect(shouldCreateBlockEvent(link)).toBe(true);
+  });
+});
+
+describe('validateBookingMirrorLinkInvariant', () => {
+  it('autoCreateBlockEvent=false なら blockCalendarId/blockAccountId が null でも ok', () => {
+    const result = validateBookingMirrorLinkInvariant({
+      autoCreateBlockEvent: false,
+      blockCalendarId: null,
+      blockAccountId: null,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('autoCreateBlockEvent=true で blockCalendarId が無ければ 400 相当のエラー', () => {
+    const result = validateBookingMirrorLinkInvariant({
+      autoCreateBlockEvent: true,
+      blockCalendarId: null,
+      blockAccountId: 'acc1',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('autoCreateBlockEvent=true で両方揃っていれば ok', () => {
+    const result = validateBookingMirrorLinkInvariant({
+      autoCreateBlockEvent: true,
+      blockCalendarId: 'cal1',
+      blockAccountId: 'acc1',
+    });
+    expect(result.ok).toBe(true);
   });
 });

--- a/apps/api/src/__tests__/calendar-target-invariant.test.ts
+++ b/apps/api/src/__tests__/calendar-target-invariant.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { validateCalendarTargetInvariant } from '../lib/calendar-target-invariant.js';
+
+describe('validateCalendarTargetInvariant', () => {
+  it('enabled=false なら calendarId/accountId が両方 null でも ok', () => {
+    const result = validateCalendarTargetInvariant({
+      enabled: false,
+      calendarId: null,
+      accountId: null,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('enabled=true で calendarId が無ければ NG', () => {
+    const result = validateCalendarTargetInvariant({
+      enabled: true,
+      calendarId: null,
+      accountId: 'acc1',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('enabled=true で accountId が無ければ NG', () => {
+    const result = validateCalendarTargetInvariant({
+      enabled: true,
+      calendarId: 'cal1',
+      accountId: null,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('enabled=true で両方揃っていれば ok', () => {
+    const result = validateCalendarTargetInvariant({
+      enabled: true,
+      calendarId: 'cal1',
+      accountId: 'acc1',
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/apps/api/src/lib/block-event.ts
+++ b/apps/api/src/lib/block-event.ts
@@ -31,56 +31,52 @@ export interface CreateBlockEventParams {
   fetchSlots?: (scheduleId: string, startUnix: number, endUnix: number) => Promise<GoogleSlot[]>;
   /** テスト用 DI。省略時は実際に待機する */
   sleep?: (ms: number) => Promise<void>;
+  /**
+   * テスト用 DI。省略時は `AbortSignal.timeout(CREATE_TIMEOUT_MS)` を使う。
+   * google-booking-mirror.ts の fetchWithTimeout と同じく、タイムアウト時に
+   * 下層の HTTP リクエストを実際に abort するため (Promise.race による見せかけの
+   * タイムアウトだと、タイムアウト後もリクエストが裏で成功し重複イベントが
+   * 作られる恐れがある)。
+   */
+  createTimeoutSignal?: () => AbortSignal;
 }
 
 function defaultSleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/** 429/503/タイムアウトは再試行可能 (transient)、それ以外 (401/403/404 等) は即失敗 (permanent) */
+/** 429/503/タイムアウト(abort)は再試行可能 (transient)、それ以外 (401/403/404 等) は即失敗 (permanent) */
 function isTransientError(err: unknown): boolean {
   const code = (err as { code?: number })?.code;
   const status = (err as { status?: number })?.status;
   if (code === 429 || code === 503 || status === 429 || status === 503) return true;
-  if (err instanceof Error && /timed out|timeout/i.test(err.message)) return true;
+  if (err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError')) {
+    return true;
+  }
+  if (err instanceof Error && /timed out|timeout|abort/i.test(err.message)) return true;
   return false;
-}
-
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(new Error(`block event creation timed out after ${ms}ms`));
-    }, ms);
-    promise.then(
-      (value) => {
-        clearTimeout(timer);
-        resolve(value);
-      },
-      (err) => {
-        clearTimeout(timer);
-        reject(err);
-      },
-    );
-  });
 }
 
 export async function createBlockEvent(params: CreateBlockEventParams): Promise<BlockEventResult> {
   const { adapter, calendarId, scheduleId, slotStart, slotEnd } = params;
   const fetchSlots = params.fetchSlots ?? fetchAvailableSlots;
   const sleep = params.sleep ?? defaultSleep;
+  const createTimeoutSignal =
+    params.createTimeoutSignal ?? (() => AbortSignal.timeout(CREATE_TIMEOUT_MS));
 
   let lastError: unknown;
   for (let attempt = 0; attempt <= MAX_TRANSIENT_RETRIES; attempt++) {
     try {
-      const event = await withTimeout(
-        adapter.createEvent(calendarId, {
+      const event = await adapter.createEvent(
+        calendarId,
+        {
           title: '予定あり',
           start: slotStart,
           end: slotEnd,
           isAllDay: false,
           transparency: 'opaque',
-        }),
-        CREATE_TIMEOUT_MS,
+        },
+        { signal: createTimeoutSignal() },
       );
       return await verifySlotGone(
         event.originalId,

--- a/apps/api/src/lib/block-event.ts
+++ b/apps/api/src/lib/block-event.ts
@@ -1,0 +1,131 @@
+import type { CalendarAdapter } from '@calendar-hub/calendar-sdk';
+import { fetchAvailableSlots, type GoogleSlot } from './google-booking-mirror.js';
+
+/**
+ * booking-mirror C1: 予約成立時に「予定あり」block event を作成する。
+ *
+ * `createEvent` の 200 は「API 呼び出しが成功した」ことしか意味せず、実際に
+ * Google 予約スケジュール側の枠が塞がったこと (conflict check 対象カレンダーへの
+ * 書き込みであること) までは保証しない。そのため作成後に `fetchAvailableSlots`
+ * で枠消失を検証し、3値 (created/created_unverified/failed) で結果を返す。
+ */
+
+export type BlockEventResult =
+  | { status: 'created'; eventId: string }
+  | { status: 'created_unverified'; eventId: string }
+  | { status: 'failed'; error: string };
+
+const CREATE_TIMEOUT_MS = 8_000;
+const MAX_TRANSIENT_RETRIES = 2;
+const TRANSIENT_RETRY_DELAY_MS = 500;
+// gRPC 側のキャッシュ有無が未検証 (計画書参照) のため、短い間隔で複数回リトライする
+const VERIFY_RETRY_DELAYS_MS = [1_000, 3_000];
+
+export interface CreateBlockEventParams {
+  adapter: CalendarAdapter;
+  calendarId: string;
+  scheduleId: string;
+  slotStart: Date;
+  slotEnd: Date;
+  /** テスト用 DI。省略時は google-booking-mirror.fetchAvailableSlots を使う */
+  fetchSlots?: (scheduleId: string, startUnix: number, endUnix: number) => Promise<GoogleSlot[]>;
+  /** テスト用 DI。省略時は実際に待機する */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** 429/503/タイムアウトは再試行可能 (transient)、それ以外 (401/403/404 等) は即失敗 (permanent) */
+function isTransientError(err: unknown): boolean {
+  const code = (err as { code?: number })?.code;
+  const status = (err as { status?: number })?.status;
+  if (code === 429 || code === 503 || status === 429 || status === 503) return true;
+  if (err instanceof Error && /timed out|timeout/i.test(err.message)) return true;
+  return false;
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`block event creation timed out after ${ms}ms`));
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+export async function createBlockEvent(params: CreateBlockEventParams): Promise<BlockEventResult> {
+  const { adapter, calendarId, scheduleId, slotStart, slotEnd } = params;
+  const fetchSlots = params.fetchSlots ?? fetchAvailableSlots;
+  const sleep = params.sleep ?? defaultSleep;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= MAX_TRANSIENT_RETRIES; attempt++) {
+    try {
+      const event = await withTimeout(
+        adapter.createEvent(calendarId, {
+          title: '予定あり',
+          start: slotStart,
+          end: slotEnd,
+          isAllDay: false,
+          transparency: 'opaque',
+        }),
+        CREATE_TIMEOUT_MS,
+      );
+      return await verifySlotGone(
+        event.originalId,
+        scheduleId,
+        slotStart,
+        slotEnd,
+        fetchSlots,
+        sleep,
+      );
+    } catch (err) {
+      lastError = err;
+      if (!isTransientError(err) || attempt === MAX_TRANSIENT_RETRIES) {
+        break;
+      }
+      await sleep(TRANSIENT_RETRY_DELAY_MS);
+    }
+  }
+  return {
+    status: 'failed',
+    error: lastError instanceof Error ? lastError.message : String(lastError),
+  };
+}
+
+async function verifySlotGone(
+  eventId: string,
+  scheduleId: string,
+  slotStart: Date,
+  slotEnd: Date,
+  fetchSlots: (scheduleId: string, startUnix: number, endUnix: number) => Promise<GoogleSlot[]>,
+  sleep: (ms: number) => Promise<void>,
+): Promise<BlockEventResult> {
+  const startUnix = Math.floor(slotStart.getTime() / 1000);
+  const endUnix = Math.floor(slotEnd.getTime() / 1000) + 60; // 境界に含める (public-booking-mirror.ts と同じ考え方)
+
+  for (const delay of VERIFY_RETRY_DELAYS_MS) {
+    await sleep(delay);
+    try {
+      const slots = await fetchSlots(scheduleId, startUnix, endUnix);
+      const stillOpen = slots.some((s) => s.startUnix === startUnix);
+      if (!stillOpen) {
+        return { status: 'created', eventId };
+      }
+    } catch {
+      // 検証 API 自体の失敗は unverified 扱いにする (event 作成は成功しているため failed にはしない)
+    }
+  }
+  return { status: 'created_unverified', eventId };
+}

--- a/apps/api/src/lib/booking-link-utils.ts
+++ b/apps/api/src/lib/booking-link-utils.ts
@@ -1,5 +1,6 @@
 import type { DocumentData } from 'firebase-admin/firestore';
 import type { BookingLink } from '@calendar-hub/shared';
+import { validateCalendarTargetInvariant } from './calendar-target-invariant.js';
 
 /**
  * Firestore document data に新フィールドの default を補完するためのロジック。
@@ -110,12 +111,17 @@ export function validateBookingLinkInvariant(input: {
   calendarIdForEvent: string | null | undefined;
   accountIdForEvent: string | null | undefined;
 }): { ok: true } | { ok: false; error: string } {
-  if (input.autoCreateCalendarEvent && (!input.calendarIdForEvent || !input.accountIdForEvent)) {
+  const result = validateCalendarTargetInvariant({
+    enabled: input.autoCreateCalendarEvent,
+    calendarId: input.calendarIdForEvent,
+    accountId: input.accountIdForEvent,
+  });
+  if (!result.ok) {
     return {
       ok: false,
       error:
         'calendarIdForEvent and accountIdForEvent are required when autoCreateCalendarEvent is true',
     };
   }
-  return { ok: true };
+  return result;
 }

--- a/apps/api/src/lib/booking-mirror-link-utils.ts
+++ b/apps/api/src/lib/booking-mirror-link-utils.ts
@@ -1,5 +1,5 @@
 import type { DocumentData } from 'firebase-admin/firestore';
-import type { BookingMirrorLink } from '@calendar-hub/shared';
+import type { BookingMirrorLink, UpdateBookingMirrorLinkInput } from '@calendar-hub/shared';
 import { validateCalendarTargetInvariant } from './calendar-target-invariant.js';
 
 /**
@@ -74,4 +74,29 @@ export function validateBookingMirrorLinkInvariant(input: {
     };
   }
   return result;
+}
+
+/**
+ * PATCH リクエスト body から Firestore update object を構築する (Partial Update)。
+ * undefined フィールドは update に含めず、Firestore 側で既存値を保持させる
+ * (非mirror版 buildBookingLinkPatchUpdate と同じ方針)。
+ */
+export function buildBookingMirrorLinkPatchUpdate(
+  body: UpdateBookingMirrorLinkInput,
+): Record<string, unknown> {
+  const update: Record<string, unknown> = {};
+  if (body.title !== undefined) update.title = body.title;
+  if (body.description !== undefined) update.description = body.description ?? null;
+  if (body.notificationEmail !== undefined) update.notificationEmail = body.notificationEmail;
+  if (body.rangeDays !== undefined) update.rangeDays = body.rangeDays;
+  if (body.status !== undefined) update.status = body.status;
+  if (body.expiresAt !== undefined) {
+    update.expiresAt = body.expiresAt ? new Date(body.expiresAt) : null;
+  }
+  if (body.autoCreateBlockEvent !== undefined) {
+    update.autoCreateBlockEvent = body.autoCreateBlockEvent;
+  }
+  if (body.blockCalendarId !== undefined) update.blockCalendarId = body.blockCalendarId;
+  if (body.blockAccountId !== undefined) update.blockAccountId = body.blockAccountId;
+  return update;
 }

--- a/apps/api/src/lib/booking-mirror-link-utils.ts
+++ b/apps/api/src/lib/booking-mirror-link-utils.ts
@@ -1,5 +1,6 @@
 import type { DocumentData } from 'firebase-admin/firestore';
 import type { BookingMirrorLink } from '@calendar-hub/shared';
+import { validateCalendarTargetInvariant } from './calendar-target-invariant.js';
 
 /**
  * Firestore document data から BookingMirrorLink を構築する。
@@ -24,5 +25,53 @@ export function buildBookingMirrorLinkFromFirestoreData(data: DocumentData): Boo
     expiresAt: data.expiresAt?.toDate?.() ?? null,
     createdAt: data.createdAt?.toDate?.() ?? new Date(),
     updatedAt: data.updatedAt?.toDate?.() ?? new Date(),
+    ...applyBookingMirrorLinkDefaults(data),
   } as BookingMirrorLink;
+}
+
+/**
+ * 既存 document (block event 拡張前に作成されたもの) に新フィールドの default を補完する。
+ * `autoCreateCalendarEvent` の非mirror版とは逆に、既定は false
+ * (稼働中リンクが突然 Google カレンダーへの書き込みを始めるのを防ぐため)。
+ */
+export function applyBookingMirrorLinkDefaults(
+  data: Record<string, unknown>,
+): Pick<BookingMirrorLink, 'autoCreateBlockEvent' | 'blockCalendarId' | 'blockAccountId'> {
+  return {
+    autoCreateBlockEvent: (data.autoCreateBlockEvent as boolean | undefined) ?? false,
+    blockCalendarId: (data.blockCalendarId as string | null | undefined) ?? null,
+    blockAccountId: (data.blockAccountId as string | null | undefined) ?? null,
+  };
+}
+
+/**
+ * 予約成立時に block event (「予定あり」) を自動作成すべきかを判定。
+ * autoCreateBlockEvent が ON で、かつ書き込み先 (blockAccountId / blockCalendarId) の
+ * 両方が設定されている場合のみ true (非mirror版 shouldCreateCalendarEvent と同じ考え方)。
+ */
+export function shouldCreateBlockEvent(link: BookingMirrorLink): boolean {
+  return link.autoCreateBlockEvent && !!link.blockAccountId && !!link.blockCalendarId;
+}
+
+/**
+ * BookingMirrorLink 作成/更新入力の不変条件をチェック。
+ * `autoCreateBlockEvent === true` のときは `blockCalendarId` と `blockAccountId` が必須。
+ */
+export function validateBookingMirrorLinkInvariant(input: {
+  autoCreateBlockEvent: boolean;
+  blockCalendarId: string | null | undefined;
+  blockAccountId: string | null | undefined;
+}): { ok: true } | { ok: false; error: string } {
+  const result = validateCalendarTargetInvariant({
+    enabled: input.autoCreateBlockEvent,
+    calendarId: input.blockCalendarId,
+    accountId: input.blockAccountId,
+  });
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: 'blockCalendarId and blockAccountId are required when autoCreateBlockEvent is true',
+    };
+  }
+  return result;
 }

--- a/apps/api/src/lib/calendar-target-invariant.ts
+++ b/apps/api/src/lib/calendar-target-invariant.ts
@@ -1,0 +1,18 @@
+/**
+ * 「有効化されているなら書き込み先 (calendarId/accountId) が必須」という不変条件の汎用版。
+ * 非mirrorの booking-link-utils.validateBookingLinkInvariant と mirrorの
+ * shouldCreateBlockEvent 系検証の両方から使う共通ロジック。
+ */
+export function validateCalendarTargetInvariant(input: {
+  enabled: boolean;
+  calendarId: string | null | undefined;
+  accountId: string | null | undefined;
+}): { ok: true } | { ok: false; error: string } {
+  if (input.enabled && (!input.calendarId || !input.accountId)) {
+    return {
+      ok: false,
+      error: 'calendarId and accountId are required when enabled is true',
+    };
+  }
+  return { ok: true };
+}

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -267,8 +267,11 @@ export function buildBookingNotificationHtml(params: {
   guestMessage?: string;
   slotStart: Date;
   slotEnd: Date;
+  /** booking-mirror C1: block event が作成できたが枠消失を確認できなかった場合の警告文 */
+  blockEventWarning?: string;
 }): string {
-  const { linkTitle, guestName, guestEmail, guestMessage, slotStart, slotEnd } = params;
+  const { linkTitle, guestName, guestEmail, guestMessage, slotStart, slotEnd, blockEventWarning } =
+    params;
   const startStr = formatJstDateTime(slotStart);
   const endStr = formatJstTime(slotEnd);
 
@@ -294,6 +297,12 @@ export function buildBookingNotificationHtml(params: {
     details: detailsLines.join('\n'),
   });
 
+  const blockWarningHtml = blockEventWarning
+    ? `<div style="border:1px solid #f0ad4e;background:#fff8e6;border-radius:8px;padding:12px 16px;margin:16px 0;">
+    <p style="margin:0;font-size:13px;color:#8a6116;">⚠️ ${escapeHtml(blockEventWarning)}</p>
+  </div>`
+    : '';
+
   return `
 <!DOCTYPE html>
 <html>
@@ -307,6 +316,7 @@ export function buildBookingNotificationHtml(params: {
     <p style="margin:4px 0;font-size:14px;"><strong>日時:</strong> ${escapeHtml(startStr)} 〜 ${escapeHtml(endStr)}</p>
     ${messageHtml}
   </div>
+  ${blockWarningHtml}
   <div style="text-align:center;margin:20px 0;">
     <a href="${escapeHtml(gcalUrl)}" target="_blank" rel="noopener" style="display:inline-block;padding:12px 24px;background:#1a73e8;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;font-size:14px;">
       📅 Google カレンダーに追加

--- a/apps/api/src/lib/mock-calendar-adapter.ts
+++ b/apps/api/src/lib/mock-calendar-adapter.ts
@@ -46,7 +46,14 @@ export class MockCalendarAdapter implements CalendarAdapter {
 
   async createEvent(
     calendarId: string,
-    event: { title: string; description?: string; start: Date; end: Date; isAllDay: boolean },
+    event: {
+      title: string;
+      description?: string;
+      start: Date;
+      end: Date;
+      isAllDay: boolean;
+      transparency?: 'opaque' | 'transparent';
+    },
   ): Promise<CalendarEvent> {
     const id = `mock_${nanoid(8)}`;
     return {

--- a/apps/api/src/routes/booking-links.ts
+++ b/apps/api/src/routes/booking-links.ts
@@ -4,6 +4,7 @@ import { FieldValue, type Query } from 'firebase-admin/firestore';
 import type { AppEnv } from '../types.js';
 import { requireAuth } from '../middleware/auth.js';
 import { getDb } from '../lib/firebase-admin.js';
+import { createAdapter } from '../lib/adapter-factory.js';
 import {
   DURATION_OPTIONS,
   BOOKING_LINK_STATUSES,
@@ -241,7 +242,8 @@ bookingLinkRoutes.patch('/bookings/:bookingId/cancel', requireAuth, async (c) =>
     return c.json({ error: 'Not found' }, 404);
   }
 
-  if (doc.data()?.status !== 'confirmed') {
+  const bookingData = doc.data()!;
+  if (bookingData.status !== 'confirmed') {
     return c.json({ error: 'Booking is not confirmed' }, 400);
   }
 
@@ -249,6 +251,18 @@ bookingLinkRoutes.patch('/bookings/:bookingId/cancel', requireAuth, async (c) =>
     status: 'cancelled_by_owner',
     updatedAt: FieldValue.serverTimestamp(),
   });
+
+  // booking-mirror C1: block event (「予定あり」) の削除。キャンセル自体は成立済みなので
+  // 削除に失敗してもログのみに留める (「空いているのに永久に埋まって見える」障害を防ぐのが
+  // 目的の後始末処理であり、失敗させて良い理由がない = 独立 try-catch で握り潰す)。
+  if (bookingData.blockEventId && bookingData.blockAccountId && bookingData.blockCalendarId) {
+    try {
+      const adapter = await createAdapter(user.uid, bookingData.blockAccountId);
+      await adapter.deleteEvent(bookingData.blockCalendarId, bookingData.blockEventId);
+    } catch (err) {
+      console.error(`Failed to delete block event for booking ${bookingId}:`, err);
+    }
+  }
 
   return c.json({ success: true });
 });

--- a/apps/api/src/routes/booking-mirror-links.ts
+++ b/apps/api/src/routes/booking-mirror-links.ts
@@ -13,6 +13,7 @@ import type {
 import { resolveScheduleId, BookingMirrorError } from '../lib/google-booking-mirror.js';
 import {
   buildBookingMirrorLinkFromFirestoreData,
+  buildBookingMirrorLinkPatchUpdate,
   validateBookingMirrorLinkInvariant,
 } from '../lib/booking-mirror-link-utils.js';
 
@@ -24,23 +25,6 @@ const DEFAULT_NOTIFICATION_EMAIL =
   process.env.DEFAULT_NOTIFICATION_EMAIL ?? 'hy.unimail.11@gmail.com';
 
 // --- ヘルパー ---
-
-function buildPatchUpdate(body: UpdateBookingMirrorLinkInput): Record<string, unknown> {
-  const update: Record<string, unknown> = {};
-  if (body.title !== undefined) update.title = body.title;
-  if (body.description !== undefined) update.description = body.description ?? null;
-  if (body.notificationEmail !== undefined) update.notificationEmail = body.notificationEmail;
-  if (body.rangeDays !== undefined) update.rangeDays = body.rangeDays;
-  if (body.status !== undefined) update.status = body.status;
-  if (body.expiresAt !== undefined) {
-    update.expiresAt = body.expiresAt ? new Date(body.expiresAt) : null;
-  }
-  if (body.autoCreateBlockEvent !== undefined)
-    update.autoCreateBlockEvent = body.autoCreateBlockEvent;
-  if (body.blockCalendarId !== undefined) update.blockCalendarId = body.blockCalendarId;
-  if (body.blockAccountId !== undefined) update.blockAccountId = body.blockAccountId;
-  return update;
-}
 
 function validateStatus(value: unknown): value is BookingMirrorLinkStatus {
   return value === 'active' || value === 'paused';
@@ -215,7 +199,7 @@ bookingMirrorLinkRoutes.patch('/:linkId', requireAuth, async (c) => {
     return c.json({ error: patchInvariant.error }, 400);
   }
 
-  const update = buildPatchUpdate(body);
+  const update = buildBookingMirrorLinkPatchUpdate(body);
   update.updatedAt = FieldValue.serverTimestamp();
   await ref.update(update);
 

--- a/apps/api/src/routes/booking-mirror-links.ts
+++ b/apps/api/src/routes/booking-mirror-links.ts
@@ -11,7 +11,10 @@ import type {
   UpdateBookingMirrorLinkInput,
 } from '@calendar-hub/shared';
 import { resolveScheduleId, BookingMirrorError } from '../lib/google-booking-mirror.js';
-import { buildBookingMirrorLinkFromFirestoreData } from '../lib/booking-mirror-link-utils.js';
+import {
+  buildBookingMirrorLinkFromFirestoreData,
+  validateBookingMirrorLinkInvariant,
+} from '../lib/booking-mirror-link-utils.js';
 
 export const bookingMirrorLinkRoutes = new Hono<AppEnv>();
 
@@ -32,6 +35,10 @@ function buildPatchUpdate(body: UpdateBookingMirrorLinkInput): Record<string, un
   if (body.expiresAt !== undefined) {
     update.expiresAt = body.expiresAt ? new Date(body.expiresAt) : null;
   }
+  if (body.autoCreateBlockEvent !== undefined)
+    update.autoCreateBlockEvent = body.autoCreateBlockEvent;
+  if (body.blockCalendarId !== undefined) update.blockCalendarId = body.blockCalendarId;
+  if (body.blockAccountId !== undefined) update.blockAccountId = body.blockAccountId;
   return update;
 }
 
@@ -79,6 +86,18 @@ bookingMirrorLinkRoutes.post('/', requireAuth, async (c) => {
     return c.json({ error: `rangeDays must be 1-${MAX_RANGE_DAYS}` }, 400);
   }
 
+  const autoCreateBlockEvent = body.autoCreateBlockEvent ?? false;
+  const blockCalendarId = body.blockCalendarId ?? null;
+  const blockAccountId = body.blockAccountId ?? null;
+  const invariant = validateBookingMirrorLinkInvariant({
+    autoCreateBlockEvent,
+    blockCalendarId,
+    blockAccountId,
+  });
+  if (!invariant.ok) {
+    return c.json({ error: invariant.error }, 400);
+  }
+
   // schedule ID を解決（失敗時は 400）
   let scheduleId: string;
   try {
@@ -108,6 +127,9 @@ bookingMirrorLinkRoutes.post('/', requireAuth, async (c) => {
     expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
     createdAt: now,
     updatedAt: now,
+    autoCreateBlockEvent,
+    blockCalendarId,
+    blockAccountId,
   };
 
   const db = getDb();
@@ -174,6 +196,23 @@ bookingMirrorLinkRoutes.patch('/:linkId', requireAuth, async (c) => {
     (!Number.isInteger(body.rangeDays) || body.rangeDays < 1 || body.rangeDays > MAX_RANGE_DAYS)
   ) {
     return c.json({ error: `rangeDays must be 1-${MAX_RANGE_DAYS}` }, 400);
+  }
+
+  // 不変条件: 既存 document + リクエスト body をマージした後の状態で検証する。
+  // body だけを見ると、一覧カードから { autoCreateBlockEvent: true } だけを送るケースで素通りする。
+  const existingLink = buildBookingMirrorLinkFromFirestoreData(doc.data()!);
+  const mergedAutoCreateBlockEvent = body.autoCreateBlockEvent ?? existingLink.autoCreateBlockEvent;
+  const mergedBlockCalendarId =
+    body.blockCalendarId !== undefined ? body.blockCalendarId : existingLink.blockCalendarId;
+  const mergedBlockAccountId =
+    body.blockAccountId !== undefined ? body.blockAccountId : existingLink.blockAccountId;
+  const patchInvariant = validateBookingMirrorLinkInvariant({
+    autoCreateBlockEvent: mergedAutoCreateBlockEvent,
+    blockCalendarId: mergedBlockCalendarId,
+    blockAccountId: mergedBlockAccountId,
+  });
+  if (!patchInvariant.ok) {
+    return c.json({ error: patchInvariant.error }, 400);
   }
 
   const update = buildPatchUpdate(body);

--- a/apps/api/src/routes/public-booking-mirror.ts
+++ b/apps/api/src/routes/public-booking-mirror.ts
@@ -18,9 +18,14 @@ import {
 } from '../lib/google-booking-mirror.js';
 import { assertE2EMockSafe } from '../lib/e2e-guard.js';
 import { pickOwnerDisplayName } from '../lib/owner-display-name.js';
-import { buildBookingMirrorLinkFromFirestoreData } from '../lib/booking-mirror-link-utils.js';
+import {
+  buildBookingMirrorLinkFromFirestoreData,
+  shouldCreateBlockEvent,
+} from '../lib/booking-mirror-link-utils.js';
 import { excludeOverlappingSlots } from '../lib/booking-mirror-slots.js';
 import { getConfirmedBookingEventsForOwner, OVERLAP_LOOKBACK_MS } from '../lib/booking-events.js';
+import { createAdapter } from '../lib/adapter-factory.js';
+import { createBlockEvent, type BlockEventResult } from '../lib/block-event.js';
 import type {
   BookingMirrorLink,
   BookingMirrorSlot,
@@ -275,6 +280,20 @@ publicBookingMirrorRoutes.post('/:linkId/book', async (c) => {
     throw err;
   }
 
+  // block event 作成は booking doc の確定 (orphan event 防止) の後、レスポンス返却の前に
+  // 同期実行する。Cloud Run が --no-cpu-throttling 無しの min-instances=0 で動いているため、
+  // レスポンス返却後の非同期処理は完走が保証されない (計画書参照)。
+  let blockEventResult: BlockEventResult | null = null;
+  if (shouldCreateBlockEvent(link)) {
+    blockEventResult = await createAndRecordBlockEvent(
+      link,
+      bookingId,
+      scheduleId,
+      slotStart,
+      slotEnd,
+    );
+  }
+
   const ownerDisplayName = await getOwnerDisplayName(link.ownerUid);
   sendBookingNotificationsAsync(
     link,
@@ -285,6 +304,7 @@ publicBookingMirrorRoutes.post('/:linkId/book', async (c) => {
     slotStart,
     slotEnd,
     ownerDisplayName,
+    blockEventResult,
   );
 
   return c.json(
@@ -296,11 +316,62 @@ publicBookingMirrorRoutes.post('/:linkId/book', async (c) => {
         guestName: body.guestName,
         linkTitle: link.title,
         ownerDisplayName,
+        blockEventStatus: blockEventResult?.status ?? 'skipped',
       },
     },
     201,
   );
 });
+
+/**
+ * block event を作成し、結果を booking doc に記録する。
+ * doc 更新の失敗 (createBlockEvent 自体は成功) は独立した try-catch で握り潰す
+ * (error-handling.md: 状態復旧 > ログ記録 > 通知の優先順)。
+ */
+async function createAndRecordBlockEvent(
+  link: BookingMirrorLink,
+  bookingId: string,
+  scheduleId: string,
+  slotStart: Date,
+  slotEnd: Date,
+): Promise<BlockEventResult> {
+  let result: BlockEventResult;
+  try {
+    const adapter = await createAdapter(link.ownerUid, link.blockAccountId!);
+    result = await createBlockEvent({
+      adapter,
+      calendarId: link.blockCalendarId!,
+      scheduleId,
+      slotStart,
+      slotEnd,
+    });
+  } catch (err) {
+    result = { status: 'failed', error: err instanceof Error ? err.message : String(err) };
+  }
+
+  if (result.status === 'created_unverified') {
+    console.error(
+      `[BLOCK-UNVERIFIED] linkId=${link.id} bookingId=${bookingId} eventId=${result.eventId}`,
+    );
+  }
+
+  try {
+    await getDb()
+      .collection('bookings')
+      .doc(bookingId)
+      .update({
+        blockEventStatus: result.status,
+        blockEventId: result.status === 'failed' ? null : result.eventId,
+        blockCalendarId: link.blockCalendarId,
+        blockAccountId: link.blockAccountId,
+        ...(result.status === 'failed' ? { blockEventError: result.error } : {}),
+      });
+  } catch (err) {
+    console.error(`Failed to record blockEventStatus for booking ${bookingId}:`, err);
+  }
+
+  return result;
+}
 
 // --- 非同期処理 ---
 
@@ -313,6 +384,7 @@ function sendBookingNotificationsAsync(
   slotStart: Date,
   slotEnd: Date,
   ownerDisplayName: string,
+  blockEventResult: BlockEventResult | null,
 ) {
   (async () => {
     const db = getDb();
@@ -354,6 +426,12 @@ function sendBookingNotificationsAsync(
     }
 
     // オーナー (= notificationEmail 宛) へ通知
+    const blockEventWarning =
+      blockEventResult?.status === 'created_unverified'
+        ? 'Google カレンダーに「予定あり」を作成しましたが、予約スケジュール側の枠消失を確認できませんでした。書き込み先カレンダーの設定をご確認ください。'
+        : blockEventResult?.status === 'failed'
+          ? 'Google カレンダーへの「予定あり」自動登録に失敗しました。下のボタンから手動で登録してください。'
+          : undefined;
     try {
       await sendEmail(auth, {
         to: link.notificationEmail,
@@ -365,6 +443,7 @@ function sendBookingNotificationsAsync(
           guestMessage,
           slotStart,
           slotEnd,
+          blockEventWarning,
         }),
         context: 'owner-notification',
       });

--- a/apps/api/src/routes/public-booking-mirror.ts
+++ b/apps/api/src/routes/public-booking-mirror.ts
@@ -283,18 +283,14 @@ publicBookingMirrorRoutes.post('/:linkId/book', async (c) => {
   // block event 作成は booking doc の確定 (orphan event 防止) の後、レスポンス返却の前に
   // 同期実行する。Cloud Run が --no-cpu-throttling 無しの min-instances=0 で動いているため、
   // レスポンス返却後の非同期処理は完走が保証されない (計画書参照)。
-  let blockEventResult: BlockEventResult | null = null;
-  if (shouldCreateBlockEvent(link)) {
-    blockEventResult = await createAndRecordBlockEvent(
-      link,
-      bookingId,
-      scheduleId,
-      slotStart,
-      slotEnd,
-    );
-  }
-
-  const ownerDisplayName = await getOwnerDisplayName(link.ownerUid);
+  // getOwnerDisplayName (Firestore 読み取り) は block event 作成結果に依存しないため、
+  // 並列実行して最大 25〜33 秒かかりうる block event フェーズにこれ以上レイテンシを積まない。
+  const [blockEventResult, ownerDisplayName] = await Promise.all([
+    shouldCreateBlockEvent(link)
+      ? createAndRecordBlockEvent(link, bookingId, scheduleId, slotStart, slotEnd)
+      : Promise.resolve(null as BlockEventResult | null),
+    getOwnerDisplayName(link.ownerUid),
+  ]);
   sendBookingNotificationsAsync(
     link,
     bookingId,

--- a/apps/web/src/app/booking-mirror-links/booking-mirror-links-content.tsx
+++ b/apps/web/src/app/booking-mirror-links/booking-mirror-links-content.tsx
@@ -5,7 +5,8 @@ import { useRouter } from 'next/navigation';
 import { useRequireAuth } from '../../hooks/useRequireAuth';
 import { apiGet, apiDelete, apiPatch } from '../../lib/api';
 import { PageShell, PageLoading } from '../../components/PageShell';
-import type { BookingMirrorLink } from '@calendar-hub/shared';
+import { dedupeCalendarsByOwnAccount, type CalendarWithAccount } from '../../lib/calendar-dedup';
+import type { BookingMirrorLink, ConnectedAccountPublic } from '@calendar-hub/shared';
 
 export function BookingMirrorLinksContent() {
   const { user, loading: authLoading } = useRequireAuth();
@@ -13,6 +14,7 @@ export function BookingMirrorLinksContent() {
   const [links, setLinks] = useState<BookingMirrorLink[]>([]);
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState('');
+  const [googleCalendars, setGoogleCalendars] = useState<CalendarWithAccount[]>([]);
 
   const loadLinks = useCallback(async () => {
     try {
@@ -28,6 +30,70 @@ export function BookingMirrorLinksContent() {
   useEffect(() => {
     if (user) loadLinks();
   }, [user, loadLinks]);
+
+  useEffect(() => {
+    if (!user) return;
+    (async () => {
+      try {
+        const [calRes, accRes] = await Promise.all([
+          apiGet<{ calendars: CalendarWithAccount[] }>('/api/calendars'),
+          apiGet<{ accounts: ConnectedAccountPublic[] }>('/api/auth/accounts'),
+        ]);
+        // 相互共有カレンダーは複数アカウント経由で id が重複するため、所有アカウントに絞り込む
+        // (詳細: calendar-dedup.ts コメント)。絞り込まないと accountId の取り違えが起きる。
+        setGoogleCalendars(
+          dedupeCalendarsByOwnAccount(
+            calRes.calendars.filter((c) => c.provider === 'google'),
+            accRes.accounts,
+          ),
+        );
+      } catch (err) {
+        console.error('Failed to load calendars:', err);
+      }
+    })();
+  }, [user]);
+
+  const handleToggleBlockEvent = async (link: BookingMirrorLink) => {
+    const enabling = !link.autoCreateBlockEvent;
+    if (enabling && googleCalendars.length === 0) {
+      setMessage('連携済みの Google カレンダーがありません');
+      return;
+    }
+    const calendarId = link.blockCalendarId ?? googleCalendars[0]?.id ?? null;
+    // ON にする際は必ず (重複解消済みの) googleCalendars から accountId を再計算する。
+    // 保存済みの blockAccountId をそのまま使うと、重複解消ロジックの修正前に保存された
+    // 誤った accountId (相互共有で別アカウント経由の calendarId と紐付いていた) が
+    // 修正後も永続してしまう。
+    const accountId = enabling
+      ? (googleCalendars.find((c) => c.id === calendarId)?.accountId ?? null)
+      : link.blockAccountId;
+    try {
+      const res = await apiPatch<{ link: BookingMirrorLink }>(
+        `/api/booking-mirror-links/${link.id}`,
+        {
+          autoCreateBlockEvent: enabling,
+          blockCalendarId: enabling ? calendarId : link.blockCalendarId,
+          blockAccountId: enabling ? accountId : link.blockAccountId,
+        },
+      );
+      setLinks((prev) => prev.map((l) => (l.id === link.id ? res.link : l)));
+    } catch {
+      setMessage('更新に失敗しました');
+    }
+  };
+
+  const handleChangeBlockCalendar = async (link: BookingMirrorLink, calendarId: string) => {
+    const accountId = googleCalendars.find((c) => c.id === calendarId)?.accountId ?? null;
+    try {
+      const res = await apiPatch<{ link: BookingMirrorLink }>(
+        `/api/booking-mirror-links/${link.id}`,
+        { blockCalendarId: calendarId, blockAccountId: accountId },
+      );
+      setLinks((prev) => prev.map((l) => (l.id === link.id ? res.link : l)));
+    } catch {
+      setMessage('更新に失敗しました');
+    }
+  };
 
   const handleToggleStatus = async (link: BookingMirrorLink) => {
     const newStatus = link.status === 'active' ? 'paused' : 'active';
@@ -114,6 +180,30 @@ export function BookingMirrorLinksContent() {
               </div>
 
               {link.description && <p style={s.cardDesc}>{link.description}</p>}
+
+              <div style={s.blockEventSection}>
+                <label style={s.checkboxItem}>
+                  <input
+                    type="checkbox"
+                    checked={link.autoCreateBlockEvent}
+                    onChange={() => handleToggleBlockEvent(link)}
+                  />
+                  <span>予約成立時に Google カレンダーへ「予定あり」を自動登録する</span>
+                </label>
+                {link.autoCreateBlockEvent && (
+                  <select
+                    value={link.blockCalendarId ?? ''}
+                    onChange={(e) => handleChangeBlockCalendar(link, e.target.value)}
+                    style={s.blockCalendarSelect}
+                  >
+                    {googleCalendars.map((cal) => (
+                      <option key={cal.id} value={cal.id}>
+                        {cal.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
 
               <div style={s.cardActions}>
                 <button onClick={() => handleCopyLink(link.id)} style={s.actionBtn}>
@@ -216,6 +306,31 @@ const s: Record<string, React.CSSProperties> = {
     color: 'var(--color-text-muted)',
     lineHeight: 1.5,
     marginBottom: '12px',
+  },
+  blockEventSection: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    padding: '12px 0',
+    borderTop: '1px solid var(--color-border)',
+  },
+  checkboxItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    fontSize: '13px',
+    cursor: 'pointer',
+  },
+  blockCalendarSelect: {
+    padding: '8px 12px',
+    background: 'var(--color-bg)',
+    border: '1px solid var(--color-border)',
+    borderRadius: '8px',
+    color: 'var(--color-text)',
+    fontSize: '13px',
+    fontFamily: 'inherit',
+    outline: 'none',
+    marginLeft: '24px',
   },
   cardActions: {
     display: 'flex',

--- a/apps/web/src/app/booking-mirror-links/new/new-mirror-link-content.tsx
+++ b/apps/web/src/app/booking-mirror-links/new/new-mirror-link-content.tsx
@@ -1,11 +1,16 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useRequireAuth } from '../../../hooks/useRequireAuth';
-import { apiPost } from '../../../lib/api';
+import { apiGet, apiPost } from '../../../lib/api';
 import { PageShell, PageLoading } from '../../../components/PageShell';
-import type { BookingMirrorLink, CreateBookingMirrorLinkInput } from '@calendar-hub/shared';
+import { dedupeCalendarsByOwnAccount, type CalendarWithAccount } from '../../../lib/calendar-dedup';
+import type {
+  BookingMirrorLink,
+  ConnectedAccountPublic,
+  CreateBookingMirrorLinkInput,
+} from '@calendar-hub/shared';
 
 export function NewMirrorLinkContent() {
   const { user, loading: authLoading } = useRequireAuth();
@@ -19,10 +24,45 @@ export function NewMirrorLinkContent() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
 
+  const [googleCalendars, setGoogleCalendars] = useState<CalendarWithAccount[]>([]);
+  const [loadingCalendars, setLoadingCalendars] = useState(true);
+  const [autoCreateBlockEvent, setAutoCreateBlockEvent] = useState(false);
+  const [blockCalendarId, setBlockCalendarId] = useState('');
+
+  useEffect(() => {
+    if (!user) return;
+    (async () => {
+      try {
+        const [calRes, accRes] = await Promise.all([
+          apiGet<{ calendars: CalendarWithAccount[] }>('/api/calendars'),
+          apiGet<{ accounts: ConnectedAccountPublic[] }>('/api/auth/accounts'),
+        ]);
+        // 相互共有カレンダーは複数アカウント経由で id が重複するため、所有アカウントに絞り込む
+        // (詳細: calendar-dedup.ts コメント)。絞り込まないと accountId の取り違えが起きる。
+        const google = dedupeCalendarsByOwnAccount(
+          calRes.calendars.filter((c) => c.provider === 'google'),
+          accRes.accounts,
+        );
+        setGoogleCalendars(google);
+        if (google.length > 0) setBlockCalendarId(google[0].id);
+      } catch (err) {
+        console.error('Failed to load calendars:', err);
+      } finally {
+        setLoadingCalendars(false);
+      }
+    })();
+  }, [user]);
+
+  const selectedBlockCalendar = googleCalendars.find((c) => c.id === blockCalendarId);
+
   const handleSubmit = async () => {
     setError('');
     if (!sourceUrl.trim()) {
       setError('Google 予約スケジュール URL は必須です');
+      return;
+    }
+    if (autoCreateBlockEvent && !selectedBlockCalendar) {
+      setError('自動登録先の Google カレンダーを設定してください');
       return;
     }
     setSubmitting(true);
@@ -33,6 +73,9 @@ export function NewMirrorLinkContent() {
         description: description.trim() || undefined,
         notificationEmail: notificationEmail.trim() || undefined,
         rangeDays,
+        autoCreateBlockEvent,
+        blockCalendarId: autoCreateBlockEvent ? selectedBlockCalendar!.id : null,
+        blockAccountId: autoCreateBlockEvent ? selectedBlockCalendar!.accountId : null,
       };
       await apiPost<{ link: BookingMirrorLink }>('/api/booking-mirror-links', input);
       router.push('/booking-mirror-links');
@@ -119,6 +162,39 @@ export function NewMirrorLinkContent() {
             </option>
           ))}
         </select>
+
+        <label style={{ ...s.checkboxItem, marginTop: '16px' }}>
+          <input
+            type="checkbox"
+            checked={autoCreateBlockEvent}
+            onChange={(e) => setAutoCreateBlockEvent(e.target.checked)}
+          />
+          <span>予約成立時に Google カレンダーへ「予定あり」を自動登録する</span>
+        </label>
+
+        {autoCreateBlockEvent &&
+          (loadingCalendars ? (
+            <span style={s.hint}>カレンダーを読み込み中...</span>
+          ) : googleCalendars.length === 0 ? (
+            <span style={s.hint}>
+              連携済みの Google カレンダーがありません。「設定」画面でアカウントを連携してください
+            </span>
+          ) : (
+            <>
+              <label style={s.label}>登録先の Google カレンダー</label>
+              <select
+                value={blockCalendarId}
+                onChange={(e) => setBlockCalendarId(e.target.value)}
+                style={s.input}
+              >
+                {googleCalendars.map((cal) => (
+                  <option key={cal.id} value={cal.id}>
+                    {cal.name}
+                  </option>
+                ))}
+              </select>
+            </>
+          ))}
       </div>
 
       <button
@@ -198,6 +274,13 @@ const s: Record<string, React.CSSProperties> = {
     color: 'var(--color-text-muted)',
     marginTop: '-2px',
     lineHeight: 1.5,
+  },
+  checkboxItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    fontSize: '13px',
+    cursor: 'pointer',
   },
   submitBtn: {
     width: '100%',

--- a/apps/web/src/lib/calendar-dedup.ts
+++ b/apps/web/src/lib/calendar-dedup.ts
@@ -1,0 +1,37 @@
+import type { ConnectedAccountPublic } from '@calendar-hub/shared';
+
+export interface CalendarWithAccount {
+  id: string;
+  name: string;
+  accountId: string;
+  provider: 'google' | 'timetree';
+}
+
+/**
+ * 相互共有されたカレンダーは複数アカウント経由で同一 id が重複して返る
+ * (`GET /api/calendars` が接続済み各アカウントの listCalendars() をフラット化するため、
+ * 例えば hy.unimail.11@gmail.com が yasushi.honda@aozora-cg.com のカレンダーを閲覧共有されて
+ * いると、"yasushi.honda@aozora-cg.com" という同じ calendar id が両アカウント経由で返る)。
+ *
+ * カレンダーの実際の所有アカウント (accountId に紐づく email === calendar id) を優先して
+ * 1 件に絞り込む。所有アカウントが見つからない場合は最初の1件を残す。
+ */
+export function dedupeCalendarsByOwnAccount(
+  calendars: CalendarWithAccount[],
+  accounts: ConnectedAccountPublic[],
+): CalendarWithAccount[] {
+  const accountById = new Map(accounts.map((a) => [a.id, a]));
+  const byCalendarId = new Map<string, CalendarWithAccount[]>();
+  for (const cal of calendars) {
+    const group = byCalendarId.get(cal.id) ?? [];
+    group.push(cal);
+    byCalendarId.set(cal.id, group);
+  }
+
+  const result: CalendarWithAccount[] = [];
+  for (const group of byCalendarId.values()) {
+    const owned = group.find((cal) => accountById.get(cal.accountId)?.email === cal.id);
+    result.push(owned ?? group[0]);
+  }
+  return result;
+}

--- a/docs/specs/2026-06-26-booking-mirror-v2-grpc-design.md
+++ b/docs/specs/2026-06-26-booking-mirror-v2-grpc-design.md
@@ -249,28 +249,25 @@ link 情報の public-safe subset を返す (タイトル / 説明 / 受付状�
 
 ## 9. スコープ外 / 将来課題
 
-| 項目                                     | 理由                                              |
-| ---------------------------------------- | ------------------------------------------------- |
-| Google Calendar への event 自動作成 (C1) | C2 採用により本リリースでは実装しない (§9.1 参照) |
-| 独自ドメイン                             | 既存方針通り                                      |
-| spam 対策 (hCaptcha 等)                  | 既存方針通り                                      |
-| 既存 v1 bookingLink との移行ツール       | v1 廃止方針なので不要                             |
+| 項目                                     | 理由                           |
+| ---------------------------------------- | ------------------------------ |
+| Google Calendar への event 自動作成 (C1) | C2 → C1 へ移行済み (§9.1 参照) |
+| 独自ドメイン                             | 既存方針通り                   |
+| spam 対策 (hCaptcha 等)                  | 既存方針通り                   |
+| 既存 v1 bookingLink との移行ツール       | v1 廃止方針なので不要          |
 
-### 9.1 二重予約リスクの取り扱い (C2 採用)
+### 9.1 二重予約リスクの取り扱い (C2 → C1 移行済み)
 
 Codex review (2026-06-26) で指摘された High リスク: Calendar Hub フォームで予約完了しても Google Appointment Schedule には予約が入らない。その枠は Google 公開ページ上では空いたままで、同枠を Google 経由で別ゲストが予約すると二重予約になる。
 
-本リリースでは **C2 = 個人運用としてリスク受容** を本田様判断で採用。理由:
+初回リリースでは **C2 = 個人運用としてリスク受容** を採用していたが、2026-07-26 に本田様の明示指示で **C1 (Google Calendar への block event 書き込み)** へ移行した。予約成立時に `apps/api/src/lib/block-event.ts` の `createBlockEvent` が指定カレンダーへ「予定あり」(Busy) の event を同期作成する。実装詳細は `~/.claude/plans/iterative-riding-hummingbird.md` の PR2 参照。
 
-- オーナー 1 名運用、ターゲット限定の予約系
-- Google 予約スケジュール側と CalendarHub mirror 側で公開先を分離する運用は可能
-- C1 (Google Calendar への block event 書き込み) には `yasushi.honda@aozora-cg.com` 等の OAuth 連携 + `calendar.events` write 権限が必要だが、本田様の方針で当該連携を削除済
+**C1 は二重予約リスクを解消ではなく縮小する**点に注意 (「永続的に空いたまま」→「event 作成 + 枠消失検証にかかる数秒〜十数秒の間だけ空いたまま」)。残存リスクを正確に記載する:
 
-将来 C2 から C1 に移行する場合の拡張点:
-
-1. 対象カレンダーを CalendarHub に OAuth 連携
-2. `BookingMirrorLink` に `blockCalendarId` / `blockAccountId` フィールド追加
-3. POST `/book` 処理に `createBlockEvent` を追加
+- Google 予約ページ経由の予約は Calendar Hub の `bookings` collection に入らないため、非ミラーの `bookingLink` の空き判定には反映されない。この非対称性は C1 では解決しない
+- block event 作成の効果は Google 側の「空き時間を確認するカレンダー」設定 (対象スケジュールの conflict check calendars) に依存し、API からは事前検証できない。`createBlockEvent` は作成後に `fetchAvailableSlots` で枠消失を再確認し、確認できない場合は `blockEventStatus='created_unverified'` として記録 + オーナー宛メールで警告する間接検出で補う
+- block event 作成が transient エラー (429/503/timeout) で失敗し続けた場合、`/book` の応答が最大 25〜33 秒程度ブロックされうる (booking 自体は block event 呼び出しより先に確定済み)。個人運用規模では transient エラー自体が稀という前提で許容し、実機運用で頻度を見て必要なら再検討する (2026-07-26 decision-maker 判断)
+- Phase 0 (OAuth 再連携・Busy 動作の実機検証) は `yasushi.honda@aozora-cg.com` の再連携完了まで完了。実機での枠消失・キャンセル時の枠復活確認は継続実施中
 
 ### 9.2 Codex review 反映の technical 改善点
 

--- a/infra/alert-policies/api-latency-p99.yaml
+++ b/infra/alert-policies/api-latency-p99.yaml
@@ -1,14 +1,24 @@
 displayName: '[Calendar Hub] API p99 latency'
 documentation:
   content: |
-    Cloud Run の API サービス (`calendar-hub-api`) の p99 レイテンシが 3 秒を
+    Cloud Run の API サービス (`calendar-hub-api`) の p99 レイテンシが 10 秒を
     5 分間継続超過。ユーザー体感の遅延劣化を検知する。
+
+    2026-07-26: booking-mirror C1 (block event 同期作成) 導入に伴い閾値を
+    3000ms → 10000ms へ引き上げ。正常な block event 作成は実測 2〜3秒かかる
+    ため (`apps/api/src/lib/block-event.ts` の検証待ち + Google API 往復)、
+    個人運用規模の低トラフィックでは 3000ms 閾値だと正常系だけで p99 が
+    頻繁に超過してしまう (Cloud Run built-in metric は URL path 別に
+    フィルタできないため、`/book` だけ除外する設定は不可)。10000ms は
+    block event 作成のリトライ含む単発の異常 (transient error retry 等) を
+    引き続き検知できる水準。
 
     対応:
     - Cloud Run の CPU / memory 使用率を確認（min instance が 0 のため cold start
       が影響している可能性が高い）
     - `gcloud run services describe calendar-hub-api` で cpu / memory 設定を確認
     - Firestore / Vertex AI / Google Calendar API のレスポンスタイムを段階的に切り分け
+    - booking-mirror の block event 作成起因か (`[BLOCK-UNVERIFIED]` ログ等) を確認
     - 必要であれば `min-instances=1` で cold start 排除（コスト増との trade-off）
 
     分散型 p99 は `ALIGN_PERCENTILE_99` aligner で Cloud Monitoring 側が
@@ -16,14 +26,14 @@ documentation:
   mimeType: text/markdown
 combiner: OR
 conditions:
-  - displayName: 'p99_latency > 3s for 5min'
+  - displayName: 'p99_latency > 10s for 5min'
     conditionThreshold:
       filter: >-
         metric.type="run.googleapis.com/request_latencies"
         AND resource.type="cloud_run_revision"
         AND resource.labels.service_name="calendar-hub-api"
       comparison: COMPARISON_GT
-      thresholdValue: 3000
+      thresholdValue: 10000
       duration: 300s
       aggregations:
         - alignmentPeriod: 300s

--- a/packages/calendar-sdk/src/__tests__/toGoogleEvent.test.ts
+++ b/packages/calendar-sdk/src/__tests__/toGoogleEvent.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { toGoogleEvent } from '../adapters/google.js';
+
+describe('toGoogleEvent transparency mapping', () => {
+  it('transparency: opaque を指定すると Google event body に反映される (booking-mirror C1: Busy 明示)', () => {
+    const body = toGoogleEvent({
+      title: '予定あり',
+      start: new Date('2026-07-27T01:00:00Z'),
+      end: new Date('2026-07-27T02:00:00Z'),
+      isAllDay: false,
+      transparency: 'opaque',
+    });
+
+    expect(body.transparency).toBe('opaque');
+  });
+
+  it('transparency: transparent を指定すると Google event body に反映される', () => {
+    const body = toGoogleEvent({
+      title: 'Free block',
+      start: new Date('2026-07-27T01:00:00Z'),
+      end: new Date('2026-07-27T02:00:00Z'),
+      isAllDay: false,
+      transparency: 'transparent',
+    });
+
+    expect(body.transparency).toBe('transparent');
+  });
+
+  it('transparency 未指定なら body に含まれない (Google 側のデフォルト opaque に委ねる)', () => {
+    const body = toGoogleEvent({
+      title: 'イベント',
+      start: new Date('2026-07-27T01:00:00Z'),
+      end: new Date('2026-07-27T02:00:00Z'),
+      isAllDay: false,
+    });
+
+    expect(body.transparency).toBeUndefined();
+  });
+});

--- a/packages/calendar-sdk/src/adapters/google.ts
+++ b/packages/calendar-sdk/src/adapters/google.ts
@@ -1,6 +1,12 @@
 import { google, type calendar_v3 } from 'googleapis';
 import type { CalendarEvent } from '@calendar-hub/shared';
-import type { Calendar, CalendarAdapter, CreateEventInput, UpdateEventInput } from '../types.js';
+import type {
+  Calendar,
+  CalendarAdapter,
+  CreateEventInput,
+  CreateEventOptions,
+  UpdateEventInput,
+} from '../types.js';
 
 export class GoogleCalendarAdapter implements CalendarAdapter {
   readonly provider = 'google' as const;
@@ -38,11 +44,15 @@ export class GoogleCalendarAdapter implements CalendarAdapter {
     return (res.data.items ?? []).map((item) => this.toCalendarEvent(item, calendarId));
   }
 
-  async createEvent(calendarId: string, event: CreateEventInput): Promise<CalendarEvent> {
-    const res = await this.calendar.events.insert({
-      calendarId,
-      requestBody: this.toGoogleEvent(event),
-    });
+  async createEvent(
+    calendarId: string,
+    event: CreateEventInput,
+    options?: CreateEventOptions,
+  ): Promise<CalendarEvent> {
+    const res = await this.calendar.events.insert(
+      { calendarId, requestBody: this.toGoogleEvent(event) },
+      { signal: options?.signal },
+    );
     return this.toCalendarEvent(res.data, calendarId);
   }
 

--- a/packages/calendar-sdk/src/adapters/google.ts
+++ b/packages/calendar-sdk/src/adapters/google.ts
@@ -89,29 +89,37 @@ export class GoogleCalendarAdapter implements CalendarAdapter {
   }
 
   private toGoogleEvent(event: CreateEventInput | UpdateEventInput): calendar_v3.Schema$Event {
-    const body: calendar_v3.Schema$Event = {};
-    if (event.title !== undefined) body.summary = event.title;
-    if (event.description !== undefined) body.description = event.description;
-    if (event.location !== undefined) body.location = event.location;
-
-    const tz = (event as CreateEventInput).timeZone ?? 'Asia/Tokyo';
-
-    if (event.start && event.end) {
-      if (event.isAllDay) {
-        body.start = { date: toDateString(event.start, tz), dateTime: null };
-        body.end = { date: toDateString(event.end, tz), dateTime: null };
-      } else {
-        body.start = { dateTime: event.start.toISOString(), timeZone: tz, date: null };
-        body.end = { dateTime: event.end.toISOString(), timeZone: tz, date: null };
-      }
-    }
-
-    if (event.extendedProperties) {
-      body.extendedProperties = { private: event.extendedProperties.private };
-    }
-
-    return body;
+    return toGoogleEvent(event);
   }
+}
+
+/** `toDateString` と同様、純粋関数として切り出しテスト可能にする */
+export function toGoogleEvent(
+  event: CreateEventInput | UpdateEventInput,
+): calendar_v3.Schema$Event {
+  const body: calendar_v3.Schema$Event = {};
+  if (event.title !== undefined) body.summary = event.title;
+  if (event.description !== undefined) body.description = event.description;
+  if (event.location !== undefined) body.location = event.location;
+  if (event.transparency !== undefined) body.transparency = event.transparency;
+
+  const tz = (event as CreateEventInput).timeZone ?? 'Asia/Tokyo';
+
+  if (event.start && event.end) {
+    if (event.isAllDay) {
+      body.start = { date: toDateString(event.start, tz), dateTime: null };
+      body.end = { date: toDateString(event.end, tz), dateTime: null };
+    } else {
+      body.start = { dateTime: event.start.toISOString(), timeZone: tz, date: null };
+      body.end = { dateTime: event.end.toISOString(), timeZone: tz, date: null };
+    }
+  }
+
+  if (event.extendedProperties) {
+    body.extendedProperties = { private: event.extendedProperties.private };
+  }
+
+  return body;
 }
 
 export function toDateString(d: Date, timeZone: string): string {

--- a/packages/calendar-sdk/src/types.ts
+++ b/packages/calendar-sdk/src/types.ts
@@ -23,6 +23,8 @@ export interface CreateEventInput {
   location?: string;
   timeZone?: string;
   extendedProperties?: EventExtendedProperties;
+  /** 'opaque' = Busy (予定あり) / 'transparent' = Free (予定なし)。省略時は Google 側の既定 (opaque) */
+  transparency?: 'opaque' | 'transparent';
 }
 
 export interface UpdateEventInput {
@@ -34,6 +36,7 @@ export interface UpdateEventInput {
   location?: string;
   timeZone?: string;
   extendedProperties?: EventExtendedProperties;
+  transparency?: 'opaque' | 'transparent';
 }
 
 export interface CalendarAdapter {

--- a/packages/calendar-sdk/src/types.ts
+++ b/packages/calendar-sdk/src/types.ts
@@ -39,6 +39,11 @@ export interface UpdateEventInput {
   transparency?: 'opaque' | 'transparent';
 }
 
+export interface CreateEventOptions {
+  /** 中断すると実際に下層の HTTP リクエストを abort する (google-booking-mirror.ts の fetchWithTimeout と同じ方針) */
+  signal?: AbortSignal;
+}
+
 export interface CalendarAdapter {
   readonly provider: CalendarProvider;
 
@@ -53,6 +58,7 @@ export interface CalendarAdapter {
   createEvent(
     calendarId: string,
     event: CreateEventInput,
+    options?: CreateEventOptions,
   ): Promise<import('@calendar-hub/shared').CalendarEvent>;
 
   updateEvent(

--- a/packages/shared/src/booking-mirror-types.ts
+++ b/packages/shared/src/booking-mirror-types.ts
@@ -22,6 +22,12 @@ export interface BookingMirrorLink {
   expiresAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
+  /** 予約成立時に Google カレンダーへ block event (「予定あり」) を自動作成するか。既存 document では false */
+  autoCreateBlockEvent: boolean;
+  /** block event の書き込み先 calendar ID */
+  blockCalendarId: string | null;
+  /** block event の書き込みに使う連携アカウント ID */
+  blockAccountId: string | null;
 }
 
 /** 公開ページに返す safe subset (ownerUid / scheduleId 等を隠す) */
@@ -41,6 +47,9 @@ export interface CreateBookingMirrorLinkInput {
   notificationEmail?: string;
   rangeDays?: number;
   expiresAt?: string | null;
+  autoCreateBlockEvent?: boolean;
+  blockCalendarId?: string | null;
+  blockAccountId?: string | null;
 }
 
 /** PATCH /api/booking-mirror-links/:linkId 入力 */
@@ -51,6 +60,9 @@ export interface UpdateBookingMirrorLinkInput {
   rangeDays?: number;
   status?: BookingMirrorLinkStatus;
   expiresAt?: string | null;
+  autoCreateBlockEvent?: boolean;
+  blockCalendarId?: string | null;
+  blockAccountId?: string | null;
 }
 
 /** 公開 slots API レスポンス 1 件 */

--- a/packages/shared/src/booking-types.ts
+++ b/packages/shared/src/booking-types.ts
@@ -47,6 +47,9 @@ export interface PublicBookingLinkInfo {
   status: BookingLinkStatus;
 }
 
+/** block event (「予定あり」) 自動作成の結果。'skipped' = autoCreateBlockEvent が無効 */
+export type BlockEventStatus = 'skipped' | 'created' | 'created_unverified' | 'failed';
+
 export interface Booking {
   id: string;
   linkId: string;
@@ -61,6 +64,15 @@ export interface Booking {
   notificationSentToOwner: boolean;
   notificationSentToGuest: boolean;
   createdAt: Date;
+  /** block event 自動作成の結果。非mirrorリンクの予約や旧document では undefined */
+  blockEventStatus?: BlockEventStatus;
+  /** 作成された Google event の素の id (google_ プレフィックスなし)。delete に使う */
+  blockEventId?: string | null;
+  /** block event 書き込み先の calendar ID (link からのスナップショット) */
+  blockCalendarId?: string | null;
+  /** block event 書き込みに使った連携アカウント ID (link からのスナップショット) */
+  blockAccountId?: string | null;
+  blockEventError?: string;
 }
 
 /** Public-safe booking confirmation */


### PR DESCRIPTION
## Summary
- Google予約スケジュール経由の二重予約リスクを縮小するため、Calendar Hub mirror経由の予約成立時に、指定カレンダーへ「予定あり」(Busy) のevent を同期作成する(C1)
- 作成後は `fetchAvailableSlots` で枠消失を検証し、3値 (`created`/`created_unverified`/`failed`) で結果を記録
- 管理画面(新規作成フォーム + 一覧カード)に自動登録設定UIを追加
- 実機検証(`yasushi.honda@aozora-cg.com`)で、block event作成 → 実際のGoogle予約ページでの枠消失を確認済み
- 実機検証中に発覚した「相互共有カレンダーによる accountId 取り違えバグ」を `calendar-dedup.ts` で修正

計画書: `~/.claude/plans/iterative-riding-hummingbird.md`
evaluatorエージェントによるAC検証: AC-1/4/5/6 PASS、AC-7/8(キャンセル時の実機確認)は今後実施

## 既知の残課題(合意済み・追跡事項)
- block event作成のtransientエラー再試行が失敗し続けると `/book` の応答が最大25〜33秒程度かかりうる(booking自体は先に確定済み)。個人運用規模ではtransientエラー自体が稀という前提で許容し、実運用の頻度を見て再検討する(2026-07-26 decision-maker判断)
- キャンセル時のblock event削除(AC-8)は実機未検証(コードレビューでは`booking-links.ts`の実装を確認済み)

## Test plan
- [x] `pnpm test` (309 tests / 21 files) 全PASS
- [x] `pnpm lint` エラーなし
- [x] `pnpm turbo type-check` エラーなし
- [x] `pnpm turbo build` 成功
- [x] 実機: mirror経由の予約 → block event作成 → 実際のGoogle予約ページで枠消失を確認
- [ ] 実機: 予約キャンセル → block event削除 → 枠復活の確認(今後実施)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Booking mirror links can automatically create Google Calendar “Busy” events when bookings are confirmed.
  * Configure the target calendar when creating or editing a mirror link.
  * Booking responses now show block-event status, including successful, unverified, failed, or skipped outcomes.
  * Cancellation attempts best-effort cleanup of associated block events.
  * Notification emails can display warnings when block-event creation is incomplete.

* **Bug Fixes**
  * Added validation to prevent incomplete calendar and account configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->